### PR TITLE
Make edit_*() functions more tolerant of Windows + naive systems

### DIFF
--- a/R/edit.R
+++ b/R/edit.R
@@ -31,9 +31,7 @@ edit_r_environ <- function(scope = c("user", "project")) {
 #' @export
 #' @rdname edit
 edit_r_makevars <- function(scope = c("user", "project")) {
-  dir <- scope_dir(scope)
-  create_directory(dir, ".R")
-  edit_file(dir, ".R/Makevars")
+  edit_file(scope_dir(scope), ".R/Makevars")
   todo("Restart R for changes to take effect")
   invisible()
 }
@@ -42,21 +40,14 @@ edit_r_makevars <- function(scope = c("user", "project")) {
 #' @rdname edit
 edit_git_config <- function(scope = c("user", "project")) {
   scope <- match.arg(scope)
-  switch(scope,
-         user = edit_file(git_scope_dir(scope), ".gitconfig"),
-         project = {
-           create_directory(proj_get(), ".git")
-           edit_file(proj_get(), ".git/config")
-         }
-  )
-
+  path <- switch(scope, user = ".gitconfig", project = ".git/config")
+  edit_file(git_scope_dir(scope), path = path)
   invisible()
 }
 
 #' @export
 #' @rdname edit
 edit_git_ignore <- function(scope = c("user", "project")) {
-  scope <- match.arg(scope)
   ## TODO(jennybc) https://github.com/r-lib/usethis/issues/182
   edit_file(git_scope_dir(scope), ".gitignore")
   invisible()
@@ -67,8 +58,6 @@ edit_git_ignore <- function(scope = c("user", "project")) {
 #' @param type Snippet type. One of "R", "markdown", "C_Cpp", "Tex",
 #'   "Javascript", "HTML", "SQL"
 edit_rstudio_snippets <- function(type = "R") {
-  create_directory("~", ".R")
-  create_directory("~", ".R/snippets")
   edit_file("~", paste0(".R/snippets/", tolower(type), ".snippets"))
   invisible()
 }

--- a/R/edit.R
+++ b/R/edit.R
@@ -43,11 +43,11 @@ edit_r_makevars <- function(scope = c("user", "project")) {
 edit_git_config <- function(scope = c("user", "project")) {
   scope <- match.arg(scope)
   switch(scope,
-    user = edit_file(scope_dir(scope, git = TRUE), ".gitconfig"),
-    project = {
-      create_directory(proj_get(), ".git")
-      edit_file(proj_get(), ".git/config")
-    }
+         user = edit_file(git_scope_dir(scope), ".gitconfig"),
+         project = {
+           create_directory(proj_get(), ".git")
+           edit_file(proj_get(), ".git/config")
+         }
   )
 
   invisible()
@@ -58,7 +58,7 @@ edit_git_config <- function(scope = c("user", "project")) {
 edit_git_ignore <- function(scope = c("user", "project")) {
   scope <- match.arg(scope)
   ## TODO(jennybc) https://github.com/r-lib/usethis/issues/182
-  edit_file(scope_dir(scope, git = TRUE), ".gitignore")
+  edit_file(git_scope_dir(scope), ".gitignore")
   invisible()
 }
 
@@ -73,15 +73,18 @@ edit_rstudio_snippets <- function(type = "R") {
   invisible()
 }
 
-scope_dir <- function(scope = c("user", "project"), git = FALSE) {
+scope_dir <- function(scope = c("user", "project")) {
   scope <- match.arg(scope)
-  message("Editing in ", scope, " scope")
+  message("Editing in ", field(scope), " scope")
 
-  if (git) {
-    switch(scope, user = git_user_dot_home(), project = proj_get())
-  } else {
-    switch(scope, user = path.expand("~"), project = proj_get())
-  }
+  switch(scope, user = path.expand("~"), project = proj_get())
+}
+
+git_scope_dir <- function(scope = c("user", "project")) {
+  scope <- match.arg(scope)
+  message("Editing in git ", field(scope), " scope")
+
+  switch(scope, user = git_user_dot_home(), project = proj_get())
 }
 
 git_user_dot_home <- function() {

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -174,6 +174,11 @@ create_directory <- function(base_path, path) {
 edit_file <- function(base_path, path) {
   full_path <- path.expand(file.path(base_path, path))
 
+  ## example: path = ".R/snippets/r.snippets" but .R doesn't exist yet
+  if (dirname(path) != ".") {
+    create_directory(base_path, dirname(path))
+  }
+
   if (!file.exists(full_path)) {
     file.create(full_path)
   }

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -42,3 +42,11 @@ test_mode <- function() {
   cat("TESTTHAT:", before, "-->", after, "\n")
   invisible()
 }
+
+skip_if_not_ci <- function() {
+  ci <- any(toupper(Sys.getenv(c("TRAVIS", "APPVEYOR"))) == "TRUE")
+  if (ci) {
+    return(invisible(TRUE))
+  }
+  skip("Not on Travis or Appveyor")
+}

--- a/tests/testthat/test-edit.R
+++ b/tests/testthat/test-edit.R
@@ -1,13 +1,13 @@
 context("edit")
 
 expect_user_file <- function(...) {
-  expect_true(file.exists(do.call(file.path, list("~", ...))))
+  expect_true(file.exists(file.path("~", ...)))
 }
 expect_user_git_file <- function(...) {
-  expect_true(file.exists(do.call(file.path, list(git_user_dot_home(), ...))))
+  expect_true(file.exists(file.path(git_user_dot_home(), ...)))
 }
 expect_project_file <- function(...) {
-  expect_true(file.exists(do.call(file.path, list(proj_get(), ...))))
+  expect_true(file.exists(file.path(proj_get(), ...)))
 }
 
 ## testing edit_XXX("user") only on travis and appveyor, because I don't want to

--- a/tests/testthat/test-edit.R
+++ b/tests/testthat/test-edit.R
@@ -1,0 +1,93 @@
+context("edit")
+
+expect_user_file <- function(...) {
+  expect_true(file.exists(do.call(file.path, list("~", ...))))
+}
+expect_user_git_file <- function(...) {
+  expect_true(file.exists(do.call(file.path, list(git_user_dot_home(), ...))))
+}
+expect_project_file <- function(...) {
+  expect_true(file.exists(do.call(file.path, list(proj_get(), ...))))
+}
+
+## testing edit_XXX("user") only on travis and appveyor, because I don't want to
+## risk creating user-level files de novo for an actual user, which would
+## obligate me to some nerve-wracking clean up
+
+test_that("edit_r_XXX('user') ensures the file exists", {
+  ## run these manually if you already have these files or are happy to
+  ## have them or delete them
+  skip_if_not_ci()
+
+  capture_output(edit_r_profile("user"))
+  expect_user_file(".Rprofile")
+
+  capture_output(edit_r_environ("user"))
+  expect_user_file(".Renviron")
+
+  capture_output(edit_r_makevars("user"))
+  expect_user_file(".R", "Makevars")
+
+  capture_output(edit_rstudio_snippets(type = "R"))
+  expect_user_file(".R", "snippets", "r.snippets")
+  capture_output(edit_rstudio_snippets(type = "HTML"))
+  expect_user_file(".R", "snippets", "html.snippets")
+})
+
+test_that("edit_git_XXX('user') ensures the file exists", {
+  ## run these manually if you already have these files or are happy to
+  ## have them or delete them
+  skip_if_not_ci()
+
+  capture_output(edit_git_config("user"))
+  expect_user_git_file(".gitconfig")
+
+  capture_output(edit_git_ignore("user"))
+  expect_user_git_file(".gitignore")
+})
+
+test_that("edit_r_profile() ensures .Rprofile exists in project", {
+  scoped_temporary_package()
+  capture_output(edit_r_profile("project"))
+  expect_project_file(".Rprofile")
+
+  scoped_temporary_project()
+  capture_output(edit_r_profile("project"))
+  expect_project_file(".Rprofile")
+})
+
+test_that("edit_r_environ() ensures .Renviron exists in project", {
+  scoped_temporary_package()
+  capture_output(edit_r_environ("project"))
+  expect_project_file(".Renviron")
+
+  scoped_temporary_project()
+  capture_output(edit_r_environ("project"))
+  expect_project_file(".Renviron")
+})
+
+test_that("edit_r_makevars() ensures .R/Makevars exists in package", {
+  scoped_temporary_package()
+  capture_output(edit_r_makevars("project"))
+  expect_project_file(".R", "Makevars")
+})
+
+test_that("edit_git_config() ensures git ignore file exists in project", {
+  scoped_temporary_package()
+  capture_output(edit_git_config("project"))
+  expect_project_file(".git", "config")
+
+  scoped_temporary_project()
+  capture_output(edit_git_config("project"))
+  expect_project_file(".git", "config")
+})
+
+test_that("edit_git_ignore() ensures .gitignore exists in project", {
+  scoped_temporary_package()
+  capture_output(edit_git_ignore("project"))
+  expect_project_file(".gitignore")
+
+  scoped_temporary_project()
+  capture_output(edit_git_ignore("project"))
+  expect_project_file(".gitignore")
+})


### PR DESCRIPTION
Fixes #183 Location of user-level git dotfiles on Windows

Two themes, all inspired by vetting `edit_*()` functions:

  * Make sure parent directory/ies exists for anything we attempt to `edit_*()`
  * Account for different default location of user-level git dot files on Windows vs. *nix

All triggered by empirical failures on Travis, AppVeyor and local Windows VM.

*In general, I'm accumulating tests in [this branch/PR](https://github.com/r-lib/usethis/pull/156), prioritized by the number of untested lines, and making small changes in master as I go. But this is a bit bigger.*
