### PR TITLE
Silence tests

### DIFF
--- a/tests/testthat/test-git.R
+++ b/tests/testthat/test-git.R
@@ -3,8 +3,7 @@ context("git")
 test_that("use_git_hook errors if project not using git", {
   # git2r::git2r::discover_repository() not working on R 3.1 (Travis)
   skip_if(getRversion() < 3.2)
-  tmp <- tempfile()
-  create_package(tmp, rstudio = FALSE)
+  scoped_temporary_package()
   expect_error(
     use_git_hook(
       "pre-commit",

--- a/tests/testthat/test-use_readme.R
+++ b/tests/testthat/test-use_readme.R
@@ -1,24 +1,20 @@
 context("readme")
 
 test_that("error if try to overwrite existing file", {
-  tmp <- tempfile()
-  create_package(tmp, rstudio = FALSE)
+  tmp <- scoped_temporary_package()
   file.create(file.path(tmp, "README.md"))
-  expect_error(use_readme_md(tmp),
-               "already exists")
+  expect_error(use_readme_md(tmp), "already exists")
   file.create(file.path(tmp, "README.Rmd"))
-  expect_error(use_readme_rmd(tmp),
-               "already exists")
+  expect_error(use_readme_rmd(tmp), "already exists")
 })
 
 test_that("sets up git pre-commit hook iff pkg uses git", {
   # git2r::git2r::discover_repository() not working on R 3.1 (Travis)
   skip_if(getRversion() < 3.2)
-  tmp <- tempfile()
-  create_package(tmp, rstudio = FALSE)
-  use_readme_rmd(open = FALSE)
+  tmp <- scoped_temporary_package()
+  capture_output(use_readme_rmd(open = FALSE))
   expect_false(file.exists(file.path(tmp, ".git", "hooks", "pre-commit")))
-  use_git()
-  use_readme_rmd(open = FALSE)
+  capture_output(use_git())
+  capture_output(use_readme_rmd(open = FALSE))
   expect_true(file.exists(file.path(tmp, ".git", "hooks", "pre-commit")))
 })


### PR DESCRIPTION
The copious use of `cat()` in usethis makes tests prone to chattiness.

I can silence some tests by switching over to `scoped_temporary_package()`.

`scoped_temporary_package()` uses `utils::capture.output()` to absorb output.

If I need to capture output for the sake of silence (vs. testing the output), should I also use `utils::capture.output()` or `testthat::capture_output()`?
