### PR TITLE
Sharpen wording around the code of conduct

### DIFF
--- a/R/code-of-conduct.R
+++ b/R/code-of-conduct.R
@@ -1,24 +1,34 @@
 #' Add a code of conduct
 #'
-#' Adds a `CODE_OF_CONDUCT.md` file to the project's top-level directory. The
-#' goal of a code of conduct is to foster an environment of inclusiveness, and
-#' to explicitly discourage inappropriate behaviour. The template comes from
+#' Adds a `CODE_OF_CONDUCT.md` file to the active project and lists in
+#' `.Rbuildignore`, in the case of a package. The goal of a code of conduct is
+#' to foster an environment of inclusiveness, and to explicitly discourage
+#' inappropriate behaviour. The template comes from
 #' <http://contributor-covenant.org>, version 1:
 #' <http://contributor-covenant.org/version/1/0/0/>.
 #'
+#' @param path Path of the directory to put `CODE_OF_CONDUCT.md` in, relative to
+#'   the active project. Passed along to [use_directory()]. Default is to locate
+#'   at top-level, but `.github/` is also common.
+#'
 #' @export
-use_code_of_conduct <- function() {
+use_code_of_conduct <- function(path = NULL) {
+  if (!is.null(path)) {
+    use_directory(path, ignore = is_package())
+  }
+  save_as <- fs::path_join(c(path, "CODE_OF_CONDUCT.md"))
+
   use_template(
     "CODE_OF_CONDUCT.md",
-    ignore = TRUE
+    save_as = save_as,
+    ignore = is_package() && is.null(path)
   )
 
   todo("Don't forget to describe the code of conduct in your README:")
-  code_block(
-    paste0("Please note that the ", value(project_name()),
-           " project is released with a ",
-           "[Contributor Code of Conduct](CODE_OF_CONDUCT.md). ",
-           "By contributing to this project, you agree to abide by its terms."
-    )
-  )
+  code_block(paste0(
+    "Please note that the ", value(project_name()),
+    " project is released with a ",
+    "[Contributor Code of Conduct](", save_as, "). ",
+    "By contributing to this project, you agree to abide by its terms."
+  ))
 }

--- a/R/code-of-conduct.R
+++ b/R/code-of-conduct.R
@@ -13,9 +13,12 @@ use_code_of_conduct <- function() {
     ignore = TRUE
   )
 
-  todo("Don't forget to describe the code of conduct in your README.md:")
+  todo("Don't forget to describe the code of conduct in your README:")
   code_block(
-    "Please note that this project is released with a [Contributor Code of Conduct](CODE_OF_CONDUCT.md).",
-    "By participating in this project you agree to abide by its terms."
+    paste0("Please note that the ", value(project_name()),
+           " project is released with a ",
+           "[Contributor Code of Conduct](CODE_OF_CONDUCT.md). ",
+           "By contributing to this project, you agree to abide by its terms."
+    )
   )
 }

--- a/R/tidyverse.R
+++ b/R/tidyverse.R
@@ -201,10 +201,13 @@ use_tidy_coc <- function() {
     ".github/CODE_OF_CONDUCT.md"
   )
 
-  todo("Don't forget to describe the code of conduct in your README.md:")
+  todo("Don't forget to describe the code of conduct in your README:")
   code_block(
-    "Please note that this project is released with a [Contributor Code of Conduct](.github/CODE_OF_CONDUCT.md).",
-    "By participating in this project you agree to abide by its terms."
+    paste0("Please note that the ", value(project_name()),
+           " project is released with a ",
+           "[Contributor Code of Conduct](.github/CODE_OF_CONDUCT.md). ",
+           "By contributing to this project, you agree to abide by its terms."
+    )
   )
 }
 

--- a/R/tidyverse.R
+++ b/R/tidyverse.R
@@ -195,20 +195,7 @@ use_tidy_support <- function() {
 use_tidy_coc <- function() {
   check_uses_github()
 
-  use_directory(".github", ignore = TRUE)
-  use_template(
-    "CODE_OF_CONDUCT.md",
-    ".github/CODE_OF_CONDUCT.md"
-  )
-
-  todo("Don't forget to describe the code of conduct in your README:")
-  code_block(
-    paste0("Please note that the ", value(project_name()),
-           " project is released with a ",
-           "[Contributor Code of Conduct](.github/CODE_OF_CONDUCT.md). ",
-           "By contributing to this project, you agree to abide by its terms."
-    )
-  )
+  use_code_of_conduct(path = ".github")
 }
 
 #' @export

--- a/man/use_code_of_conduct.Rd
+++ b/man/use_code_of_conduct.Rd
@@ -4,12 +4,18 @@
 \alias{use_code_of_conduct}
 \title{Add a code of conduct}
 \usage{
-use_code_of_conduct()
+use_code_of_conduct(path = NULL)
+}
+\arguments{
+\item{path}{Path of the directory to put \code{CODE_OF_CONDUCT.md} in, relative to
+the active project. Passed along to \code{\link[=use_directory]{use_directory()}}. Default is to locate
+at top-level, but \code{.github/} is also common.}
 }
 \description{
-Adds a \code{CODE_OF_CONDUCT.md} file to the project's top-level directory. The
-goal of a code of conduct is to foster an environment of inclusiveness, and
-to explicitly discourage inappropriate behaviour. The template comes from
+Adds a \code{CODE_OF_CONDUCT.md} file to the active project and lists in
+\code{.Rbuildignore}, in the case of a package. The goal of a code of conduct is
+to foster an environment of inclusiveness, and to explicitly discourage
+inappropriate behaviour. The template comes from
 \url{http://contributor-covenant.org}, version 1:
 \url{http://contributor-covenant.org/version/1/0/0/}.
 }


### PR DESCRIPTION
Fixes #352 

  * Specify the name of the project
  * "participating" --> "contributing to" in the README sentence
  * Removed `.md` from `README.md` to avoid the whole `.Rmd` vs `.md` thing

@batpigandme We are already using Contributor Covenant 1.0 and not 1.4, fwiw.