### PR TITLE
Expose overwrite parameter in use_github_links

### DIFF
--- a/R/github.R
+++ b/R/github.R
@@ -155,9 +155,12 @@ use_github <- function(organisation = NULL,
 }
 
 #' @export
+#' @param overwrite By default, `use_github_links()` will not overwrite
+#'   existing fields. Set to `TRUE` to overwrite existing links.
 #' @rdname use_github
 use_github_links <- function(auth_token = NULL,
-                             host = "https://api.github.com") {
+                             host = "https://api.github.com",
+                             overwrite = FALSE) {
   check_uses_github()
 
   info <- gh::gh_tree_remote(proj_get())
@@ -169,8 +172,9 @@ use_github_links <- function(auth_token = NULL,
     .token = auth_token
   )
 
-  use_description_field("URL", res$html_url)
-  use_description_field("BugReports", file.path(res$html_url, "issues"))
+  use_description_field("URL", res$html_url, overwrite = overwrite)
+  use_description_field("BugReports", file.path(res$html_url, "issues"),
+    overwrite = overwrite)
 
   invisible()
 }

--- a/man/use_github.Rd
+++ b/man/use_github.Rd
@@ -8,7 +8,8 @@
 use_github(organisation = NULL, private = FALSE, protocol = c("ssh",
   "https"), credentials = NULL, auth_token = NULL, host = NULL)
 
-use_github_links(auth_token = NULL, host = "https://api.github.com")
+use_github_links(auth_token = NULL, host = "https://api.github.com",
+  overwrite = FALSE)
 }
 \arguments{
 \item{organisation}{If supplied, the repo will be created under this
@@ -29,6 +30,9 @@ variable. Use \code{\link[=browse_github_pat]{browse_github_pat()}} to help set 
 \item{host}{GitHub API host to use. Override with the endpoint-root for your
 GitHub enterprise instance, for example,
 "https://github.hostname.com/api/v3"}
+
+\item{overwrite}{By default, \code{use_github_links()} will not overwrite
+existing fields. Set to \code{TRUE} to overwrite existing links.}
 }
 \description{
 \code{use_github()} takes a local project, creates an associated repo on GitHub,


### PR DESCRIPTION
Previously you would get the error 

> Error: URL has a different value in DESCRIPTION. Use overwrite = TRUE to overwrite.

But there was no way to actually pass `overwrite = TRUE`.

Fixes #316