### PR TITLE
Refactor project data helpers

### DIFF
--- a/R/helpers.R
+++ b/R/helpers.R
@@ -71,29 +71,27 @@ find_template <- function(template_name, package = "usethis") {
 
 project_data <- function(base_path = proj_get()) {
   if (is_package(base_path)) {
-    package_data(base_path)
+    data <- package_data(base_path)
   } else {
-    list(Project = basename(base_path))
+    data <- list(Project = basename(base_path))
   }
+  if (uses_github(base_path)) {
+    data$github_owner <- github_owner()
+    data$github_repo <- github_repo()
+  }
+  data
 }
 
 package_data <- function(base_path = proj_get()) {
   desc <- desc::description$new(base_path)
-
-  out <- as.list(desc$get(desc$fields()))
-  if (uses_github(base_path)) {
-    out$github <- gh::gh_tree_remote(base_path)
-  }
-  out
+  as.list(desc$get(desc$fields()))
 }
 
 project_name <- function(base_path = proj_get()) {
-  desc_path <- file.path(base_path, "DESCRIPTION")
-
-  if (file.exists(desc_path)) {
-    desc::desc_get("Package", base_path)[[1]]
+  if (is_package(base_path)) {
+    project_data(base_path)$Package
   } else {
-    basename(normalizePath(base_path, mustWork = FALSE))
+    project_data(base_path)$Project
   }
 }
 

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -70,6 +70,13 @@ find_template <- function(template_name, package = "usethis") {
 }
 
 project_data <- function(base_path = proj_get()) {
+  if (!is_proj(base_path)) {
+    stop(
+      value(base_path), " doesn't meet the usethis criteria for a project.\n",
+      "Read more in the help for ", code("proj_get()"), ".",
+      call. = FALSE
+    )
+  }
   if (is_package(base_path)) {
     data <- package_data(base_path)
   } else {
@@ -88,6 +95,14 @@ package_data <- function(base_path = proj_get()) {
 }
 
 project_name <- function(base_path = proj_get()) {
+  ## escape hatch necessary to solve this chicken-egg problem:
+  ## create_package() calls use_description(), which calls project_name()
+  ## to learn package name from the path, in order to make DESCRIPTION
+  ## and DESCRIPTION is how we recognize a package as a usethis project
+  if (!is_proj(base_path)) {
+    return(basename(base_path))
+  }
+
   if (is_package(base_path)) {
     project_data(base_path)$Package
   } else {


### PR DESCRIPTION
Main points:

  * Moved the GitHub stuff out of `package_data()` and into `project_data()`, so that it's also available for non-package projects.
  * Use `github_owner()` and `github_repo()` helpers I recently added. (*They were added because we were doing this all over the place and it's awkward because two pieces of info.*)
  * Always refer to GitHub "owner" because works equally well for individual users and orgs. It also matches GitHub API terminology.
  * Consult  `project_data()` in `project_name()`, instead of re-implementing similar logic re: DESCRIPTION or basename of path.

Question: we have an `is_proj()` helper. Should we use it in `project_data()` instead of being so easy-going? `is_proj()` will return `TRUE` if the target path fulfills any of our `proj_crit()`, which we pass along to rprojroot.