### PR TITLE
Fast file path

### DIFF
--- a/R/badge.R
+++ b/R/badge.R
@@ -65,7 +65,7 @@ use_cran_badge <- function() {
   check_is_package("use_cran_badge()")
   pkg <- project_name()
 
-  src <- paste0("https://www.r-pkg.org/badges/version/", pkg)
+  src <- file.path("https://www.r-pkg.org/badges/version", pkg)
   href <- paste0("https://cran.r-project.org/package=", pkg)
   use_badge("CRAN status", href, src)
 
@@ -82,8 +82,8 @@ use_bioc_badge <- function() {
     "http://www.bioconductor.org/shields/build/release/bioc/",
     pkg, ".svg"
   )
-  href <- paste0(
-    "https://bioconductor.org/checkResults/release/bioc-LATEST/",
+  href <- file.path(
+    "https://bioconductor.org/checkResults/release/bioc-LATEST",
     pkg
   )
   use_badge("BioC status", href, src)
@@ -97,8 +97,8 @@ use_depsy_badge <- function() {
   check_is_package("use_depsy_badge()")
   pkg <- project_name()
 
-  src <- paste0("http://depsy.org/api/package/cran/", pkg, "/badge.svg")
-  href <- paste0("http://depsy.org/package/r/", pkg)
+  src <- file.path("http://depsy.org/api/package/cran", pkg, "badge.svg")
+  href <- file.path("http://depsy.org/package/r", pkg)
   use_badge("Depsy", href, src)
 
   invisible(TRUE)
@@ -139,12 +139,11 @@ use_binder_badge <- function() {
   if (uses_github(proj_get())) {
     gh <- gh::gh_tree_remote(proj_get())
 
-    url <- paste(
+    url <- file.path(
       "https://mybinder.org/v2/gh",
       gh$username,
       gh$repo,
-      "master",
-      sep = "/")
+      "master")
 
     img <- "http://mybinder.org/badge.svg"
 

--- a/R/ci.R
+++ b/R/ci.R
@@ -163,13 +163,11 @@ use_appveyor_badge <- function() {
 
 appveyor_info <- function(base_path = proj_get()) {
   gh <- gh::gh_tree_remote(base_path)
-
   img <- paste0(
-    file.path(
-      "https://ci.appveyor.com/api/projects/status/github",
-      gh$username,
-      gh$repo
-    ),
+    "https://ci.appveyor.com/api/projects/status/github/",
+    gh$username,
+    "/",
+    gh$repo,
     "?branch=master&svg=true"
   )
   url <- file.path(

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -262,7 +262,7 @@ edit_file <- function(path) {
 }
 
 view_url <- function(..., open = interactive()) {
-  url <- paste(..., sep = "/")
+  url <- file.path(...)
   if (open) {
     done("Opening url")
     utils::browseURL(url)

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -262,7 +262,7 @@ edit_file <- function(path) {
 }
 
 view_url <- function(..., open = interactive()) {
-  url <- file.path(...)
+  url <- paste(..., sep = "/")
   if (open) {
     done("Opening url")
     utils::browseURL(url)

--- a/R/style.R
+++ b/R/style.R
@@ -1,5 +1,5 @@
 bullet <- function(lines, bullet) {
-  lines <- paste0(bullet, " ", lines)
+  lines <- paste(bullet, lines)
   cat_line(lines)
 }
 

--- a/R/style.R
+++ b/R/style.R
@@ -1,5 +1,5 @@
 bullet <- function(lines, bullet) {
-  lines <- paste(bullet, lines)
+  lines <- paste0(bullet, " ", lines)
   cat_line(lines)
 }
 


### PR DESCRIPTION
- Replaced `paste` or `paste0` with `file.path` wherever it made path construction faster
- Removed `file.path` when used within `paste0`

<details>
<summary>Benchmarking</summary>

```r
library(microbenchmark)
pkg <- "usethis"
# commit a651c89
microbenchmark(
  src <- paste0("http://depsy.org/api/package/cran/", pkg, "/badge.svg"),
  src <- file.path("http://depsy.org/api/package/cran", pkg, "badge.svg")
)
# commit a651c89
microbenchmark(
  href <- paste0("http://depsy.org/package/r/", pkg),
  href <- file.path("http://depsy.org/package/r", pkg)
)
# commit a651c89
microbenchmark(
  src <- paste0("https://www.r-pkg.org/badges/version/", pkg),
  src <- file.path("https://www.r-pkg.org/badges/version", pkg)
)
# commit a651c89
microbenchmark(
  href <- paste0(
    "https://bioconductor.org/checkResults/release/bioc-LATEST/",
    pkg
  ),
  href <- file.path(
    "https://bioconductor.org/checkResults/release/bioc-LATEST",
    pkg
  )
)
# commit 917d337
microbenchmark(
  paste0(
    file.path(
      "https://ci.appveyor.com/api/projects/status/github",
      "tidyverse",
      "dplyr"
    ),
    "?branch=master&svg=true"
  ),
  paste0(
    "https://ci.appveyor.com/api/projects/status/github/",
    "tidyverse",
    "/",
    "dplyr",
    "?branch=master&svg=true"
  )
)
# commit 6a228b4
microbenchmark(
  paste(
    "https://mybinder.org/v2/gh",
    "tidyverse",
    "dplyr",
    "master",
    sep = "/"),
  file.path(
    "https://mybinder.org/v2/gh",
    "tidyverse",
    "dplyr",
    "master"
  )  
)
# commit 6a228b4
microbenchmark(
  paste0("bullet", " ", "lines"),
  paste("bullet", "lines"),
  times = 1e3
)

```