### PR TITLE
Added link to roxygen2md package

### DIFF
--- a/R/roxygen.R
+++ b/R/roxygen.R
@@ -1,9 +1,9 @@
 #' Use roxygen with markdown
 #'
 #' You'll need to manually re-document once enabled. If you are already using
-#' roxygen2, but not with markdown, the roxygen2md package will be used to
-#' convert many Rd expressions to markdown. The package uses heuristics, so
-#' you'll need to check the results.
+#' roxygen2, but not with markdown, the [roxygen2md](https://github.com/r-lib/roxygen2md) 
+#' package will be used to convert many Rd expressions to markdown. The 
+#' package uses heuristics, so you'll need to check the results.
 #'
 #' @export
 use_roxygen_md <- function() {

--- a/man/use_roxygen_md.Rd
+++ b/man/use_roxygen_md.Rd
@@ -8,7 +8,7 @@ use_roxygen_md()
 }
 \description{
 You'll need to manually re-document once enabled. If you are already using
-roxygen2, but not with markdown, the roxygen2md package will be used to
-convert many Rd expressions to markdown. The package uses heuristics, so
-you'll need to check the results.
+roxygen2, but not with markdown, the \href{https://github.com/r-lib/roxygen2md}{roxygen2md}
+package will be used to convert many Rd expressions to markdown. The
+package uses heuristics, so you'll need to check the results.
 }


### PR DESCRIPTION
`use_roxygen_md()` references the roxygen2md package. This PR adds a hyperlink to the roxygen2md repo for easier directing from the package docs.