### PR TITLE
Add is_package() and check_is_package()

### DIFF
--- a/R/badge.R
+++ b/R/badge.R
@@ -6,6 +6,7 @@
 #'
 #' @export
 use_cran_badge <- function() {
+  check_is_package("use_cran_badge()")
   pkg <- project_name()
 
   src <- paste0("http://www.r-pkg.org/badges/version/", pkg)
@@ -24,6 +25,7 @@ use_cran_badge <- function() {
 #'
 #' @export
 use_depsy_badge <- function() {
+  check_is_package("use_depsy_badge()")
   pkg <- project_name()
 
   src <- paste0("http://depsy.org/api/package/cran/", pkg, "/badge.svg")

--- a/R/data.R
+++ b/R/data.R
@@ -32,13 +32,7 @@ use_data <- function(...,
                      internal = FALSE,
                      overwrite = FALSE,
                      compress = "bzip2") {
-  if (!is_package()) {
-    stop(
-      code("use_data()"), " only handles data for R packages and ",
-      "the project ", value(project_name()), " is not a package.",
-      call. = FALSE
-    )
-  }
+  check_is_package("use_data()")
 
   objs <- get_objs_from_dots(dots(...))
 

--- a/R/description.R
+++ b/R/description.R
@@ -9,7 +9,6 @@
 #'   from `getOption("devtools.desc")`.
 #' @export
 use_description <- function(fields = NULL) {
-
   name <- project_name()
   check_package_name(name)
 

--- a/R/dev-version.R
+++ b/R/dev-version.R
@@ -6,6 +6,7 @@
 #' @export
 #' @inheritParams use_template
 use_dev_version <- function() {
+  check_is_package("use_dev_version()")
   if (uses_git() && git_uncommitted()) {
     stop(
       "Uncommited changes. Please commit to git before continuing",

--- a/R/documentation.R
+++ b/R/documentation.R
@@ -9,6 +9,7 @@
 #' @inheritParams use_template
 #' @export
 use_package_doc <- function() {
+  check_is_package("use_package_doc()")
   name <- project_name()
 
   use_template(

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -40,10 +40,6 @@ find_template <- function(template_name) {
   path
 }
 
-is_package <- function(base_path = proj_get()) {
-  file.exists(file.path(base_path, "DESCRIPTION"))
-}
-
 project_data <- function(base_path = proj_get()) {
   if (is_package(base_path)) {
     package_data(base_path)

--- a/R/namespace.R
+++ b/R/namespace.R
@@ -6,5 +6,6 @@
 #' @inheritParams use_template
 #' @export
 use_namespace <- function() {
+  check_is_package("use_namespace()")
   use_template("NAMESPACE")
 }

--- a/R/package.R
+++ b/R/package.R
@@ -16,6 +16,7 @@
 #' use_package("dplyr", "suggests")
 #' }
 use_package <- function(package, type = "Imports") {
+  check_is_package("use_package()")
   use_dependency(package, type)
 
   switch(tolower(type),

--- a/R/package.R
+++ b/R/package.R
@@ -16,7 +16,6 @@
 #' use_package("dplyr", "suggests")
 #' }
 use_package <- function(package, type = "Imports") {
-  check_is_package("use_package()")
   use_dependency(package, type)
 
   switch(tolower(type),

--- a/R/proj.R
+++ b/R/proj.R
@@ -20,9 +20,9 @@ is_proj <- function(path = ".") !is.null(proj_find(path))
 is_package <- function(base_path = proj_get()) {
   res <- tryCatch(
     rprojroot::find_package_root_file(path = base_path),
-    error = function(e) NA
+    error = function(e) NULL
   )
-  !is.na(res)
+  !is.null(res)
 }
 
 check_is_package <- function(whos_asking = NULL) {

--- a/R/proj.R
+++ b/R/proj.R
@@ -26,20 +26,21 @@ is_package <- function(base_path = proj_get()) {
 }
 
 check_is_package <- function(whos_asking = NULL) {
-  if (!is_package()) {
-    message <- paste0(
-      "Project ", value(project_name()), " is not an R package."
-    )
-    if (!is.null(whos_asking)) {
-      message <- paste0(
-        code(whos_asking),
-        " is designed to work with packages. ",
-        message
-      )
-    }
-    stop(message, call. = FALSE)
+  if (is_package()) {
+    return(invisible())
   }
-  invisible()
+
+  message <- paste0(
+    "Project ", value(project_name()), " is not an R package."
+  )
+  if (!is.null(whos_asking)) {
+    message <- paste0(
+      code(whos_asking),
+      " is designed to work with packages. ",
+      message
+    )
+  }
+  stop(message, call. = FALSE)
 }
 
 #' Get and set currently active project

--- a/R/proj.R
+++ b/R/proj.R
@@ -17,6 +17,31 @@ proj_find <- function(path = ".") {
 
 is_proj <- function(path = ".") !is.null(proj_find(path))
 
+is_package <- function(base_path = proj_get()) {
+  res <- tryCatch(
+    rprojroot::find_package_root_file(path = base_path),
+    error = function(e) NA
+  )
+  !is.na(res)
+}
+
+check_is_package <- function(whos_asking = NULL) {
+  if (!is_package()) {
+    message <- paste0(
+      "Project ", value(project_name()), " is not an R package."
+    )
+    if (!is.null(whos_asking)) {
+      message <- paste0(
+        code(whos_asking),
+        " is designed to work with packages. ",
+        message
+      )
+    }
+    stop(message, call. = FALSE)
+  }
+  invisible()
+}
+
 #' Get and set currently active project
 #'
 #' When attached, usethis uses rprojroot to find the project root of the

--- a/R/revdep.R
+++ b/R/revdep.R
@@ -7,6 +7,7 @@
 #' @export
 #' @inheritParams use_template
 use_revdep <- function() {
+  check_is_package("use_revdep()")
   use_directory("revdep", ignore = TRUE)
   use_git_ignore("revdep/checks")
   use_git_ignore("revdep/library")

--- a/R/test.R
+++ b/R/test.R
@@ -8,7 +8,7 @@
 #' @export
 #' @inheritParams use_template
 use_testthat <- function() {
-  ## TODO(jennybc): check if project is a package
+  check_is_package("use_testthat()")
   check_installed("testthat")
 
   use_dependency("testthat", "Suggests")

--- a/R/vignette.R
+++ b/R/vignette.R
@@ -9,6 +9,7 @@
 #' @export
 #' @inheritParams use_template
 use_vignette <- function(name) {
+  check_is_package("use_vignette()")
   check_installed("rmarkdown")
 
   use_dependency("knitr", "Suggests")

--- a/tests/testthat/test-proj.R
+++ b/tests/testthat/test-proj.R
@@ -1,0 +1,19 @@
+context("projects")
+
+test_that("is_package() detects package-hood", {
+  scoped_temporary_package()
+  expect_true(is_package())
+
+  scoped_temporary_project()
+  expect_false(is_package())
+})
+
+test_that("check_is_package() errors for non-package", {
+  scoped_temporary_project()
+  expect_error(check_is_package(), "not an R package")
+})
+
+test_that("check_is_package() can reveal who's asking", {
+  scoped_temporary_project()
+  expect_error(check_is_package("foo"), "foo")
+})


### PR DESCRIPTION
I decided to delegate the definition of a package to rprojroot.

I think every function I applied `check_is_package()` to is a no-brainer. We will soon find out if it's annoying that any of these refuse to work on non-package projects.

There are probably more functions that should call `check_is_package()`, but this still represents progress.