### PR TITLE
Set an explicit default width of 100% for README figs

### DIFF
--- a/inst/templates/omni-README
+++ b/inst/templates/omni-README
@@ -9,7 +9,8 @@ output: github_document
 knitr::opts_chunk$set(
   collapse = TRUE,
   comment = "#>",
-  fig.path = "man/figures/README-"
+  fig.path = "man/figures/README-",
+  out.width = "100%",
 )
 ```
 {{/Rmd}}


### PR DESCRIPTION
Meant to combat figs that run off the page for README.html that CRAN creates and hosts.

Suggests the use of, e.g.,

```{r echo = FALSE}
knitr::include_graphics("man/figures/i-already-exist.png")
```

for pre-made figs.