### PR TITLE
Chooseopen: passing "open = T/F" arguments to use_template()

### DIFF
--- a/R/cran.R
+++ b/R/cran.R
@@ -9,12 +9,12 @@
 #'
 #' @export
 #' @inheritParams use_template
-use_cran_comments <- function(base_path = ".") {
+use_cran_comments <- function(base_path = ".", open = TRUE) {
   use_template(
     "cran-comments.md",
     data = list(rversion = paste0(version$major, ".", version$minor)),
     ignore = TRUE,
-    open = TRUE,
+    open = open,
     base_path = base_path
   )
 

--- a/R/news.R
+++ b/R/news.R
@@ -4,11 +4,11 @@
 #'
 #' @inheritParams use_template
 #' @export
-use_news_md <- function(base_path = ".") {
+use_news_md <- function(base_path = ".", open = TRUE) {
   use_template(
     "NEWS.md",
     data = package_data(base_path),
-    open = TRUE,
+    open = open,
     base_path = base_path
   )
 }

--- a/R/readme.R
+++ b/R/readme.R
@@ -18,7 +18,7 @@
 #' use_readme_rmd()
 #' use_readme_md()
 #' }
-use_readme_rmd <- function(base_path = ".") {
+use_readme_rmd <- function(base_path = ".", open = TRUE) {
   check_installed("rmarkdown")
 
   data <- package_data(base_path)
@@ -29,7 +29,7 @@ use_readme_rmd <- function(base_path = ".") {
     "README.Rmd",
     data = data,
     ignore = TRUE,
-    open = TRUE,
+    open = open,
     base_path = base_path
   )
 
@@ -46,12 +46,12 @@ use_readme_rmd <- function(base_path = ".") {
 
 #' @export
 #' @rdname use_readme_rmd
-use_readme_md <- function(base_path = ".") {
+use_readme_md <- function(base_path = ".", open = TRUE) {
   use_template(
     "omni-README",
     "README.md",
     data = package_data(base_path),
-    open = TRUE,
+    open = open,
     base_path = base_path
   )
 }

--- a/R/test.R
+++ b/R/test.R
@@ -26,7 +26,7 @@ use_testthat <- function(base_path = ".") {
 #' @param name Test name. if `NULL`, and you're using RStudio, will use
 #'   the name of the file open in the source editor.
 #' @export
-use_test <- function(name = NULL, base_path = ".") {
+use_test <- function(name = NULL, base_path = ".", open = TRUE) {
   name <- find_test_name(name)
 
   if (!uses_testthat(base_path)) {
@@ -36,7 +36,7 @@ use_test <- function(name = NULL, base_path = ".") {
   use_template("test-example.R",
     file.path("tests", "testthat", name),
     data = list(test_name = name),
-    open = TRUE,
+    open = open,
     base_path = base_path
   )
 

--- a/man/use_cran_comments.Rd
+++ b/man/use_cran_comments.Rd
@@ -4,10 +4,12 @@
 \alias{use_cran_comments}
 \title{Create a comment for submission to CRAN.}
 \usage{
-use_cran_comments(base_path = ".")
+use_cran_comments(base_path = ".", open = TRUE)
 }
 \arguments{
 \item{base_path}{Path to package root.}
+
+\item{open}{Should the new created file be opened in RStudio?}
 }
 \description{
 This creates a template for your communications with CRAN when submitting a

--- a/man/use_news_md.Rd
+++ b/man/use_news_md.Rd
@@ -4,10 +4,12 @@
 \alias{use_news_md}
 \title{Create a simple \code{NEWS.md}}
 \usage{
-use_news_md(base_path = ".")
+use_news_md(base_path = ".", open = TRUE)
 }
 \arguments{
 \item{base_path}{Path to package root.}
+
+\item{open}{Should the new created file be opened in RStudio?}
 }
 \description{
 This creates a basic \code{NEWS.md} in the root directory.

--- a/man/use_readme_rmd.Rd
+++ b/man/use_readme_rmd.Rd
@@ -5,12 +5,14 @@
 \alias{use_readme_md}
 \title{Create README files.}
 \usage{
-use_readme_rmd(base_path = ".")
+use_readme_rmd(base_path = ".", open = TRUE)
 
-use_readme_md(base_path = ".")
+use_readme_md(base_path = ".", open = TRUE)
 }
 \arguments{
 \item{base_path}{Path to package root.}
+
+\item{open}{Should the new created file be opened in RStudio?}
 }
 \description{
 Creates skeleton README files with sections for

--- a/man/use_testthat.Rd
+++ b/man/use_testthat.Rd
@@ -7,13 +7,15 @@
 \usage{
 use_testthat(base_path = ".")
 
-use_test(name = NULL, base_path = ".")
+use_test(name = NULL, base_path = ".", open = TRUE)
 }
 \arguments{
 \item{base_path}{Path to package root.}
 
 \item{name}{Test name. if \code{NULL}, and you're using RStudio, will use
 the name of the file open in the source editor.}
+
+\item{open}{Should the new created file be opened in RStudio?}
 }
 \description{
 \code{use_testthat} sets up testing infrastructure, creating


### PR DESCRIPTION
As per issue #86. Some infrastructure-creation functions automatically open the resulting files in the current session, which is not always the desired behaviour. This is because these functions wrap `use_template()` with a hard-coded `open = TRUE` argument.

In this branch, I added `open = TRUE` arguments to the relevant wrapper functions, and replaced the hardcoded `open = TRUE` in the body of the functions with `open = open`.

The more recent commit is writing some automated tests to ensure these functions still execute without error.
