### PR TITLE
Tolerate .Rproj files in the session temp dir

### DIFF
--- a/R/create.R
+++ b/R/create.R
@@ -197,6 +197,14 @@ check_not_nested <- function(path, name) {
     return()
   }
 
+  ## special case: allow nested project if
+  ## 1) is_testing()
+  ## 2) proposed project name matches magic string we build into test projects
+  ## https://github.com/r-lib/usethis/pull/241
+  if (is_testing() && grepl("aaa", name)) {
+    return()
+  }
+
   message <- paste0(
     "New project ", value(name), " is nested inside an existing project ",
     value(proj_root), "."

--- a/R/rstudio.R
+++ b/R/rstudio.R
@@ -72,7 +72,7 @@ use_blank_slate <- function(scope = c("user", "project")) {
   invisible()
 }
 
-# Is base_path an RStudio Project?
+# Is base_path an RStudio Project or inside an RStudio Project?
 is_rstudio_project <- function(base_path = proj_get()) {
   res <- tryCatch(
     rprojroot::find_rstudio_root_file(path = base_path),

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -1,16 +1,20 @@
-scoped_temporary_package <- function(dir = tempfile(),
+## putting `pattern` in the package or project name is part of our strategy for
+## suspending the nested project check during testing
+pattern <- "aaa"
+
+scoped_temporary_package <- function(dir = tempfile(pattern = pattern),
                                      env = parent.frame(),
                                      rstudio = FALSE) {
   scoped_temporary_thing(dir, env, rstudio, "package")
 }
 
-scoped_temporary_project <- function(dir = tempfile(),
+scoped_temporary_project <- function(dir = tempfile(pattern = pattern),
                                      env = parent.frame(),
                                      rstudio = FALSE) {
   scoped_temporary_thing(dir, env, rstudio, "project")
 }
 
-scoped_temporary_thing <- function(dir = tempfile(),
+scoped_temporary_thing <- function(dir = tempfile(pattern = pattern),
                                    env = parent.frame(),
                                    rstudio = FALSE,
                                    thing = c("package", "project")) {

--- a/tests/testthat/test-browse.R
+++ b/tests/testthat/test-browse.R
@@ -28,8 +28,8 @@ test_that("github_home() strips everything after USER/REPO", {
 })
 
 test_that("cran_home() produces canonical URL", {
-  pkg <- scoped_temporary_package(tempfile("foo"))
-  expect_match(cran_home(), "https://cran.r-project.org/package=foo")
+  pkg <- scoped_temporary_package(tempfile("aaa"))
+  expect_match(cran_home(), "https://cran.r-project.org/package=aaa")
   expect_match(cran_home("bar"), "https://cran.r-project.org/package=bar")
 })
 

--- a/tests/testthat/test-create.R
+++ b/tests/testthat/test-create.R
@@ -26,7 +26,7 @@ test_that("nested project is disallowed, by default", {
 ## https://github.com/r-lib/usethis/issues/227
 test_that("proj is normalized when path does not pre-exist", {
   ## take care to provide a **non-absolute** path
-  path_package <- basename(tempfile())
+  path_package <- basename(tempfile(pattern = "aaa"))
   withr::with_dir(
     tempdir(), {
       ## better than proj_get() here because won't error if not in project
@@ -38,7 +38,7 @@ test_that("proj is normalized when path does not pre-exist", {
   )
   expect_true(dir.exists(new_proj))
 
-  path_project <- basename(tempfile())
+  path_project <- basename(tempfile(pattern = "aaa"))
   withr::with_dir(
     tempdir(), {
       old_proj <- proj$cur


### PR DESCRIPTION
I suffer from this frequently when other activities have left a stray `.Rproj` file in the session temp directory. ~~Is this kosher? No one should be putting anything of value there, right?~~