### PR TITLE
Restore original project if new project launches in new RStudio instance

### DIFF
--- a/R/create.R
+++ b/R/create.R
@@ -198,7 +198,7 @@ create_from_github <- function(repo_spec,
     credentials = credentials,
     progress = FALSE
   )
-  proj_set(repo_path)
+  op <- proj_set(repo_path)
 
   if (fork) {
     r <- git2r::repository(proj_get())
@@ -213,7 +213,14 @@ create_from_github <- function(repo_spec,
   }
 
   if (open) {
-    open_project(proj_get())
+    fresh_rstudio <- open_project(proj_get())
+    if (fresh_rstudio) {
+      cat_line(
+        crayon::bold("Restoring original project state: "),
+        crayon::red(path_file(op %||% "-- no active project --"))
+      )
+      proj_set(op, force = TRUE)
+    }
   }
 }
 

--- a/R/proj.R
+++ b/R/proj.R
@@ -89,7 +89,9 @@ proj_get <- function() {
 proj_set <- function(path = ".", force = FALSE) {
   old <- proj$cur
 
-  check_is_dir(path)
+  if (!is.null(path)) {
+    check_is_dir(path)
+  }
   path <- proj_path_prep(path)
 
   if (force) {


### PR DESCRIPTION
Fixes #390 When rstudio = TRUE, don't change active project in create_package()

Reminder, because I have tripped on this a lot myself: the `rstudio` argument of `create_*()` controls whether an Rproj file is added to the new project. `open` is the argument that controls if/how the new project is launched, i.e. whether `open_project()` is called (which has its own `rstudio` argument, with a different meaning).