### PR TITLE
Handle new value for existing DESCRIPTION field when `overwrite = FALSE`

### DIFF
--- a/R/helpers.R
+++ b/R/helpers.R
@@ -72,10 +72,14 @@ project_name <- function(base_path = proj_get()) {
   }
 }
 
-use_description_field <- function(name, value, base_path = proj_get(), overwrite = FALSE) {
+use_description_field <- function(name,
+                                  value,
+                                  base_path = proj_get(),
+                                  overwrite = FALSE) {
   curr <- desc::desc_get(name, file = base_path)[[1]]
-  if (identical(curr, value))
+  if (identical(curr, value)) {
     return()
+  }
 
   if (is.na(curr) || overwrite) {
     done("Setting ", field(name), " field in DESCRIPTION to ", value(value))

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -78,13 +78,20 @@ use_description_field <- function(name,
                                   overwrite = FALSE) {
   curr <- desc::desc_get(name, file = base_path)[[1]]
   if (identical(curr, value)) {
-    return()
+    return(invisible())
   }
 
-  if (is.na(curr) || overwrite) {
-    done("Setting ", field(name), " field in DESCRIPTION to ", value(value))
-    desc::desc_set(name, value, file = base_path)
+  if (!is.na(curr) && !overwrite) {
+    stop(
+      field(name), " has a different value in DESCRIPTION. ",
+      "Use overwrite = TRUE to overwrite.",
+      call. = FALSE
+    )
   }
+
+  done("Setting ", field(name), " field in DESCRIPTION to ", value(value))
+  desc::desc_set(name, value, file = base_path)
+  invisible()
 }
 
 use_dependency <- function(package, type, version = "*") {


### PR DESCRIPTION
Fixes #157 use_description_field() isn't done yet 