### PR TITLE
remove extra path separators

### DIFF
--- a/R/ci.R
+++ b/R/ci.R
@@ -165,7 +165,7 @@ appveyor_info <- function(base_path = proj_get()) {
   gh <- gh::gh_tree_remote(base_path)
 
   img <- file.path(
-    "https://ci.appveyor.com/api/projects/status/github/",
+    "https://ci.appveyor.com/api/projects/status/github",
     gh$username,
     gh$repo,
     "?branch=master&svg=true"

--- a/R/ci.R
+++ b/R/ci.R
@@ -164,10 +164,12 @@ use_appveyor_badge <- function() {
 appveyor_info <- function(base_path = proj_get()) {
   gh <- gh::gh_tree_remote(base_path)
 
-  img <- file.path(
-    "https://ci.appveyor.com/api/projects/status/github",
-    gh$username,
-    gh$repo,
+  img <- paste0(
+    file.path(
+      "https://ci.appveyor.com/api/projects/status/github",
+      gh$username,
+      gh$repo
+    ),
     "?branch=master&svg=true"
   )
   url <- file.path(


### PR DESCRIPTION
- Removes extra slash between `github` and `gh$username`
- Removes extra slash between `gh$repo` and `?branch=master&svg=true`