### PR TITLE
Use clipr to add code to clipboard

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,6 +12,7 @@ BugReports: https://github.com/r-lib/usethis/issues
 Depends: 
     R (>= 3.1)
 Imports: 
+    clipr,
     clisymbols,
     crayon,
     desc,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # usethis 0.0.0.9000
 
+* Functions which require code to be copied now automatically put the code on
+  the clipboard if it is available (#52).
+
 * `use_coverage("codecov")` now sets a default threshold of 1% to try and 
   reduce false positives (#8).
 

--- a/R/style.R
+++ b/R/style.R
@@ -16,6 +16,7 @@ code_block <- function(...) {
   block <- paste0("  ", c(...), collapse = "\n")
   if (clipr::clipr_available()) {
     clipr::write_clip(paste0(c(...), collapse = "\n"))
+    message("copied to clipboard:")
   }
   cat_line(crayon::make_style("darkgrey")(block))
 }

--- a/R/style.R
+++ b/R/style.R
@@ -14,6 +14,9 @@ done <- function(...) {
 
 code_block <- function(...) {
   block <- paste0("  ", c(...), collapse = "\n")
+  if (clipr::clipr_available()) {
+    clipr::write_clip(paste0(c(...), collapse = "\n"))
+  }
   cat_line(crayon::make_style("darkgrey")(block))
 }
 


### PR DESCRIPTION
This makes it easy to paste into the source files where needed.

It looks like all current uses of `code_block()` are places where it makes sense to put the code on the clipboard. If we think this may change in the future we could either have an option to `code_block()`, or have a helper function which calls `clipr::write_clip()` and `code_block()` internally and switch the current uses of `code_block()` to the helper.

Fixes #52