### PR TITLE
Change test-pkg to test.pkg.

### DIFF
--- a/R/github.R
+++ b/R/github.R
@@ -48,9 +48,9 @@
 #' @export
 #' @examples
 #' \dontrun{
-#' create_package("test-pkg") # creates package in current working directory
+#' create_package("test.pkg") # creates package in current working directory
 #'
-#' ## now, working inside "test-pkg", initialize git repository
+#' ## now, working inside "test.pkg", initialize git repository
 #' use_git()
 #'
 #' ## create github repository and configure as git remote

--- a/man/use_github.Rd
+++ b/man/use_github.Rd
@@ -64,9 +64,9 @@ parameter. Read more about ssh setup in \href{http://happygitwithr.com/ssh-keys.
 
 \examples{
 \dontrun{
-create_package("test-pkg") # creates package in current working directory
+create_package("test.pkg") # creates package in current working directory
 
-## now, working inside "test-pkg", initialize git repository
+## now, working inside "test.pkg", initialize git repository
 use_git()
 
 ## create github repository and configure as git remote


### PR DESCRIPTION
* Make `create_package()` example a valid package name.
* Fixes #319.