### PR TITLE
Make the default Title title case

### DIFF
--- a/R/description.R
+++ b/R/description.R
@@ -39,7 +39,7 @@ build_description_list <- function(name, fields = list()) {
   defaults <- list(
     Package = name,
     Version = "0.0.0.9000",
-    Title = "What the Package Does (one line, title case)",
+    Title = "What the Package Does (One Line, Title Case)",
     Description = "What the package does (one paragraph).",
     "Authors@R" = author,
     License = license,


### PR DESCRIPTION
Currently the default field is not title case, so if you check a newly created package with `--as-cran` you get a NOTE.

    The Title field should be in title case, current version then in title case:
    ‘What the Package Does (one line, title case)’
    ‘What the Package Does (One Line, Title Case)’

Maybe the note is helpful in that it reminds you to change the title, but maybe not and it would be nicer to avoid the note.