### PR TITLE
Work on edit_*() functions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # usethis 1.2.0.9000
 
+* `edit_*()` functions now return the target path, invisibly (#255).
+
+* `edit_git_ignore(scope = "user")` prefers `~/.gitignore`, but detects an existing `~/.gitignore_global`, if it exists. If a new global gitignore file is created, it is created as `~/.gitignore` and recorded in user's git config as the `core.excludesfile` (#255).
+
 * `create_from_github()` gains several arguments and new functionality. The `protocol` argument lets user convey whether remote URLs should be ssh or https. In the case of "fork and clone", the original repo is added as `upstream` remote. It is now possible -- although rarely necessary -- to directly specify the GitHub PAT, credentials (in git2r form), and GitHub host (#214, #214, #253).
 
 * `use_github_labels()` can create or update the colour of arbitrary GitHub issue labels, defaulting to a set of labels and colours used by the tidyverse packages, which are now exposed via `tidy_labels()`. That set now includes the labels "good first issue" and "help wanted" (#168, #249).

--- a/R/edit.R
+++ b/R/edit.R
@@ -15,7 +15,8 @@ NULL
 #' @export
 #' @rdname edit
 edit_r_profile <- function(scope = c("user", "project")) {
-  file <- edit_file(scope_dir(scope), ".Rprofile")
+  file <- file.path(scope_dir(scope), ".Rprofile")
+  edit_file(file)
   todo("Restart R for changes to take effect")
   invisible(file)
 }
@@ -23,7 +24,8 @@ edit_r_profile <- function(scope = c("user", "project")) {
 #' @export
 #' @rdname edit
 edit_r_environ <- function(scope = c("user", "project")) {
-  file <- edit_file(scope_dir(scope), ".Renviron")
+  file <- file.path(scope_dir(scope), ".Renviron")
+  edit_file(file)
   todo("Restart R for changes to take effect")
   invisible(file)
 }
@@ -31,7 +33,8 @@ edit_r_environ <- function(scope = c("user", "project")) {
 #' @export
 #' @rdname edit
 edit_r_makevars <- function(scope = c("user", "project")) {
-  file <- edit_file(scope_dir(scope), ".R/Makevars")
+  file <- file.path(scope_dir(scope), ".R/Makevars")
+  edit_file(file)
   todo("Restart R for changes to take effect")
   invisible(file)
 }
@@ -41,16 +44,16 @@ edit_r_makevars <- function(scope = c("user", "project")) {
 edit_git_config <- function(scope = c("user", "project")) {
   scope <- match.arg(scope)
   path <- switch(scope, user = ".gitconfig", project = ".git/config")
-  file <- edit_file(git_scope_dir(scope), path = path)
-  invisible(file)
+  file <- file.path(git_scope_dir(scope), path = path)
+  invisible(edit_file(file))
 }
 
 #' @export
 #' @rdname edit
 edit_git_ignore <- function(scope = c("user", "project")) {
   ## TODO(jennybc) https://github.com/r-lib/usethis/issues/182
-  file <- edit_file(git_scope_dir(scope), ".gitignore")
-  invisible(file)
+  file <- file.path(git_scope_dir(scope), ".gitignore")
+  invisible(edit_file(file))
 }
 
 #' @export
@@ -58,8 +61,8 @@ edit_git_ignore <- function(scope = c("user", "project")) {
 #' @param type Snippet type. One of "R", "markdown", "C_Cpp", "Tex",
 #'   "Javascript", "HTML", "SQL"
 edit_rstudio_snippets <- function(type = "R") {
-  file <- edit_file("~", paste0(".R/snippets/", tolower(type), ".snippets"))
-  invisible(file)
+  file <- file.path("~", paste0(".R/snippets/", tolower(type), ".snippets"))
+  invisible(edit_file(file))
 }
 
 scope_dir <- function(scope = c("user", "project")) {

--- a/R/edit.R
+++ b/R/edit.R
@@ -15,25 +15,25 @@ NULL
 #' @export
 #' @rdname edit
 edit_r_profile <- function(scope = c("user", "project")) {
-  edit_file(scope_dir(scope), ".Rprofile")
+  file <- edit_file(scope_dir(scope), ".Rprofile")
   todo("Restart R for changes to take effect")
-  invisible()
+  invisible(file)
 }
 
 #' @export
 #' @rdname edit
 edit_r_environ <- function(scope = c("user", "project")) {
-  edit_file(scope_dir(scope), ".Renviron")
+  file <- edit_file(scope_dir(scope), ".Renviron")
   todo("Restart R for changes to take effect")
-  invisible()
+  invisible(file)
 }
 
 #' @export
 #' @rdname edit
 edit_r_makevars <- function(scope = c("user", "project")) {
-  edit_file(scope_dir(scope), ".R/Makevars")
+  file <- edit_file(scope_dir(scope), ".R/Makevars")
   todo("Restart R for changes to take effect")
-  invisible()
+  invisible(file)
 }
 
 #' @export
@@ -41,16 +41,16 @@ edit_r_makevars <- function(scope = c("user", "project")) {
 edit_git_config <- function(scope = c("user", "project")) {
   scope <- match.arg(scope)
   path <- switch(scope, user = ".gitconfig", project = ".git/config")
-  edit_file(git_scope_dir(scope), path = path)
-  invisible()
+  file <- edit_file(git_scope_dir(scope), path = path)
+  invisible(file)
 }
 
 #' @export
 #' @rdname edit
 edit_git_ignore <- function(scope = c("user", "project")) {
   ## TODO(jennybc) https://github.com/r-lib/usethis/issues/182
-  edit_file(git_scope_dir(scope), ".gitignore")
-  invisible()
+  file <- edit_file(git_scope_dir(scope), ".gitignore")
+  invisible(file)
 }
 
 #' @export
@@ -58,8 +58,8 @@ edit_git_ignore <- function(scope = c("user", "project")) {
 #' @param type Snippet type. One of "R", "markdown", "C_Cpp", "Tex",
 #'   "Javascript", "HTML", "SQL"
 edit_rstudio_snippets <- function(type = "R") {
-  edit_file("~", paste0(".R/snippets/", tolower(type), ".snippets"))
-  invisible()
+  file <- edit_file("~", paste0(".R/snippets/", tolower(type), ".snippets"))
+  invisible(file)
 }
 
 scope_dir <- function(scope = c("user", "project")) {

--- a/R/edit.R
+++ b/R/edit.R
@@ -76,6 +76,20 @@ edit_git_ignore <- function(scope = c("user", "project")) {
   invisible(edit_file(file))
 }
 
+## .gitignore is more common, but .gitignore_global appears in some
+## very prominent places --> we must allow for the latter, if pre-exists
+git_ignore_path <- function(scope) {
+  path <- scoped_git_path(scope, ".gitignore")
+  if (scope == "project") {
+    return(path)
+  }
+  if (!file.exists(path)) {
+    alt_path <- scoped_git_path("user", ".gitignore_global")
+    path <- if (file.exists(alt_path)) alt_path else path
+  }
+  path
+}
+
 
 scoped_path <- function(scope, ...) file.path(scope_dir(scope), ...)
 scoped_git_path <- function(scope, ...) file.path(scope_git_dir(scope), ...)

--- a/R/edit.R
+++ b/R/edit.R
@@ -70,9 +70,11 @@ edit_git_ignore <- function(scope = c("user", "project")) {
   scope <- match.arg(scope)
   file <- git_ignore_path(scope)
   if (scope == "user" && !file.exists(file)) {
-    todo("Tell git about this new global gitignore file for changes to take effect!")
-    todo("For example, execute something like this in a shell:")
-    code_block("git config --global core.excludesfile '~/.gitignore'")
+    done(
+      "Adding new global gitignore to your git config: ",
+      value(".gitignore")
+    )
+    git2r::config(global = TRUE, core.excludesfile = "~/.gitignore")
   }
   invisible(edit_file(file))
 }

--- a/R/edit.R
+++ b/R/edit.R
@@ -67,7 +67,8 @@ edit_git_config <- function(scope = c("user", "project")) {
 #' @export
 #' @rdname edit
 edit_git_ignore <- function(scope = c("user", "project")) {
-  file <- scoped_git_path(scope, ".gitignore")
+  scope <- match.arg(scope)
+  file <- git_ignore_path(scope)
   if (scope == "user" && !file.exists(file)) {
     todo("Tell git about this new global gitignore file for changes to take effect!")
     todo("For example, execute something like this in a shell:")

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -262,7 +262,7 @@ edit_file <- function(base_path, path) {
       utils::file.edit(full_path)
     }
   }
-  invisible()
+  invisible(full_path)
 }
 
 view_url <- function(..., open = interactive()) {

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -46,7 +46,7 @@ use_template <- function(template,
   }
 
   if (open) {
-    edit_file(proj_get(), save_as)
+    edit_file(proj_path(save_as))
   }
 
   invisible(new)
@@ -239,22 +239,18 @@ create_directory <- function(base_path, path) {
   target_path
 }
 
-edit_file <- function(base_path, path) {
-  full_path <- path.expand(file.path(base_path, path))
-
-  ## example: path = ".R/snippets/r.snippets" but .R doesn't exist yet
-  if (dirname(path) != ".") {
-    create_directory(base_path, dirname(path))
-  }
+edit_file <- function(path) {
+  full_path <- path.expand(path)
+  create_directory(dirname(dirname(full_path)), basename(dirname(full_path)))
 
   if (!file.exists(full_path)) {
     file.create(full_path)
   }
 
   if (!interactive() || is_testing()) {
-    todo("Edit ", value(path))
+    todo("Edit ", value(basename(path)))
   } else {
-    todo("Modify ", value(path))
+    todo("Modify ", value(basename(path)))
 
     if (rstudioapi::isAvailable() && rstudioapi::hasFun("navigateToFile")) {
       rstudioapi::navigateToFile(full_path)

--- a/R/pkgdown.R
+++ b/R/pkgdown.R
@@ -7,7 +7,7 @@
 #' @export
 use_pkgdown <- function() {
   check_is_package("use_pkgdown()")
-  edit_file(proj_get(), "_pkgdown.yml")
+  edit_file(proj_path("_pkgdown.yml"))
   use_build_ignore("_pkgdown.yml")
 
   use_directory("docs", ignore = TRUE)

--- a/R/r.R
+++ b/R/r.R
@@ -9,7 +9,7 @@ use_r <- function(name = NULL) {
   name <- find_r_name(name)
 
   use_directory("R")
-  edit_file(proj_get(), paste0("R/", name))
+  edit_file(proj_path("R", name))
 
   invisible(TRUE)
 }

--- a/R/rcpp.R
+++ b/R/rcpp.R
@@ -24,7 +24,7 @@ use_rcpp <- function() {
       paste0("useDynLib('", project_name(), "', .registration = TRUE)"),
       "importFrom('Rcpp', 'sourceCpp')"
     )
-    edit_file(proj_get(), "NAMESPACE")
+    edit_file(proj_path("NAMESPACE"))
   }
   todo("Run document()")
 }

--- a/R/test.R
+++ b/R/test.R
@@ -36,7 +36,7 @@ use_test <- function(name = NULL, open = TRUE) {
   path <- file.path("tests", "testthat", name)
 
   if (file.exists(proj_path(path))) {
-    edit_file(proj_get(), path)
+    edit_file(proj_path(path))
   } else {
     use_template(
       "test-example.R",

--- a/R/vignette.R
+++ b/R/vignette.R
@@ -36,5 +36,5 @@ use_vignette <- function(name) {
     proj_path(path), "html_vignette", "rmarkdown",
     create_dir = FALSE, edit = FALSE
   )
-  edit_file(proj_get(), path)
+  edit_file(proj_path(path))
 }

--- a/man/edit.Rd
+++ b/man/edit.Rd
@@ -5,9 +5,9 @@
 \alias{edit_r_profile}
 \alias{edit_r_environ}
 \alias{edit_r_makevars}
+\alias{edit_rstudio_snippets}
 \alias{edit_git_config}
 \alias{edit_git_ignore}
-\alias{edit_rstudio_snippets}
 \title{Open useful configuration files}
 \usage{
 edit_r_profile(scope = c("user", "project"))
@@ -16,11 +16,11 @@ edit_r_environ(scope = c("user", "project"))
 
 edit_r_makevars(scope = c("user", "project"))
 
+edit_rstudio_snippets(type = "R")
+
 edit_git_config(scope = c("user", "project"))
 
 edit_git_ignore(scope = c("user", "project"))
-
-edit_rstudio_snippets(type = "R")
 }
 \arguments{
 \item{scope}{Edit globally for the current \strong{user}, or locally for the
@@ -28,6 +28,9 @@ current \strong{project}}
 
 \item{type}{Snippet type. One of "R", "markdown", "C_Cpp", "Tex",
 "Javascript", "HTML", "SQL"}
+}
+\value{
+Path to the file, invisibly.
 }
 \description{
 \itemize{

--- a/tests/testthat/test-edit.R
+++ b/tests/testthat/test-edit.R
@@ -1,14 +1,14 @@
 context("edit")
 
 expect_user_file <- function(...) {
-  expect_true(file.exists(file.path("~", ...)))
+  expect_true(file.exists(scoped_path("user", ...)))
 }
+
 expect_user_git_file <- function(...) {
-  expect_true(file.exists(file.path(git_user_dot_home(), ...)))
+  expect_true(file.exists(scoped_git_path("user", ...)))
 }
-expect_project_file <- function(...) {
-  expect_true(file.exists(proj_path(...)))
-}
+
+expect_project_file <- function(...) expect_true(file.exists(proj_path(...)))
 
 ## testing edit_XXX("user") only on travis and appveyor, because I don't want to
 ## risk creating user-level files de novo for an actual user, which would

--- a/tests/testthat/test-edit.R
+++ b/tests/testthat/test-edit.R
@@ -44,6 +44,8 @@ test_that("edit_git_XXX('user') ensures the file exists", {
 
   capture_output(edit_git_ignore("user"))
   expect_user_git_file(".gitignore")
+  cfg <- git2r::config()
+  expect_match(cfg$global$core.excludesfile, "gitignore")
 })
 
 test_that("edit_r_profile() ensures .Rprofile exists in project", {

--- a/tests/testthat/test-use-dependency.R
+++ b/tests/testthat/test-use-dependency.R
@@ -35,7 +35,7 @@ test_that("we message for version change and are silent for same version", {
 test_that("use_dependency() upgrades a dependency", {
   scoped_temporary_package()
 
-  use_dependency("usethis", "Suggests")
+  capture_output(use_dependency("usethis", "Suggests"))
   expect_match(desc::desc_get("Suggests", proj_get()), "usethis")
 
   expect_output(use_dependency("usethis", "Imports"), "Removing.*Adding")
@@ -47,7 +47,7 @@ test_that("use_dependency() upgrades a dependency", {
 test_that("use_dependency() declines to downgrade a dependency", {
   scoped_temporary_package()
 
-  use_dependency("usethis", "Imports")
+  capture_output(use_dependency("usethis", "Imports"))
   expect_match(desc::desc_get("Imports", proj_get()), "usethis")
 
   expect_warning(use_dependency("usethis", "Suggests"), "no change")


### PR DESCRIPTION
Path handling will get even better once I tackle #177 (Use fs when released). Please view this as incremental progress in order to achieve this:

  * `edit_git_ignore(scope = "user")` should message if user-level `.gitignore`is created *de novo*, as `edit_r_profile()` and `edit_r_environ()` do. Until you edit `core.excludesfile` in git config, the new gitignore file has no effect. But in order to do that, you need to separate path formation from path creation & editing.
  * Fixes #181 (`edit_git_ignore("user")` should explain how to put file into force).

Fixes #182 (Be more flexible re: name of global gitignore file).

Return path, invisibly, from all `edit_*()` functions.

I think overall it is more convenient to edit a path than to edit a subpath within a basepath, given the helpers `scoped_path()`, `scoped_git_path()`, and `proj_path()`. Hence this change:

  * `edit_file(base_path, path)` --> `edit_file(full_path)`