### PR TITLE
Don't help people depend on tidyverse or devtools

### DIFF
--- a/R/package.R
+++ b/R/package.R
@@ -16,7 +16,6 @@
 #' }
 use_package <- function(package, type = "Imports") {
   refuse_package(package, verboten = "tidyverse")
-  refuse_package(package, verboten = "devtools")
 
   use_dependency(package, type)
 
@@ -50,7 +49,6 @@ show_includes <- function(package) {
 #' @rdname use_package
 use_dev_package <- function(package, type = "Imports") {
   refuse_package(package, verboten = "tidyverse")
-  refuse_package(package, verboten = "devtools")
 
   if (!requireNamespace(package, quietly = TRUE)) {
     stop(package, " must be installed before you can take a dependency on it",

--- a/R/package.R
+++ b/R/package.R
@@ -49,6 +49,9 @@ show_includes <- function(package) {
 #' @export
 #' @rdname use_package
 use_dev_package <- function(package, type = "Imports") {
+  refuse_package(package, verboten = "tidyverse")
+  refuse_package(package, verboten = "devtools")
+
   if (!requireNamespace(package, quietly = TRUE)) {
     stop(package, " must be installed before you can take a dependency on it",
       call. = FALSE

--- a/R/package.R
+++ b/R/package.R
@@ -15,6 +15,9 @@
 #' use_package("dplyr", "suggests")
 #' }
 use_package <- function(package, type = "Imports") {
+  refuse_package(package, verboten = "tidyverse")
+  refuse_package(package, verboten = "devtools")
+
   use_dependency(package, type)
 
   switch(tolower(type),
@@ -48,7 +51,8 @@ show_includes <- function(package) {
 use_dev_package <- function(package, type = "Imports") {
   if (!requireNamespace(package, quietly = TRUE)) {
     stop(package, " must be installed before you can take a dependency on it",
-      call. = FALSE)
+      call. = FALSE
+    )
   }
 
   use_package(package, type = type)
@@ -75,4 +79,15 @@ package_remote <- function(package) {
   }
 
   paste0(github_info, collapse = "/")
+}
+
+refuse_package <- function(package, verboten) {
+  if (identical(package, verboten)) {
+    stop(paste0(
+      value(package), " is a meta-package and it is rarely a good idea to ",
+      "depend on it. Please determine the specific underlying package(s) that ",
+      "offer the function(s) you need and depend on that instead."
+    ), call. = FALSE)
+  }
+  invisible(package)
 }

--- a/tests/testthat/test-use-package.R
+++ b/tests/testthat/test-use-package.R
@@ -1,7 +1,6 @@
 context("use_package")
 
-test_that("use_package() won't facilitate dependency on tidyverse, devtools", {
+test_that("use_package() won't facilitate dependency on tidyverse", {
   scoped_temporary_package()
   expect_error(use_package("tidyverse"), "rarely a good idea")
-  expect_error(use_package("devtools"), "rarely a good idea")
 })

--- a/tests/testthat/test-use-package.R
+++ b/tests/testthat/test-use-package.R
@@ -1,0 +1,7 @@
+context("use_package")
+
+test_that("use_package() won't facilitate dependency on tidyverse, devtools", {
+  scoped_temporary_package()
+  expect_error(use_package("tidyverse"), "rarely a good idea")
+  expect_error(use_package("devtools"), "rarely a good idea")
+})


### PR DESCRIPTION
Fixes #172 use_package("tidyverse|devtools") should generate a warning

So far, I'm just refusing to add the dependency and not adding all the individual packages. I don't really think we want people depending on every single package in the tidyverse either. I think it's OK to ask people to figure out what they need, yes?