### PR TITLE
Remove comma after last argument passed to knitr::ops_chunk$set

### DIFF
--- a/inst/templates/omni-README
+++ b/inst/templates/omni-README
@@ -10,7 +10,7 @@ knitr::opts_chunk$set(
   collapse = TRUE,
   comment = "#>",
   fig.path = "man/figures/README-",
-  out.width = "100%",
+  out.width = "100%"
 )
 ```
 {{/Rmd}}


### PR DESCRIPTION
Fix use_readme_rmd() to exclude comma after last argument passed to knitr::ops_chunk$set (#112)