### PR TITLE
Rename yesno() to nope(); use our own interactive()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,7 +30,7 @@ Imports:
     whisker
 Suggests: 
     covr,
-    testthat,
+    testthat (>= 2.0.0),
     withr
 Encoding: UTF-8
 LazyData: true

--- a/R/create.R
+++ b/R/create.R
@@ -143,7 +143,7 @@ check_not_nested <- function(path, name) {
     stop(message, call. = FALSE)
   }
 
-  if (yesno(message, " This is rarely a good idea. Do you wish to create anyway?")) {
+  if (nope(message, " This is rarely a good idea. Do you wish to create anyway?")) {
     stop("Aborting project creation", call. = FALSE)
   }
 }

--- a/R/create.R
+++ b/R/create.R
@@ -14,7 +14,6 @@ create_package <- function(path = ".",
                            fields = getOption("devtools.desc"),
                            rstudio = rstudioapi::isAvailable(),
                            open = interactive()) {
-
   path <- normalizePath(path, mustWork = FALSE)
 
   name <- basename(path)
@@ -45,7 +44,6 @@ create_package <- function(path = ".",
 create_project <- function(path = ".",
                            rstudio = rstudioapi::isAvailable(),
                            open = interactive()) {
-
   path <- normalizePath(path, mustWork = FALSE)
 
   name <- basename(path)
@@ -133,8 +131,9 @@ open_project <- function(path, name, rstudio = NA) {
 check_not_nested <- function(path, name) {
   proj_root <- proj_find(path)
 
-  if (is.null(proj_root))
+  if (is.null(proj_root)) {
     return()
+  }
 
   message <- paste0(
     "New project ", value(name), " is nested inside an existing project ",
@@ -147,5 +146,4 @@ check_not_nested <- function(path, name) {
   if (yesno(message, " This is rarely a good idea. Do you wish to create anyway?")) {
     stop("Aborting project creation", call. = FALSE)
   }
-
 }

--- a/R/github.R
+++ b/R/github.R
@@ -79,7 +79,7 @@ use_github <- function(organisation = NULL,
     paste0("Description: ", repo_desc),
     copy = FALSE
   )
-  if (yesno("Are title and description ok?")) {
+  if (nope("Are title and description ok?")) {
     return(invisible())
   }
 

--- a/R/github.R
+++ b/R/github.R
@@ -76,14 +76,23 @@ use_github <- function(organisation = NULL,
   repo_name <- pkg$Project %||% gsub("\n", " ", pkg$Package)
   repo_desc <- pkg$Title %||% ""
 
-  todo("Check title and description")
-  code_block(
-    paste0("Name:        ", repo_name),
-    paste0("Description: ", repo_desc),
-    copy = FALSE
-  )
-  if (nope("Are title and description ok?")) {
-    return(invisible())
+  if (interactive()) {
+    todo("Check title and description")
+    code_block(
+      paste0("Name:        ", repo_name),
+      paste0("Description: ", repo_desc),
+      copy = FALSE
+    )
+    if (nope("Are title and description ok?")) {
+      return(invisible())
+    }
+  } else {
+    done("Setting title and description")
+    code_block(
+      paste0("Name:        ", repo_name),
+      paste0("Description: ", repo_desc),
+      copy = FALSE
+    )
   }
 
   done("Creating GitHub repository")

--- a/R/github.R
+++ b/R/github.R
@@ -61,7 +61,10 @@ use_github <- function(organisation = NULL,
                        auth_token = NULL,
                        host = NULL) {
   if (!uses_git()) {
-    stop("Please use_git() before use_github()", call. = FALSE)
+    stop(
+      "Please call ", code("use_git()"), " before ",
+      code("use_github()"), ".", call. = FALSE
+    )
   }
 
   if (uses_github(proj_get())) {

--- a/R/github.R
+++ b/R/github.R
@@ -60,7 +60,6 @@ use_github <- function(organisation = NULL,
                        credentials = NULL,
                        auth_token = NULL,
                        host = NULL) {
-
   if (!uses_git()) {
     stop("Please use_git() before use_github()", call. = FALSE)
   }
@@ -87,7 +86,8 @@ use_github <- function(organisation = NULL,
   done("Creating GitHub repository")
 
   if (is.null(organisation)) {
-    create <- gh::gh("POST /user/repos",
+    create <- gh::gh(
+      "POST /user/repos",
       name = repo_name,
       description = repo_desc,
       private = private,
@@ -95,7 +95,8 @@ use_github <- function(organisation = NULL,
       .token = auth_token
     )
   } else {
-    create <- gh::gh("POST /orgs/:org/repos",
+    create <- gh::gh(
+      "POST /orgs/:org/repos",
       org = organisation,
       name = repo_name,
       description = repo_desc,
@@ -145,7 +146,6 @@ use_github <- function(organisation = NULL,
 #' @rdname use_github
 use_github_links <- function(auth_token = NULL,
                              host = "https://api.github.com") {
-
   check_uses_github()
 
   info <- gh::gh_tree_remote(proj_get())

--- a/R/readme.R
+++ b/R/readme.R
@@ -18,7 +18,7 @@
 #' use_readme_rmd()
 #' use_readme_md()
 #' }
-use_readme_rmd <- function(open = TRUE) {
+use_readme_rmd <- function(open = interactive()) {
   check_installed("rmarkdown")
 
   data <- project_data()
@@ -44,7 +44,7 @@ use_readme_rmd <- function(open = TRUE) {
 
 #' @export
 #' @rdname use_readme_rmd
-use_readme_md <- function(open = TRUE) {
+use_readme_md <- function(open = interactive()) {
   use_template(
     if (is_package()) "package-README" else "project-README",
     "README.md",

--- a/R/rstudio.R
+++ b/R/rstudio.R
@@ -92,11 +92,13 @@ rproj_path <- function(base_path = proj_get()) {
 
 # Is base_path open in RStudio?
 in_rstudio <- function(base_path = proj_get()) {
-  if (!rstudioapi::isAvailable())
+  if (!rstudioapi::isAvailable()) {
     return(FALSE)
+  }
 
-  if (!rstudioapi::hasFun("getActiveProject"))
+  if (!rstudioapi::hasFun("getActiveProject")) {
     return(FALSE)
+  }
 
   proj <- rstudioapi::getActiveProject()
 
@@ -128,18 +130,21 @@ restart_rstudio <- function(message = NULL) {
     return(FALSE)
   }
 
-  if (!interactive())
+  if (!interactive()) {
     return(FALSE)
+  }
 
   if (!is.null(message)) {
     todo(message)
   }
 
-  if (!rstudioapi::hasFun("openProject"))
+  if (!rstudioapi::hasFun("openProject")) {
     return(FALSE)
+  }
 
-  if (yesno(todo_bullet(), " Restart now?"))
+  if (yesno(todo_bullet(), " Restart now?")) {
     return(FALSE)
+  }
 
   rstudioapi::openProject(proj_get())
 }

--- a/R/rstudio.R
+++ b/R/rstudio.R
@@ -142,7 +142,7 @@ restart_rstudio <- function(message = NULL) {
     return(FALSE)
   }
 
-  if (yesno(todo_bullet(), " Restart now?")) {
+  if (nope(todo_bullet(), " Restart now?")) {
     return(FALSE)
   }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -3,14 +3,17 @@ can_overwrite <- function(path) {
 
   if (!file.exists(path)) {
     TRUE
-  } else if (interactive() && !yesno("Overwrite `", name, "`?")) {
+  } else if (interactive() && !nope("Overwrite `", name, "`?")) {
     TRUE
   } else {
     FALSE
   }
 }
 
-yesno <- function(...) {
+## FALSE: user selected the "yes"
+## TRUE: user did anything else: selected one of the "no's" or selected nothing,
+##   i.e. entered 0
+nope <- function(...) {
   yeses <- c("Yes", "Definitely", "For sure", "Yup", "Yeah", "I agree", "Absolutely")
   nos <- c("No way", "Not yet", "I forget", "No", "Nope", "Uhhhh... Maybe?")
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -15,7 +15,7 @@ can_overwrite <- function(path) {
 ##   i.e. entered 0
 nope <- function(...) {
   yeses <- c("Yes", "Definitely", "For sure", "Yup", "Yeah", "I agree", "Absolutely")
-  nos <- c("No way", "Not yet", "I forget", "No", "Nope", "Uhhhh... Maybe?")
+  nos <- c("No way", "Not yet", "I forget", "No", "Nope", "Hell no")
 
   cat(paste0(..., collapse = ""))
   qs <- c(sample(yeses, 1), sample(nos, 2))

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,10 +1,10 @@
 can_overwrite <- function(path) {
-  name <- basename(path)
-
   if (!file.exists(path)) {
-    TRUE
-  } else if (interactive() && !nope("Overwrite `", name, "`?")) {
-    TRUE
+    return(TRUE)
+  }
+
+  if (interactive()) {
+    nope("Overwrite pre-existing file ", value(basename(path)), "?")
   } else {
     FALSE
   }
@@ -17,8 +17,8 @@ nope <- function(...) {
   message <- paste0(..., collapse = "")
   if (!interactive()) {
     stop(
-      code("nope()"), " called in non-interactive session.\n",
-      "Message: ", message, call. = FALSE
+      "User input required in non-interactive session.\n",
+      "Query: ", message, call. = FALSE
     )
   }
   yeses <- c("Yes", "Definitely", "For sure", "Yup", "Yeah", "I agree", "Absolutely")

--- a/R/utils.R
+++ b/R/utils.R
@@ -14,10 +14,17 @@ can_overwrite <- function(path) {
 ## TRUE: user did anything else: selected one of the "no's" or selected nothing,
 ##   i.e. entered 0
 nope <- function(...) {
+  message <- paste0(..., collapse = "")
+  if (!interactive()) {
+    stop(
+      code("nope()"), " called in non-interactive session.\n",
+      "Message: ", message, call. = FALSE
+    )
+  }
   yeses <- c("Yes", "Definitely", "For sure", "Yup", "Yeah", "I agree", "Absolutely")
   nos <- c("No way", "Not yet", "I forget", "No", "Nope", "Hell no")
 
-  cat(paste0(..., collapse = ""))
+  cat(message)
   qs <- c(sample(yeses, 1), sample(nos, 2))
   rand <- sample(length(qs))
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -54,3 +54,11 @@ check_installed <- function(pkg) {
     )
   }
 }
+
+is_testing <- function() {
+  identical(Sys.getenv("TESTTHAT"), "true")
+}
+
+interactive <- function() {
+  base::interactive() && !is_testing()
+}

--- a/man/use_readme_rmd.Rd
+++ b/man/use_readme_rmd.Rd
@@ -5,9 +5,9 @@
 \alias{use_readme_md}
 \title{Create README files.}
 \usage{
-use_readme_rmd(open = TRUE)
+use_readme_rmd(open = interactive())
 
-use_readme_md(open = TRUE)
+use_readme_md(open = interactive())
 }
 \arguments{
 \item{open}{Should the new created file be opened in RStudio?}

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -16,3 +16,11 @@ scoped_temporary_package <- function(dir = tempfile(),
   capture_output(create_package(dir, rstudio = rstudio, open = FALSE))
   invisible(dir)
 }
+
+test_mode <- function() {
+  before <- Sys.getenv("TESTTHAT")
+  after <- if (before == "true") "false" else "true"
+  Sys.setenv(TESTTHAT = after)
+  cat("TESTTHAT:", before, "-->", after, "\n")
+  invisible()
+}

--- a/tests/testthat/test-use_readme.R
+++ b/tests/testthat/test-use_readme.R
@@ -3,9 +3,9 @@ context("readme")
 test_that("error if try to overwrite existing file", {
   tmp <- scoped_temporary_package()
   file.create(file.path(tmp, "README.md"))
-  expect_error(use_readme_md(tmp), "already exists")
+  expect_error(use_readme_md(), "already exists")
   file.create(file.path(tmp, "README.Rmd"))
-  expect_error(use_readme_rmd(tmp), "already exists")
+  expect_error(use_readme_rmd(), "already exists")
 })
 
 test_that("sets up git pre-commit hook iff pkg uses git", {


### PR DESCRIPTION
Fixes #142 (Think about behaviour of `yesno()` inside tests), where by "think about" I actually meant "make less annoying".

You also touched on this here (https://github.com/r-lib/usethis/issues/111#issuecomment-353196290), though I am not throwing an error. I'm just assuming the user has NOT authorized whatever action was being proposed. It feels like an error would be a net negative from the testing point of view.

I find `nope()` makes it a bit easier to remember that `TRUE` means "no" and `FALSE` means "yes".

The [branch where I'm accumulating tests](https://github.com/r-lib/usethis/tree/add-tests) passes with this.