### PR TITLE
Return the correct urls from appveyor

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+* `appveyor_info()` now return the url and the image links correctly, correcting the display of the appveyor badge. 
+
 # usethis 1.2.0.9000
 
 * `create_package()` and `create_project()` return a normalized path, even if target directory does not pre-exist (#227, #228).

--- a/R/ci.R
+++ b/R/ci.R
@@ -163,13 +163,13 @@ use_appveyor_badge <- function() {
 appveyor_info <- function(base_path = proj_get()) {
   gh <- gh::gh_tree_remote(base_path)
 
-  url <- file.path(
+  img <- file.path(
     "https://ci.appveyor.com/api/projects/status/github/",
     gh$username,
     gh$repo,
     "?branch=master&svg=true"
   )
-  img <- file.path(
+  url <- file.path(
     "https://ci.appveyor.com",
     gh$username,
     gh$repo

--- a/R/ci.R
+++ b/R/ci.R
@@ -171,6 +171,7 @@ appveyor_info <- function(base_path = proj_get()) {
   )
   url <- file.path(
     "https://ci.appveyor.com",
+    "project",
     gh$username,
     gh$repo
   )


### PR DESCRIPTION
Previously the appveyor badge was not properly rendered as appveyor_info returned the url of the repository as the image. The change only affects the name of the urls returned by appveyor_info to be used by use_badge_appveyor. 