### PR TITLE
sync badge link text capitalization pattern

### DIFF
--- a/R/ci.R
+++ b/R/ci.R
@@ -158,7 +158,7 @@ appveyor_activate <- function(browse = interactive()) {
 
 use_appveyor_badge <- function() {
   appveyor <- appveyor_info(proj_get())
-  use_badge("AppVeyor Build Status", appveyor$url, appveyor$img)
+  use_badge("AppVeyor build status", appveyor$url, appveyor$img)
 }
 
 appveyor_info <- function(base_path = proj_get()) {


### PR DESCRIPTION
To be consistent with the other badges, so that only the first word in the link text is capitalized:
```rmd
[![Travis build status](https://travis-ci.org/r-lib/usethis.svg?branch=master)](https://travis-ci.org/r-lib/usethis)
[![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/github/r-lib/usethis?branch=master&svg=true)](https://ci.appveyor.com/project/r-lib/usethis)
[![Coverage status](https://codecov.io/gh/r-lib/usethis/branch/master/graph/badge.svg)](https://codecov.io/github/r-lib/usethis?branch=master)
[![CRAN status](http://www.r-pkg.org/badges/version/usethis)](https://cran.r-project.org/package=usethis)
```