### PR TITLE
Make rmarkdown a soft dependency

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,16 +30,16 @@ Imports:
     git2r,
     httr,
     rematch2,
-    rmarkdown,
     rprojroot,
     rstudioapi,
-    styler,
     whisker
 Suggests: 
     covr,
     knitr,
     roxygen2,
     testthat (>= 2.0.0),
+    rmarkdown,
+    styler,
     withr
 Encoding: UTF-8
 LazyData: true

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -36,10 +36,10 @@ Imports:
 Suggests: 
     covr,
     knitr,
-    roxygen2,
-    testthat (>= 2.0.0),
     rmarkdown,
+    roxygen2,
     styler,
+    testthat (>= 2.0.0),
     withr
 Encoding: UTF-8
 LazyData: true

--- a/tests/testthat/test-use-readme.R
+++ b/tests/testthat/test-use-readme.R
@@ -1,6 +1,8 @@
 context("use_readme")
 
 test_that("error if try to overwrite existing file", {
+  skip_if_not_installed("rmarkdown")
+
   scoped_temporary_package()
   file.create(proj_path("README.md"))
   expect_error(use_readme_md(), "already exists")
@@ -12,6 +14,7 @@ test_that("sets up git pre-commit hook iff pkg uses git", {
   # git2r::git2r::discover_repository() not working on R 3.1 (Travis)
   skip_if(getRversion() < 3.2)
   skip_if_no_git_config()
+  skip_if_not_installed("rmarkdown")
 
   scoped_temporary_package()
   capture_output(use_readme_rmd(open = FALSE))

--- a/tests/testthat/test-use-tidy-style.R
+++ b/tests/testthat/test-use-tidy-style.R
@@ -3,6 +3,8 @@ context("use_tidy_style")
 test_that("styling the package works", {
   skip_if(getRversion() < 3.2)
   skip_if_no_git_config()
+  skip_if_not_installed("styler")
+
   pkg <- scoped_temporary_package()
   capture_output(use_r("bad_style"))
   path_to_bad_style <- proj_path("R/bad_style.R")
@@ -16,6 +18,8 @@ test_that("styling the package works", {
 test_that("styling of non-packages works", {
   skip_if(getRversion() < 3.2)
   skip_if_no_git_config()
+  skip_if_not_installed("styler")
+
   proj <- scoped_temporary_project()
   path_to_bad_style <- proj_path("R/bad_style.R")
   capture_output(use_r("bad_style"))

--- a/tests/testthat/test-vignette.R
+++ b/tests/testthat/test-vignette.R
@@ -1,16 +1,22 @@
 context("use-vignette")
 
 test_that("use_vignette() requires a package", {
+  skip_if_not_installed("rmarkdown")
+
   scoped_temporary_project()
   expect_error(use_vignette(), "not an R package")
 })
 
 test_that("use_vignette() requires a `name`", {
+  skip_if_not_installed("rmarkdown")
+
   scoped_temporary_package()
   expect_error(use_vignette(), "no default")
 })
 
 test_that("use_vignette() does the promised setup", {
+  skip_if_not_installed("rmarkdown")
+
   scoped_temporary_package()
   capture_output(use_vignette("name"))
 


### PR DESCRIPTION
We have previously tried to keep the stringr / stringi dependency out of devtools, however it snuck back in via rmarkdown. It looks like this was always meant to be a soft dependency (hence the calls to `check_installed()` but it was accidentally put in the wrong place in the DESCRIPTION.

I also moved styler as well, since it too can be a soft dependency.