### PR TITLE
Update pipe.R

### DIFF
--- a/inst/templates/pipe.R
+++ b/inst/templates/pipe.R
@@ -1,6 +1,6 @@
 #' Pipe operator
 #'
-#' See \code{magrittr::\link[magrittr]{\%>\%}} for details.
+#' See \code{magrittr::\link[magrittr]{pipe}} for details.
 #'
 #' @name %>%
 #' @rdname pipe


### PR DESCRIPTION
devtools::install() return the following warning:
```
missing file link '%>%'
```
which makes Travis crash at:
```
checking whether package ‘XYZ’ can be installed ... ERROR
```

use of rdname works correctly