### PR TITLE
Put a floor on clipr, rprojroot

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,7 +21,7 @@ Depends:
     R (>= 3.1)
 Imports: 
     backports (>= 1.1.0),
-    clipr,
+    clipr (>= 0.3.0),
     clisymbols,
     crayon,
     curl (>= 2.7),
@@ -32,7 +32,7 @@ Imports:
     glue (>= 1.2.0.9000),
     rematch2,
     rlang,
-    rprojroot,
+    rprojroot (>= 1.2),
     rstudioapi,
     utils,
     whisker


### PR DESCRIPTION
Fixes #351 Aggressively state minimum versions of dependencies

clipr and rprojroot are concrete examples where we use specific functions that I can see were added at a specific version, based on reading NEWS.

I contemplated every other package in Imports and Suggests and couldn't find a specific reason to state a minimum version.

How aggressive should I be?
Any vague notions that I should put a floor on anything else?