### PR TITLE
Set .here for projects that don't meet other criteria

### DIFF
--- a/R/create.R
+++ b/R/create.R
@@ -59,6 +59,8 @@ create_project <- function(path = ".",
 
   if (rstudio) {
     use_rstudio()
+  } else {
+    writeLines(character(), file.path(path, ".here"))
   }
   if (open) {
     open_project(path, name, rstudio = rstudio)

--- a/R/proj.R
+++ b/R/proj.R
@@ -15,6 +15,8 @@ proj_find <- function(path = ".") {
   )
 }
 
+is_proj <- function(path = ".") !is.null(proj_find(path))
+
 #' Get and set currently active project
 #'
 #' When attached, usethis uses rprojroot to find the project root of the


### PR DESCRIPTION
Fixes #154 Make sure all new projects meet one project criterion

Also added `is_proj()`. These are little odds and ends that look helpful as I write a bunch of tests, which will come in a separate PR.
