### PR TITLE
Correct the extension for YAML template in use_rmarkdown_template

### DIFF
--- a/R/rmarkdown.R
+++ b/R/rmarkdown.R
@@ -37,7 +37,7 @@ use_rmarkdown_template <- function(template_name = "Template Name",
       template_description = template_description,
       template_create_dir = template_create_dir
     ),
-    save_as = file.path(template_dir, "template.yml")
+    save_as = file.path(template_dir, "template.yaml")
   )
 
   use_template(

--- a/tests/testthat/test-use-rmarkdown.R
+++ b/tests/testthat/test-use-rmarkdown.R
@@ -4,7 +4,7 @@ test_that("use_rmarkdown_template() creates everything as promised, defaults", {
   scoped_temporary_package()
   capture_output(use_rmarkdown_template())
   path <- file.path("inst", "rmarkdown", "templates", "template-name")
-  yml <- readLines(proj_path(path, "template.yml"))
+  yml <- readLines(proj_path(path, "template.yaml"))
   expect_true(
     all(
       c("name: Template Name", "description: >",
@@ -25,7 +25,7 @@ test_that("use_rmarkdown_template() creates everything as promised, args", {
     template_create_dir = TRUE
   ))
   path <- file.path("inst", "rmarkdown", "templates", "bbb")
-  yml <- readLines(proj_path(path, "template.yml"))
+  yml <- readLines(proj_path(path, "template.yaml"))
   expect_true(
     all(
       c("name: aaa", "description: >", "   ccc", "create_dir: TRUE") %in% yml


### PR DESCRIPTION
A simple change of `yml` to `yaml` to increase compatibility.

## Reference

* fixes #331