### PR TITLE
Make scoped_temporary_package() easier to work with

### DIFF
--- a/R/proj.R
+++ b/R/proj.R
@@ -61,14 +61,6 @@ proj_set <- function(path = ".", force = FALSE) {
   invisible(old)
 }
 
-scoped_temporary_package <- function(dir = tempfile(), env = parent.frame()) {
-  old <- proj$cur
-  withr::defer(proj_set(old), envir = env)
-
-  utils::capture.output(create_package(dir, rstudio = FALSE, open = FALSE))
-  invisible(dir)
-}
-
 .onAttach <- function(...) {
   proj_set(".")
 }

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -1,6 +1,15 @@
 scoped_temporary_package <- function(dir = tempfile(), env = parent.frame()) {
   old <- proj$cur
-  withr::defer(proj_set(old), envir = env)
+  # Can't schedule a deferred project reset if calling this from the R console,
+  # which is useful when developing tests
+  if (identical(env, globalenv())) {
+    todo(
+      "Switching to a temporary project! To restore current project:\n",
+      "proj_set(\"", old, "\")"
+    )
+  } else {
+    withr::defer(proj_set(old), envir = env)
+  }
 
   utils::capture.output(create_package(dir, rstudio = FALSE, open = FALSE))
   invisible(dir)

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -11,6 +11,6 @@ scoped_temporary_package <- function(dir = tempfile(), env = parent.frame()) {
     withr::defer(proj_set(old), envir = env)
   }
 
-  utils::capture.output(create_package(dir, rstudio = FALSE, open = FALSE))
+  capture_output(create_package(dir, rstudio = FALSE, open = FALSE))
   invisible(dir)
 }

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -1,0 +1,7 @@
+scoped_temporary_package <- function(dir = tempfile(), env = parent.frame()) {
+  old <- proj$cur
+  withr::defer(proj_set(old), envir = env)
+
+  utils::capture.output(create_package(dir, rstudio = FALSE, open = FALSE))
+  invisible(dir)
+}


### PR DESCRIPTION
Fixes #141: makes it possible to call `scoped_temporary_package()` in the console. Nicer for test development.

Move `scoped_temporary_package()` to `tests/testthat/helper.R`.