### PR TITLE
Use HTTPS for CRAN badge image.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 * `appveyor_info()` no longer reverses the repo's URL and image link. Corrects the markdown produced by `use_appveyor_badge()` (#240, @llrs). 
 
+* Use HTTPS for CRAN badge image (@jdblischak, #235).
+
 * `create_package()` and `create_project()` return a normalized path, even if target directory does not pre-exist (#227, #228).
 
 # usethis 1.2.0

--- a/R/badge.R
+++ b/R/badge.R
@@ -9,7 +9,7 @@ use_cran_badge <- function() {
   check_is_package("use_cran_badge()")
   pkg <- project_name()
 
-  src <- paste0("http://www.r-pkg.org/badges/version/", pkg)
+  src <- paste0("https://www.r-pkg.org/badges/version/", pkg)
   href <- paste0("https://cran.r-project.org/package=", pkg)
   use_badge("CRAN status", href, src)
 


### PR DESCRIPTION
I changed the URL for the CRAN badge image to use HTTPS. The HTTP URL caused my pkgdown site hosted on GitHub Pages to be labeled as insecure (https://github.com/jdblischak/workflowr/issues/96).

The HTTPS URL appears to work, e.g. here is the badge for usethis using HTTPS: [![CRAN status](https://www.r-pkg.org/badges/version/usethis)](https://cran.r-project.org/package=usethis)
