### PR TITLE
Less promiscuous Rbuildignoring

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,4 +1,4 @@
-^.*\.Rproj$
+^usethis\.Rproj$
 ^\.Rproj\.user$
 ^revdep$
 ^\.travis\.yml$

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 .Rhistory
 .RData
 revdep/.cache.rds
-.Rbuildignore
 revdep/checks
 revdep/library
 revdep/checks.noindex

--- a/R/rstudio.R
+++ b/R/rstudio.R
@@ -13,7 +13,13 @@ use_rstudio <- function() {
 
   use_git_ignore(".Rproj.user")
   if (is_package()) {
-    use_build_ignore(c("^.*\\.Rproj$", "^\\.Rproj\\.user$"), escape = FALSE)
+    use_build_ignore(
+      c(
+        paste0("^", project_name(), "\\.Rproj$"),
+        "^\\.Rproj\\.user$"
+      ),
+      escape = FALSE
+    )
   }
 
   invisible(TRUE)

--- a/tests/testthat/test-use-template.R
+++ b/tests/testthat/test-use-template.R
@@ -14,3 +14,10 @@ test_that("find_template errors if template missing", {
   expect_error(find_template("xxx"), "Could not find template")
 })
 
+test_that("find_template can find templates for tricky Rbuildignored files", {
+  expect_match(find_template("travis.yml"), "travis\\.yml$")
+  expect_match(find_template("codecov.yml"), "codecov\\.yml$")
+  expect_match(find_template("cran-comments.md"), "cran-comments\\.md$")
+  expect_match(find_template("template.Rproj"), "template\\.Rproj$")
+})
+


### PR DESCRIPTION
Fixes #127 create_package doesn't work on CRAN

I just got bitten by this very hard, while writing tests for various function around RStudio Projects (coming soon, in a different PR). Relieved to get to the bottom of it! The `.Rproj` template wasn't surviving in the built package. The insidious part is I could pass tests with `test()` but then fail with `check()` ☹️.

I deliberately added a failing test first (https://github.com/r-lib/usethis/pull/146/commits/ae230172efa55efff3cc8ca10b6f18b1ae3d0140), then the fix for usethis itself.

I also went ahead and tightened up the line usethis adds to `.Rbuildignore` when it creates an RStudio project.