### PR TITLE
Document usage for tidyverse labels 🏷

### DIFF
--- a/R/github-labels.R
+++ b/R/github-labels.R
@@ -10,6 +10,20 @@
 #'   `tidy_labels()` returns the labels and colours commonly used by tidyverse
 #'   packages.
 #'
+#' @section Label usage:
+#' Labels are used as part of the issue-triage process, designed to minimise the
+#' time spent re-reading issues. The absence of a label indicates that an issue
+#' is new, and has yet to be triaged.
+#' * `reprex` indicates that an issue does not have a minimal reproducible
+#'   example, and that a reply has been sent requesting one from the user.
+#' * `bug` type, indicates an unexpected problem or unintended behavior.
+#' * `feature` type, indicates a feature request or enhancement.
+#' * `docs` type, indicates an issue with the documentation.
+#' * `performance` indicates a non-breaking area related to performance.
+#' * `wip` indicates that someone else is working on it or has promised to.
+#' * `good first issue` indicates a good issue for first-time contributors.
+#' * `help wanted` indicates that a maintainer wants help on an issue.
+#'
 #' @param labels Named character vector of labels. The names are the label text,
 #'   such as "bug", and the values are the label colours in hexadecimal, such as
 #'   "e02a2a". First, labels that don't yet exist are created, then label

--- a/man/use_github_labels.Rd
+++ b/man/use_github_labels.Rd
@@ -40,6 +40,24 @@ and (2) not present in the labels you provide via \code{labels}.
 \code{tidy_labels()} returns the labels and colours commonly used by tidyverse
 packages.
 }
+\section{Label usage}{
+
+Labels are used as part of the issue-triage process, designed to minimise the
+time spent re-reading issues. The absence of a label indicates that an issue
+is new, and has yet to be triaged.
+\itemize{
+\item \code{reprex} indicates that an issue does not have a minimal reproducible
+example, and that a reply has been sent requesting one from the user.
+\item \code{bug} type, indicates an unexpected problem or unintended behavior.
+\item \code{feature} type, indicates a feature request or enhancement.
+\item \code{docs} type, indicates an issue with the documentation.
+\item \code{performance} indicates a non-breaking area related to performance.
+\item \code{wip} indicates that someone else is working on it or has promised to.
+\item \code{good first issue} indicates a good issue for first-time contributors.
+\item \code{help wanted} indicates that a maintainer wants help on an issue.
+}
+}
+
 \examples{
 \dontrun{
 ## typical use in, e.g., a new tidyverse project


### PR DESCRIPTION
* Adds section describing use of labels for issue triage.
* Gives rough definitions for each label included.
* Fixes #252.

### Inspiration
* https://gist.github.com/batpigandme/3efba27ba8e62f731ef6016cf5370513
* https://help.github.com/articles/about-labels/#using-default-labels