### PR TITLE
adds import of UQ, UQS, !!, and !!!

### DIFF
--- a/inst/templates/tidy-eval.R
+++ b/inst/templates/tidy-eval.R
@@ -1,6 +1,6 @@
 #' Tidy eval helpers
 #'
-#' These six functions provide tidy eval-compatible ways to capture
+#' These functions provide tidy eval-compatible ways to capture
 #' symbols (`sym()`, `syms()`, `ensym()`), expressions (`expr()`,
 #' `exprs()`, `enexpr()`), and quosures (`quo()`, `quos()`, `enquo()`).
 #' To learn more about tidy eval and how to use these tools, read
@@ -16,6 +16,7 @@
 #' @export           sym syms ensym
 #' @importFrom rlang expr exprs enexpr
 #' @export           expr exprs enexpr
+#' @importFrom rlang UQ UQS !! !!!
 NULL
 
 # Flag inline helpers as global variables so R CMD check doesn't warn

--- a/inst/templates/tidy-eval.R
+++ b/inst/templates/tidy-eval.R
@@ -16,7 +16,7 @@
 #' @export           sym syms ensym
 #' @importFrom rlang expr exprs enexpr
 #' @export           expr exprs enexpr
-#' @importFrom rlang UQ UQS !! !!!
+#' @importFrom rlang UQ UQS
 NULL
 
 # Flag inline helpers as global variables so R CMD check doesn't warn


### PR DESCRIPTION
Addresses #98

Added the syntactic-sugar versions, too - please let me know if they should not be there.

Also, seemed to be more than six functions there, so thought I would remove the count.

If you think it would be constructive to export these, I can amend to add

```
#' @export UQ UQS !! !!!
```

as well as a sentence to the descriptive paragraph.