### PR TITLE
Windows-proof same_contents()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,7 +21,6 @@ Imports:
     clisymbols,
     crayon,
     desc,
-    digest,
     gh,
     git2r,
     rmarkdown,

--- a/R/description.R
+++ b/R/description.R
@@ -28,7 +28,7 @@ build_description <- function(name, fields = list()) {
   # Collapse all vector arguments to single strings
   desc <- vapply(desc_list, function(x) paste(x, collapse = ", "), character(1))
 
-  paste0(names(desc), ": ", desc, "\n", collapse = "")
+  paste0(names(desc), ": ", desc)
 }
 
 build_description_list <- function(name, fields = list()) {

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -29,7 +29,7 @@ use_template <- function(template,
 
 render_template <- function(template, data = list()) {
   template_path <- find_template(template)
-  paste0(whisker::whisker.render(readLines(template_path), data), "\n", collapse = "")
+  strsplit(whisker::whisker.render(readLines(template_path), data), "\n")[[1]]
 }
 
 find_template <- function(template_name) {

--- a/R/write.R
+++ b/R/write.R
@@ -22,7 +22,7 @@ write_union <- function(base_path, path, new_lines, quiet = FALSE) {
 }
 
 write_over <- function(base_path, path, contents) {
-  stopifnot(is.character(contents), length(contents) == 1)
+  stopifnot(is.character(contents), length(contents) > 0)
 
   full_path <- file.path(base_path, path)
   dir.create(dirname(full_path), showWarnings = FALSE)
@@ -56,8 +56,5 @@ same_contents <- function(path, contents) {
   if (!file.exists(path))
     return(FALSE)
 
-  text_hash <- digest::digest(contents, serialize = FALSE)
-  file_hash <- digest::digest(file = path)
-
-  identical(text_hash, file_hash)
+  identical(readLines(path), contents)
 }

--- a/R/write.R
+++ b/R/write.R
@@ -21,6 +21,7 @@ write_union <- function(base_path, path, new_lines, quiet = FALSE) {
   write_utf8(full_path, all)
 }
 
+## `contents` is a character vector of prospective lines
 write_over <- function(base_path, path, contents) {
   stopifnot(is.character(contents), length(contents) > 0)
 

--- a/tests/testthat/test-use_readme.R
+++ b/tests/testthat/test-use_readme.R
@@ -11,8 +11,6 @@ test_that("error if try to overwrite existing file", {
 test_that("sets up git pre-commit hook iff pkg uses git", {
   # git2r::git2r::discover_repository() not working on R 3.1 (Travis)
   skip_if(getRversion() < 3.2)
-  # temporary fix!
-  skip_on_appveyor()
   tmp <- scoped_temporary_package()
   capture_output(use_readme_rmd(open = FALSE))
   expect_false(file.exists(file.path(tmp, ".git", "hooks", "pre-commit")))

--- a/tests/testthat/test-write.R
+++ b/tests/testthat/test-write.R
@@ -1,0 +1,9 @@
+context("test-write.R")
+
+test_that("same_contents() detects if contents are / are not same", {
+  tmp <- tempfile()
+  x <- letters[1:3]
+  writeLines(x, con = tmp, sep = "\n")
+  expect_true(same_contents(tmp, x))
+  expect_false(same_contents(tmp, letters[4:6]))
+})


### PR DESCRIPTION
Fixes #148 Reconsider comparison method in `same_contents()`

Fixes `same_contents()` and `write_over()` on Windows, by keeping proposed text as a character vector. This avoids OS-specific line ending issues when deciding if proposed text is same as current. With this, all tests now pass on Windows.