### PR TITLE
explicitly import testthat

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,14 +16,14 @@ Imports:
     httr,
     jsonlite,
     rmarkdown,
-    gh
+    gh,
+    testthat
 Remotes: r-pkgs/gh
 License: GPL-3
 Encoding: UTF-8
 LazyData: true
 RoxygenNote: 5.0.1.9000
 Suggests: 
-    testthat,
     covr
 Url: https://github.com/r-pkgs/usethis
 BugReports: https://github.com/r-pkgs/usethis/issues


### PR DESCRIPTION
when using use_testthat on a new computer, fails as testthat not available. Suggest moving testthat to Imports so it will be installed