### PR TITLE
Better create_from_github()

### DIFF
--- a/R/create.R
+++ b/R/create.R
@@ -146,7 +146,7 @@ create_from_github <- function(repo,
 
   pat <- auth_token %||% gh_token()
   pat_available <- pat != ""
-  user <- if (pat_available) gh::gh_whoami()[["login"]] else NULL
+  user <- if (pat_available) gh::gh_whoami(pat)[["login"]] else NULL
 
   gh <- function(endpoint, ...) {
     gh::gh(

--- a/R/create.R
+++ b/R/create.R
@@ -88,12 +88,8 @@ create_project <- function(path,
 #' Creates a new local Git repository from a repository on GitHub. It is highly
 #' recommended that you pre-configure or pass a GitHub personal access token
 #' (PAT) as described in [gh::gh_whoami()]. In particular, a PAT is required in
-#' order for `create_from_github()` to do "fork and clone".
-#'
-#' Currently only works for public repositories. A future version of this
-#' function will likely have an interface closer to [use_github()], i.e. more
-#' ability to accept credentials and more control over the Git configuration of
-#' the affected remote or local repositories.
+#' order for `create_from_github()` to do ["fork and
+#' clone"](https://help.github.com/articles/fork-a-repo/).
 #'
 #' @seealso [use_course()] for one-time download of all files in a Git repo,
 #'   without any local or remote Git operations.
@@ -102,12 +98,18 @@ create_project <- function(path,
 #' @param repo GitHub repo specification in this form: `owner/reponame`. The
 #'   second part will be the name of the new local repo.
 #' @inheritParams use_course
-#' @param fork Create and clone a fork? Or clone `repo` itself? Defaults to
-#'   `TRUE` if you can't push to `repo`, `FALSE` if you can.
+#' @param fork If `TRUE`, we create and clone a fork. If `FALSE`, we clone
+#'   `repo` itself. Will be set to `FALSE` if no `auth_token` (a.k.a. PAT) is
+#'   provided or preconfigured. Otherwise, if unspecified, defaults to `FALSE`
+#'   if you can push to `repo` and `TRUE` if you cannot. If a fork is created,
+#'   the original target repo is added to the local repo as the `upstream`
+#'   remote, using your preferred `protocol`, to make it easier to pull upstream
+#'   changes in the future.
 #' @param rstudio Initiate an [RStudio
 #'   Project](https://support.rstudio.com/hc/en-us/articles/200526207-Using-Projects)?
 #'    Defaults to `TRUE` if in an RStudio session and project has no
 #'   pre-existing `.Rproj` file. Defaults to `FALSE` otherwise.
+#' @inheritParams use_github
 #' @export
 #' @examples
 #' \dontrun{
@@ -124,6 +126,8 @@ create_from_github <- function(repo,
                                host = NULL) {
   destdir <- destdir %||% conspicuous_place()
   check_is_dir(destdir)
+  check_not_nested(destdir, repo)
+  protocol <- match.arg(protocol)
 
   repo <- strsplit(repo, "/")[[1]]
   if (length(repo) != 2) {
@@ -134,33 +138,57 @@ create_from_github <- function(repo,
   }
   owner <- repo[[1]]
   repo <- repo[[2]]
-  repo_info <- gh::gh("GET /repos/:owner/:repo", owner = owner, repo = repo)
 
-  check_not_nested(destdir, repo)
-
-  auth_token <- auth_token %||% gh_token()
-  pat_available <- auth_token != ""
+  pat <- auth_token %||% gh_token()
+  pat_available <- pat != ""
   user <- if (pat_available) gh::gh_whoami()[["login"]] else NULL
 
-  fork <- rationalize_fork(fork, repo_info, pat_available, user)
-
-  if (fork) {
-    ## https://developer.github.com/v3/repos/forks/#create-a-fork
-    done("Forking repo")
-    fork_info <- gh::gh(
-      "POST /repos/:owner/:repo/forks",
-      owner = owner, repo = repo
+  gh <- function(endpoint, ...) {
+    gh::gh(
+      endpoint,
+      ...,
+      .token = auth_token,
+      .api_url = host
     )
-    owner <- fork_info$owner$login
-    git_url <- fork_info$git_url
-  } else {
-    git_url <- repo_info$git_url
   }
 
+  repo_info <- gh("GET /repos/:owner/:repo", owner = owner, repo = repo)
+
+  fork <- rationalize_fork(fork, repo_info, pat_available, user)
+  if (fork) {
+    ## https://developer.github.com/v3/repos/forks/#create-a-fork
+    done("Forking ", value(repo_info$full_name))
+    upstream_url <- switch(
+      protocol,
+      https = repo_info$clone_url,
+      ssh = repo_info$ssh_url
+    )
+    repo_info <- gh(
+      "POST /repos/:owner/:repo/forks", owner = owner, repo = repo
+    )
+  }
+
+  origin_url <- switch(
+    protocol,
+    https = repo_info$clone_url,
+    ssh = repo_info$ssh_url
+  )
+
   repo_path <- create_directory(destdir, repo)
-  done("Cloning repo from ", value(git_url), " into ", value(repo_path))
-  git2r::clone(git_url, normalizePath(repo_path), progress = FALSE)
+  done("Cloning repo from ", value(origin_url), " into ", value(repo_path))
+  git2r::clone(
+    origin_url,
+    normalizePath(repo_path, mustWork = FALSE),
+    credentials = credentials,
+    progress = FALSE
+  )
   proj_set(repo_path)
+
+  if (fork) {
+    r <- git2r::repository(proj_get())
+    done("Adding ", value("upstream"), " remote: ", value(upstream_url))
+    git2r::remote_add(r, "upstream", upstream_url)
+  }
 
   rstudio <- rstudio %||% rstudioapi::isAvailable()
   rstudio <- rstudio && !is_rstudio_project(repo_path)

--- a/R/create.R
+++ b/R/create.R
@@ -85,14 +85,15 @@ create_project <- function(path,
 
 #' Create a repo and project from GitHub
 #'
-#' Creates a new local Git repository from a repository on GitHub. If you have
-#' pre-configured a GitHub personal access token (PAT) as described in
-#' [gh::gh_whoami()], you will get more sensible default behavior for the `fork`
-#' argument. You cannot create a fork without a PAT. Currently only works for
-#' public repositories. A future version of this function will likely have an
-#' interface closer to [use_github()], i.e. more ability to accept credentials
-#' and more control over the Git configuration of the affected remote or local
-#' repositories.
+#' Creates a new local Git repository from a repository on GitHub. It is highly
+#' recommended that you pre-configure or pass a GitHub personal access token
+#' (PAT) as described in [gh::gh_whoami()]. In particular, a PAT is required in
+#' order for `create_from_github()` to do "fork and clone".
+#'
+#' Currently only works for public repositories. A future version of this
+#' function will likely have an interface closer to [use_github()], i.e. more
+#' ability to accept credentials and more control over the Git configuration of
+#' the affected remote or local repositories.
 #'
 #' @seealso [use_course()] for one-time download of all files in a Git repo,
 #'   without any local or remote Git operations.
@@ -116,7 +117,11 @@ create_from_github <- function(repo,
                                destdir = NULL,
                                fork = NA,
                                rstudio = NULL,
-                               open = interactive()) {
+                               open = interactive(),
+                               protocol = c("ssh", "https"),
+                               credentials = NULL,
+                               auth_token = NULL,
+                               host = NULL) {
   destdir <- destdir %||% conspicuous_place()
   check_is_dir(destdir)
 

--- a/R/create.R
+++ b/R/create.R
@@ -248,12 +248,7 @@ rationalize_fork <- function(fork, repo_info, pat_available, user = NULL) {
   owner <- repo_info$owner$login
 
   if (is.na(fork)) {
-    if (pat_available) {
-      # fork only if can't push to the repo
-      fork <- !isTRUE(perms$push)
-    } else {
-      fork <- FALSE
-    }
+    fork <- pat_available && !isTRUE(perms$push)
   }
 
   if (fork && !pat_available) {

--- a/R/create.R
+++ b/R/create.R
@@ -139,6 +139,11 @@ create_from_github <- function(repo,
   owner <- repo[[1]]
   repo <- repo[[2]]
 
+  repo_path <- create_directory(destdir, repo)
+  if (dir.exists(repo_path)) {
+    check_is_empty(repo_path)
+  }
+
   pat <- auth_token %||% gh_token()
   pat_available <- pat != ""
   user <- if (pat_available) gh::gh_whoami()[["login"]] else NULL
@@ -174,7 +179,6 @@ create_from_github <- function(repo,
     ssh = repo_info$ssh_url
   )
 
-  repo_path <- create_directory(destdir, repo)
   done("Cloning repo from ", value(origin_url), " into ", value(repo_path))
   git2r::clone(
     origin_url,
@@ -221,7 +225,7 @@ check_not_nested <- function(path, name) {
   proj_root <- proj_find(path)
 
   if (is.null(proj_root)) {
-    return()
+    return(invisible())
   }
 
   message <- paste0(
@@ -235,6 +239,7 @@ check_not_nested <- function(path, name) {
   if (nope(message, " This is rarely a good idea. Do you wish to create anyway?")) {
     stop("Aborting project creation", call. = FALSE)
   }
+  invisible()
 }
 
 rationalize_fork <- function(fork, repo_info, pat_available, user = NULL) {

--- a/R/github.R
+++ b/R/github.R
@@ -1,17 +1,19 @@
 #' Connect a local repo with GitHub.
 #'
-#' `use_github()` requires that your package have a git repository, which you
-#' can create with [use_git()], if needed. `use_github()` then sets up
-#' appropriate git remotes and syncs. `use_github_links()` populates the `URL`
-#' and `BugReports` fields with appropriate links (unless they already exist).
+#' `use_github()` requires that your project have a local git repository, which
+#' you can initialize with [use_git()], if needed. `use_github()` then creates
+#' an associated repo on GitHub, adds that to your local repo as a remote, and
+#' makes an initial push to synchronize. `use_github_links()` populates the
+#' `URL` and `BugReports` fields of a GitHub-using R package with appropriate
+#' links (unless they already exist).
 #'
 #' @section Authentication:
 #'
 #'   A new GitHub repo will be created via the GitHub API, therefore you must
-#'   provide a GitHub personal access token (PAT) via the argument `auth_token`,
-#'   which defaults to the value of the `GITHUB_PAT` environment variable.
-#'   Obtain a PAT from \url{https://github.com/settings/tokens}. The "repo"
-#'   scope is required which is one of the default scopes for a new PAT.
+#'   make a [GitHub personal access token
+#'   (PAT)](https://github.com/settings/tokens) available. You can either
+#'   provide this directly via the auth_token `argument` or store it in an
+#'   environment variable, as described in [gh::gh_whoami()].
 #'
 #'   The argument `protocol` reflects how you wish to authenticate with GitHub
 #'   for this repo in the long run. For either `protocol`, a remote named
@@ -23,7 +25,8 @@
 #'   public and private keys are in the default locations, `~/.ssh/id_rsa.pub`
 #'   and `~/.ssh/id_rsa`, respectively, and that `ssh-agent` is configured to
 #'   manage any associated passphrase.  Alternatively, specify a
-#'   [git2r::cred_ssh_key()] object via the `credentials` parameter.
+#'   [git2r::cred_ssh_key()] object via the `credentials` parameter. Read more
+#'   about ssh setup in [Happy Git](http://happygitwithr.com/ssh-keys.html).
 #'
 #' @inheritParams use_git
 #' @param organisation If supplied, the repo will be created under this

--- a/R/github.R
+++ b/R/github.R
@@ -1,49 +1,46 @@
 #' Connect a local repo with GitHub.
 #'
-#' `use_github()` requires that your package have a git repository,
-#' which you can create with [use_git()], if needed.
-#' `use_github()` then sets up appropriate git remotes and syncs.
-#' `use_github_links()` populates the `URL` and `BugReports`
-#' fields with appropriate links (unless they already exist).
+#' `use_github()` requires that your package have a git repository, which you
+#' can create with [use_git()], if needed. `use_github()` then sets up
+#' appropriate git remotes and syncs. `use_github_links()` populates the `URL`
+#' and `BugReports` fields with appropriate links (unless they already exist).
 #'
 #' @section Authentication:
 #'
 #'   A new GitHub repo will be created via the GitHub API, therefore you must
-#'   provide a GitHub personal access token (PAT) via the argument
-#'   `auth_token`, which defaults to the value of the `GITHUB_PAT`
-#'   environment variable. Obtain a PAT from
-#'   \url{https://github.com/settings/tokens}. The "repo" scope is required
-#'   which is one of the default scopes for a new PAT.
+#'   provide a GitHub personal access token (PAT) via the argument `auth_token`,
+#'   which defaults to the value of the `GITHUB_PAT` environment variable.
+#'   Obtain a PAT from \url{https://github.com/settings/tokens}. The "repo"
+#'   scope is required which is one of the default scopes for a new PAT.
 #'
-#'   The argument `protocol` reflects how you wish to authenticate with
-#'   GitHub for this repo in the long run. For either `protocol`, a remote
-#'   named "origin" is created, an initial push is made using the specified
-#'   `protocol`, and a remote tracking branch is set. The URL of the
-#'   "origin" remote has the form `git@@github.com:<USERNAME>/<REPO>.git`
-#'   (`protocol = "ssh"`, the default) or
-#'   `https://github.com/<USERNAME>/<REPO>.git` (\code{protocol =
-#'   "https"}). For `protocol = "ssh"`, it is assumed that public and
-#'   private keys are in the default locations, `~/.ssh/id_rsa.pub` and
-#'   `~/.ssh/id_rsa`, respectively, and that `ssh-agent` is configured
-#'   to manage any associated passphrase.  Alternatively, specify a
-#'   [git2r::cred_ssh_key()] object via the `credentials`
-#'   parameter.
+#'   The argument `protocol` reflects how you wish to authenticate with GitHub
+#'   for this repo in the long run. For either `protocol`, a remote named
+#'   "origin" is created, an initial push is made using the specified
+#'   `protocol`, and a remote tracking branch is set. The URL of the "origin"
+#'   remote has the form `git@@github.com:<USERNAME>/<REPO>.git` (`protocol =
+#'   "ssh"`, the default) or `https://github.com/<USERNAME>/<REPO>.git`
+#'   (\code{protocol = "https"}). For `protocol = "ssh"`, it is assumed that
+#'   public and private keys are in the default locations, `~/.ssh/id_rsa.pub`
+#'   and `~/.ssh/id_rsa`, respectively, and that `ssh-agent` is configured to
+#'   manage any associated passphrase.  Alternatively, specify a
+#'   [git2r::cred_ssh_key()] object via the `credentials` parameter.
 #'
 #' @inheritParams use_git
 #' @param organisation If supplied, the repo will be created under this
 #'   organisation. You must have access to create repositories.
 #' @param auth_token Provide a personal access token (PAT) from
-#'   \url{https://github.com/settings/tokens}. If `NULL`, will use the
-#'   `GITHUB_PAT` environment variable.
+#'   \url{https://github.com/settings/tokens}. If `NULL`, will use the logic
+#'   described in [gh::gh_whoami()] to look for a token stored in an environment
+#'   variable.
 #' @param private If `TRUE`, creates a private repository.
 #' @param host GitHub API host to use. Override with the endpoint-root for your
 #'   GitHub enterprise instance, for example,
-#'   "https://github.hostname.com/api/v3". You can set this globally using
-#'   the `GITHUB_API_URL` env var.
+#'   "https://github.hostname.com/api/v3". You can set this globally using the
+#'   `GITHUB_API_URL` env var.
 #' @param protocol transfer protocol, either "ssh" (the default) or "https"
-#' @param credentials A [git2r::cred_ssh_key()] specifying specific
-#' ssh credentials or NULL for default ssh key and ssh-agent behaviour.
-#' Default is NULL.
+#' @param credentials A [git2r::cred_ssh_key()] specifying specific ssh
+#'   credentials or NULL for default ssh key and ssh-agent behaviour. Default is
+#'   NULL.
 #' @export
 #' @examples
 #' \dontrun{

--- a/R/github.R
+++ b/R/github.R
@@ -197,3 +197,10 @@ check_uses_github <- function(base_path = proj_get()) {
     call. = FALSE
   )
 }
+
+## use from gh when/if exported
+## https://github.com/r-lib/gh/issues/74
+gh_token <- function() {
+  token <- Sys.getenv('GITHUB_PAT', "")
+  if (token == "") Sys.getenv("GITHUB_TOKEN", "") else token
+}

--- a/R/utils.R
+++ b/R/utils.R
@@ -54,6 +54,14 @@ check_is_dir <- function(x) {
   invisible(x)
 }
 
+check_is_empty <- function(x) {
+  files <- list.files(x)
+  if (length(files) > 0) {
+    stop(value(x), " exists and is not an empty directory", call. = FALSE)
+  }
+  invisible(x)
+}
+
 dots <- function(...) {
   eval(substitute(alist(...)))
 }

--- a/man/create_from_github.Rd
+++ b/man/create_from_github.Rd
@@ -5,7 +5,8 @@
 \title{Create a repo and project from GitHub}
 \usage{
 create_from_github(repo, destdir = NULL, fork = NA, rstudio = NULL,
-  open = interactive())
+  open = interactive(), protocol = c("ssh", "https"), credentials = NULL,
+  auth_token = NULL, host = NULL)
 }
 \arguments{
 \item{repo}{GitHub repo specification in this form: \code{owner/reponame}. The
@@ -13,8 +14,13 @@ second part will be the name of the new local repo.}
 
 \item{destdir}{The new folder is stored here. Defaults to user's Desktop.}
 
-\item{fork}{Create and clone a fork? Or clone \code{repo} itself? Defaults to
-\code{TRUE} if you can't push to \code{repo}, \code{FALSE} if you can.}
+\item{fork}{If \code{TRUE}, we create and clone a fork. If \code{FALSE}, we clone
+\code{repo} itself. Will be set to \code{FALSE} if no \code{auth_token} (a.k.a. PAT) is
+provided or preconfigured. Otherwise, if unspecified, defaults to \code{FALSE}
+if you can push to \code{repo} and \code{TRUE} if you cannot. If a fork is created,
+the original target repo is added to the local repo as the \code{upstream}
+remote, using your preferred \code{protocol}, to make it easier to pull upstream
+changes in the future.}
 
 \item{rstudio}{Initiate an \href{https://support.rstudio.com/hc/en-us/articles/200526207-Using-Projects}{RStudio Project}?
 Defaults to \code{TRUE} if in an RStudio session and project has no
@@ -23,16 +29,28 @@ pre-existing \code{.Rproj} file. Defaults to \code{FALSE} otherwise.}
 \item{open}{If \code{TRUE} and in RStudio, new project will be opened in a new
 instance, if possible, or will be switched to, otherwise. If \code{TRUE} and not
 in RStudio, working directory will be set to the new project.}
+
+\item{protocol}{transfer protocol, either "ssh" (the default) or "https"}
+
+\item{credentials}{A \code{\link[git2r:cred_ssh_key]{git2r::cred_ssh_key()}} specifying specific ssh
+credentials or NULL for default ssh key and ssh-agent behaviour. Default is
+NULL.}
+
+\item{auth_token}{Provide a personal access token (PAT) from
+\url{https://github.com/settings/tokens}. If \code{NULL}, will use the logic
+described in \code{\link[gh:gh_whoami]{gh::gh_whoami()}} to look for a token stored in an environment
+variable.}
+
+\item{host}{GitHub API host to use. Override with the endpoint-root for your
+GitHub enterprise instance, for example,
+"https://github.hostname.com/api/v3". You can set this globally using the
+\code{GITHUB_API_URL} env var.}
 }
 \description{
-Creates a new local Git repository from a repository on GitHub. If you have
-pre-configured a GitHub personal access token (PAT) as described in
-\code{\link[gh:gh_whoami]{gh::gh_whoami()}}, you will get more sensible default behavior for the \code{fork}
-argument. You cannot create a fork without a PAT. Currently only works for
-public repositories. A future version of this function will likely have an
-interface closer to \code{\link[=use_github]{use_github()}}, i.e. more ability to accept credentials
-and more control over the Git configuration of the affected remote or local
-repositories.
+Creates a new local Git repository from a repository on GitHub. It is highly
+recommended that you pre-configure or pass a GitHub personal access token
+(PAT) as described in \code{\link[gh:gh_whoami]{gh::gh_whoami()}}. In particular, a PAT is required in
+order for \code{create_from_github()} to do \href{https://help.github.com/articles/fork-a-repo/}{"fork and clone"}.
 }
 \examples{
 \dontrun{

--- a/man/use_github.Rd
+++ b/man/use_github.Rd
@@ -33,33 +33,32 @@ GitHub enterprise instance, for example,
 \code{GITHUB_API_URL} env var.}
 }
 \description{
-\code{use_github()} requires that your package have a git repository, which you
-can create with \code{\link[=use_git]{use_git()}}, if needed. \code{use_github()} then sets up
-appropriate git remotes and syncs. \code{use_github_links()} populates the \code{URL}
-and \code{BugReports} fields with appropriate links (unless they already exist).
+\code{use_github()} requires that your project have a local git repository, which
+you can initialize with \code{\link[=use_git]{use_git()}}, if needed. \code{use_github()} then creates
+an associated repo on GitHub, adds that to your local repo as a remote, and
+makes an initial push to synchronize. \code{use_github_links()} populates the
+\code{URL} and \code{BugReports} fields of a GitHub-using R package with appropriate
+links (unless they already exist).
 }
 \section{Authentication}{
 
 
 A new GitHub repo will be created via the GitHub API, therefore you must
-provide a GitHub personal access token (PAT) via the argument \code{auth_token},
-which defaults to the value of the \code{GITHUB_PAT} environment variable.
-Obtain a PAT from \url{https://github.com/settings/tokens}. The "repo"
-scope is required which is one of the default scopes for a new PAT.
+make a \href{https://github.com/settings/tokens}{GitHub personal access token (PAT)} available. You can either
+provide this directly via the auth_token \code{argument} or store it in an
+environment variable, as described in \code{\link[gh:gh_whoami]{gh::gh_whoami()}}.
 
-The argument \code{protocol} reflects how you wish to authenticate with
-GitHub for this repo in the long run. For either \code{protocol}, a remote
-named "origin" is created, an initial push is made using the specified
-\code{protocol}, and a remote tracking branch is set. The URL of the
-"origin" remote has the form \code{git@github.com:<USERNAME>/<REPO>.git}
-(\code{protocol = "ssh"}, the default) or
-\code{https://github.com/<USERNAME>/<REPO>.git} (\code{protocol =
-  "https"}). For \code{protocol = "ssh"}, it is assumed that public and
-private keys are in the default locations, \code{~/.ssh/id_rsa.pub} and
-\code{~/.ssh/id_rsa}, respectively, and that \code{ssh-agent} is configured
-to manage any associated passphrase.  Alternatively, specify a
-\code{\link[git2r:cred_ssh_key]{git2r::cred_ssh_key()}} object via the \code{credentials}
-parameter.
+The argument \code{protocol} reflects how you wish to authenticate with GitHub
+for this repo in the long run. For either \code{protocol}, a remote named
+"origin" is created, an initial push is made using the specified
+\code{protocol}, and a remote tracking branch is set. The URL of the "origin"
+remote has the form \code{git@github.com:<USERNAME>/<REPO>.git} (\code{protocol = "ssh"}, the default) or \code{https://github.com/<USERNAME>/<REPO>.git}
+(\code{protocol = "https"}). For \code{protocol = "ssh"}, it is assumed that
+public and private keys are in the default locations, \code{~/.ssh/id_rsa.pub}
+and \code{~/.ssh/id_rsa}, respectively, and that \code{ssh-agent} is configured to
+manage any associated passphrase.  Alternatively, specify a
+\code{\link[git2r:cred_ssh_key]{git2r::cred_ssh_key()}} object via the \code{credentials} parameter. Read more
+about ssh setup in \href{http://happygitwithr.com/ssh-keys.html}{Happy Git}.
 }
 
 \examples{

--- a/man/use_github.Rd
+++ b/man/use_github.Rd
@@ -18,35 +18,34 @@ organisation. You must have access to create repositories.}
 
 \item{protocol}{transfer protocol, either "ssh" (the default) or "https"}
 
-\item{credentials}{A \code{\link[git2r:cred_ssh_key]{git2r::cred_ssh_key()}} specifying specific
-ssh credentials or NULL for default ssh key and ssh-agent behaviour.
-Default is NULL.}
+\item{credentials}{A \code{\link[git2r:cred_ssh_key]{git2r::cred_ssh_key()}} specifying specific ssh
+credentials or NULL for default ssh key and ssh-agent behaviour. Default is
+NULL.}
 
 \item{auth_token}{Provide a personal access token (PAT) from
-\url{https://github.com/settings/tokens}. If \code{NULL}, will use the
-\code{GITHUB_PAT} environment variable.}
+\url{https://github.com/settings/tokens}. If \code{NULL}, will use the logic
+described in \code{\link[gh:gh_whoami]{gh::gh_whoami()}} to look for a token stored in an environment
+variable.}
 
 \item{host}{GitHub API host to use. Override with the endpoint-root for your
 GitHub enterprise instance, for example,
-"https://github.hostname.com/api/v3". You can set this globally using
-the \code{GITHUB_API_URL} env var.}
+"https://github.hostname.com/api/v3". You can set this globally using the
+\code{GITHUB_API_URL} env var.}
 }
 \description{
-\code{use_github()} requires that your package have a git repository,
-which you can create with \code{\link[=use_git]{use_git()}}, if needed.
-\code{use_github()} then sets up appropriate git remotes and syncs.
-\code{use_github_links()} populates the \code{URL} and \code{BugReports}
-fields with appropriate links (unless they already exist).
+\code{use_github()} requires that your package have a git repository, which you
+can create with \code{\link[=use_git]{use_git()}}, if needed. \code{use_github()} then sets up
+appropriate git remotes and syncs. \code{use_github_links()} populates the \code{URL}
+and \code{BugReports} fields with appropriate links (unless they already exist).
 }
 \section{Authentication}{
 
 
 A new GitHub repo will be created via the GitHub API, therefore you must
-provide a GitHub personal access token (PAT) via the argument
-\code{auth_token}, which defaults to the value of the \code{GITHUB_PAT}
-environment variable. Obtain a PAT from
-\url{https://github.com/settings/tokens}. The "repo" scope is required
-which is one of the default scopes for a new PAT.
+provide a GitHub personal access token (PAT) via the argument \code{auth_token},
+which defaults to the value of the \code{GITHUB_PAT} environment variable.
+Obtain a PAT from \url{https://github.com/settings/tokens}. The "repo"
+scope is required which is one of the default scopes for a new PAT.
 
 The argument \code{protocol} reflects how you wish to authenticate with
 GitHub for this repo in the long run. For either \code{protocol}, a remote

--- a/man/use_github_labels.Rd
+++ b/man/use_github_labels.Rd
@@ -13,7 +13,7 @@ tidy_labels()
 \arguments{
 \item{labels}{Named character vector of labels. The names are the label text,
 such as "bug", and the values are the label colours in hexadecimal, such as
-"d73a4a". First, labels that don't yet exist are created, then label
+"e02a2a". First, labels that don't yet exist are created, then label
 colours are updated.}
 
 \item{delete_default}{If \code{TRUE}, will remove GitHub default labels that do
@@ -21,13 +21,14 @@ not appear in the \code{labels} vector (presumably defaults that aren't relevant
 to your workflow).}
 
 \item{auth_token}{Provide a personal access token (PAT) from
-\url{https://github.com/settings/tokens}. If \code{NULL}, will use the
-\code{GITHUB_PAT} environment variable.}
+\url{https://github.com/settings/tokens}. If \code{NULL}, will use the logic
+described in \code{\link[gh:gh_whoami]{gh::gh_whoami()}} to look for a token stored in an environment
+variable.}
 
 \item{host}{GitHub API host to use. Override with the endpoint-root for your
 GitHub enterprise instance, for example,
-"https://github.hostname.com/api/v3". You can set this globally using
-the \code{GITHUB_API_URL} env var.}
+"https://github.hostname.com/api/v3". You can set this globally using the
+\code{GITHUB_API_URL} env var.}
 }
 \description{
 \code{use_github_labels()} creates new labels and/or changes label

--- a/tests/manual/manual-create-from-github.R
+++ b/tests/manual/manual-create-from-github.R
@@ -43,7 +43,10 @@ create_from_github("jennybc/fluffy-otter", fork = TRUE)
 create_from_github("jennybc/fluffy-otter", fork = NA)
 ## gets created, as clone but no fork
 
-## make my PAT unavailable
+## store my PAT
+token <- gh_token()
+
+## make my PAT unavailable via env vars
 Sys.unsetenv(c("GITHUB_PAT", "GITHUB_TOKEN"))
 gh::gh_whoami()
 
@@ -64,3 +67,9 @@ create_from_github("cran/TailRank", fork = TRUE)
 ## fork = NA
 create_from_github("cran/TailRank", fork = NA)
 ## created as clone (no fork)
+unlink("~/Desktop/TailRank/", recursive = TRUE)
+
+## create from repo I do not have push access to
+## fork = TRUE, explicitly provide token
+create_from_github("cran/TailRank", fork = TRUE, auth_token = token)
+## fork and clone

--- a/tests/manual/manual-create-from-github.R
+++ b/tests/manual/manual-create-from-github.R
@@ -1,0 +1,66 @@
+load_all()
+
+## this repo was chosen because it was first one listed for the cran gh user
+## i.e., totally arbitrary
+unlink("~/Desktop/TailRank/", recursive = TRUE)
+
+## I assume a PAT is configured
+gh::gh_whoami()
+
+## create from repo I do not have push access to
+## fork = FALSE
+create_from_github("cran/TailRank", fork = FALSE)
+unlink("~/Desktop/TailRank/", recursive = TRUE)
+
+## create from repo I do not have push access to
+## fork = TRUE
+create_from_github("cran/TailRank", fork = TRUE)
+## fork and clone --> should see origin and upstream remotes
+unlink("~/Desktop/TailRank/", recursive = TRUE)
+
+## create from repo I do not have push access to
+## fork = NA
+create_from_github("cran/TailRank", fork = TRUE)
+## fork and clone --> should see origin and upstream remotes
+unlink("~/Desktop/TailRank/", recursive = TRUE)
+
+## a repo I created just for testing
+unlink("~/Desktop/fluffy-otter/", recursive = TRUE)
+
+## create from repo I DO have push access to
+## fork = FALSE
+create_from_github("jennybc/fluffy-otter", fork = FALSE)
+## make a local edit and push to confirm origin remote is properly setup
+unlink("~/Desktop/fluffy-otter/", recursive = TRUE)
+
+## create from repo I do have push access to
+## fork = TRUE
+create_from_github("jennybc/fluffy-otter", fork = TRUE)
+## expect error because I own it and can't fork it
+
+## create from repo I do have push access to
+## fork = NA
+create_from_github("jennybc/fluffy-otter", fork = NA)
+## gets created, as clone but no fork
+
+## make my PAT unavailable
+Sys.unsetenv(c("GITHUB_PAT", "GITHUB_TOKEN"))
+gh::gh_whoami()
+
+unlink("~/Desktop/TailRank/", recursive = TRUE)
+
+## create from repo I do not have push access to
+## fork = FALSE
+create_from_github("cran/TailRank", fork = FALSE)
+## created, clone, origin remote is cran/TailRank
+unlink("~/Desktop/TailRank/", recursive = TRUE)
+
+## create from repo I do not have push access to
+## fork = TRUE
+create_from_github("cran/TailRank", fork = TRUE)
+## expect error because PAT not available
+
+## create from repo I do not have push access to
+## fork = NA
+create_from_github("cran/TailRank", fork = NA)
+## created as clone (no fork)

--- a/tests/manual/manual-create-from-github.R
+++ b/tests/manual/manual-create-from-github.R
@@ -20,7 +20,7 @@ unlink("~/Desktop/TailRank/", recursive = TRUE)
 
 ## create from repo I do not have push access to
 ## fork = NA
-create_from_github("cran/TailRank", fork = TRUE)
+create_from_github("cran/TailRank", fork = NA)
 ## fork and clone --> should see origin and upstream remotes
 unlink("~/Desktop/TailRank/", recursive = TRUE)
 

--- a/tests/testthat/test-create.R
+++ b/tests/testthat/test-create.R
@@ -49,3 +49,54 @@ test_that("proj is normalized when path does not pre-exist", {
   )
   expect_true(dir.exists(new_proj))
 })
+
+test_that("rationalize_fork() honors fork = FALSE", {
+  expect_false(
+    rationalize_fork(fork = FALSE, repo_info = list(), pat_available = TRUE)
+  )
+  expect_false(
+    rationalize_fork(fork = FALSE, repo_info = list(), pat_available = FALSE)
+  )
+})
+
+test_that("rationalize_fork() won't attempt to fork w/o PAT", {
+  expect_false(
+    rationalize_fork(fork = NA, repo_info = list(), pat_available = FALSE)
+  )
+  expect_error(
+    rationalize_fork(fork = TRUE, repo_info = list(), pat_available = FALSE),
+    "No GitHub Personal Access Token available"
+  )
+})
+
+test_that("rationalize_fork() won't attempt to fork repo owned by user", {
+  expect_error(
+    rationalize_fork(
+      fork = TRUE,
+      repo_info = list(full_name = "USER/REPO", owner = list(login = "USER")),
+      pat_available = TRUE,
+      user = "USER"
+    ),
+    "Can't fork"
+  )
+})
+
+test_that("rationalize_fork() forks by default iff user cannot push", {
+  expect_false(
+    rationalize_fork(
+      fork = NA,
+      repo_info = list(permissions = list(push = TRUE)),
+      pat_available = TRUE
+    )
+  )
+  expect_true(
+    rationalize_fork(
+      fork = NA,
+      repo_info = list(
+        owner = list(login = "SOMEONE_ELSE"),
+        permissions = list(push = FALSE)
+      ),
+      pat_available = TRUE
+    )
+  )
+})


### PR DESCRIPTION
Fixes  #215 `create_from_github()` should share many arguments with `use_github()`
Fixes #214 GitHub connectivity

I think this completes the obvious set of GitHub operations a typical user would expect. At least in terms of project initiation.

* Clones from the ssh or https url (vs the git url, previously), which stores a usable URL for the `origin` remote, i.e. pull/push should now work going forward
* More explicit logic re: forking and PAT availability
* Adds `upstream` remote in case of fork, also honouring ssh vs https protocol
* Allows token, credentials, host to be specified