### PR TITLE
Project activation

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,3 +1,4 @@
+^principles\.md$
 ^usethis\.Rproj$
 ^\.Rproj\.user$
 ^revdep$

--- a/R/create.R
+++ b/R/create.R
@@ -36,7 +36,6 @@ create_package <- function(path,
   check_not_nested(path_dir(path), name)
 
   create_directory(path_dir(path), name)
-  cat_line(crayon::bold("Changing active project to", crayon::red(name)))
   proj_set(path, force = TRUE)
 
   use_directory("R")
@@ -64,7 +63,6 @@ create_project <- function(path,
   check_not_nested(path_dir(path), name)
 
   create_directory(path_dir(path), name)
-  cat_line(crayon::bold("Changing active project to", crayon::red(name)))
   proj_set(path, force = TRUE)
 
   use_directory("R")

--- a/R/create.R
+++ b/R/create.R
@@ -213,9 +213,7 @@ open_project <- function(path, rstudio = NA) {
 }
 
 check_not_nested <- function(path, name) {
-  path_is_proj <- is_proj(path)
-
-  if (!path_is_proj) {
+  if (!possibly_in_proj(path)) {
     return(invisible())
   }
 

--- a/R/create.R
+++ b/R/create.R
@@ -47,7 +47,10 @@ create_package <- function(path,
     use_rstudio()
   }
   if (open) {
-    open_project(proj_get())
+    fresh_rstudio <- open_project(proj_get())
+    if (fresh_rstudio) {
+      proj_revert()
+    }
   }
 
   invisible(TRUE)
@@ -76,7 +79,10 @@ create_project <- function(path,
     file_create(proj_path(".here"))
   }
   if (open) {
-    open_project(proj_get())
+    fresh_rstudio <- open_project(proj_get())
+    if (fresh_rstudio) {
+      proj_revert()
+    }
   }
 
   invisible(TRUE)
@@ -192,24 +198,28 @@ create_from_github <- function(repo_spec,
   }
 
   if (open) {
-    open_project(proj_get())
+    fresh_rstudio <- open_project(proj_get())
+    if (fresh_rstudio) {
+      proj_revert()
+    }
   }
 }
 
 open_project <- function(path, rstudio = NA) {
-  rproj_path <- rproj_path(path)
   if (is.na(rstudio)) {
-    rstudio <- !is.na(rproj_path)
+    rstudio <- is_rstudio_project(path)
   }
 
   if (rstudio && rstudioapi::hasFun("openProject")) {
-    done("Opening project in RStudio")
-    rstudioapi::openProject(rproj_path, newSession = TRUE)
-  } else {
-    setwd(path)
-    done("Changing working directory to {value(path)}")
+    done("Opening new project in RStudio")
+    rstudioapi::openProject(rproj_path(path), newSession = TRUE)
+    ## TODO: check this is correct on rstudio server / cloud
+    return(invisible(TRUE))
   }
-  invisible(TRUE)
+
+  setwd(path)
+  done("Changing working directory to {value(path)}")
+  invisible(FALSE)
 }
 
 check_not_nested <- function(path, name) {

--- a/R/create.R
+++ b/R/create.R
@@ -213,12 +213,12 @@ open_project <- function(path, restore = NA, rstudio = NA) {
     if (!is.na(restore)) {
       proj_set(restore, force = TRUE)
     }
-    return(invisible(TRUE))
+    invisible(TRUE)
+  } else {
+    setwd(path)
+    done("Changing working directory to {value(path)}")
+    invisible(FALSE)
   }
-
-  setwd(path)
-  done("Changing working directory to {value(path)}")
-  invisible(FALSE)
 }
 
 check_not_nested <- function(path, name) {

--- a/R/proj.R
+++ b/R/proj.R
@@ -50,7 +50,6 @@ check_is_package <- function(whos_asking = NULL) {
 #' file. It then stores the active project for use for the remainder of the
 #' session. Use `proj_get()` to see the active project and `proj_set()` to set
 #' it manually.
-
 #'
 #' @description In general, user scripts should not call `usethis::proj_get()`
 #'   or `usethis::proj_set()`. They are internal functions that are exported for
@@ -65,6 +64,7 @@ check_is_package <- function(whos_asking = NULL) {
 #'   problem: you need to set the active project in order to add
 #'   project-signalling infrastructure, such as initialising a Git repo or
 #'   adding a DESCRIPTION file.
+#' @param quiet Logical. Whether to announce project activation.
 #' @keywords internal
 #' @export
 #' @examples
@@ -75,10 +75,10 @@ check_is_package <- function(whos_asking = NULL) {
 #' ## manually set the active project
 #' proj_set("path/to/target/project")
 #' }
-proj_get <- function() {
+proj_get <- function(quiet = FALSE) {
   # Called for first time so try working directory
   if (!proj_active()) {
-    proj_set(".")
+    proj_set(".", quiet = quiet)
   }
 
   proj$cur
@@ -86,7 +86,7 @@ proj_get <- function() {
 
 #' @export
 #' @rdname proj_get
-proj_set <- function(path = ".", force = FALSE) {
+proj_set <- function(path = ".", force = FALSE, quiet = FALSE) {
   old <- proj$cur
 
   check_is_dir(path)
@@ -94,6 +94,9 @@ proj_set <- function(path = ".", force = FALSE) {
 
   if (force) {
     proj$cur <- path
+    if (!quiet) {
+      done("Changing active project to {value(path)}")
+    }
     return(invisible(old))
   }
 
@@ -104,6 +107,9 @@ proj_set <- function(path = ".", force = FALSE) {
     )
   }
   proj$cur <- new_proj
+  if (!quiet) {
+    done("Changing active project to {value(path)}")
+  }
   invisible(old)
 }
 

--- a/R/proj.R
+++ b/R/proj.R
@@ -16,7 +16,7 @@ proj_find <- function(path = ".") {
   )
 }
 
-is_proj <- function(path = ".") !is.null(proj_find(path))
+possibly_in_proj <- function(path = ".") !is.null(proj_find(path))
 
 is_package <- function(base_path = proj_get()) {
   res <- tryCatch(
@@ -151,7 +151,7 @@ is_in_proj <- function(path) {
 }
 
 project_data <- function(base_path = proj_get()) {
-  if (!is_proj(base_path)) {
+  if (!possibly_in_proj(base_path)) {
     stop_glue(
       "{value(base_path)} doesn't meet the usethis criteria for a project.\n",
       "Read more in the help for {code(\"proj_get()\")}."
@@ -180,7 +180,7 @@ project_name <- function(base_path = proj_get()) {
   ## create_package() calls use_description(), which calls project_name()
   ## to learn package name from the path, in order to make DESCRIPTION
   ## and DESCRIPTION is how we recognize a package as a usethis project
-  if (!is_proj(base_path)) {
+  if (!possibly_in_proj(base_path)) {
     return(path_file(base_path))
   }
 

--- a/R/proj.R
+++ b/R/proj.R
@@ -112,7 +112,7 @@ proj_set_ <- function(path, quiet = FALSE) {
   if (!quiet) {
     done("Changing active project to {value(proj$cur)}")
   }
-  return(invisible(proj$prev))
+  invisible(proj$prev)
 }
 
 proj_revert <- function(quiet = FALSE) {

--- a/R/proj.R
+++ b/R/proj.R
@@ -143,12 +143,10 @@ is_in_proj <- function(path) {
   if (!proj_active()) {
     return(FALSE)
   }
-
-  ## realize path, if possible; use "as is", otherwise
-  path <- tryCatch(path_real(path), error = function(e) NULL) %||% path
   identical(
     proj_get(),
-    path_common(c(proj_get(), path))
+    ## use path_abs() in case path does not exist yet
+    path_common(c(proj_get(), path_abs(path)))
   )
 }
 

--- a/R/proj.R
+++ b/R/proj.R
@@ -87,17 +87,13 @@ proj_get <- function(quiet = FALSE) {
 #' @export
 #' @rdname proj_get
 proj_set <- function(path = ".", force = FALSE, quiet = FALSE) {
-  old <- proj$cur
-
-  check_is_dir(path)
+  if (!is.null(path)) {
+    check_is_dir(path)
+  }
   path <- proj_path_prep(path)
 
   if (force) {
-    proj$cur <- path
-    if (!quiet) {
-      done("Changing active project to {value(path)}")
-    }
-    return(invisible(old))
+    return(proj_set_(path, quiet = quiet))
   }
 
   new_proj <- proj_path_prep(proj_find(path))
@@ -106,11 +102,21 @@ proj_set <- function(path = ".", force = FALSE, quiet = FALSE) {
       "Path {value(path)} does not appear to be inside a project or package."
     )
   }
-  proj$cur <- new_proj
+  proj_set_(new_proj, quiet = quiet)
+}
+
+proj_set_ <- function(path, quiet = FALSE) {
+  force(path)
+  proj$prev <- proj$cur %||% NULL
+  proj$cur <- path
   if (!quiet) {
-    done("Changing active project to {value(path)}")
+    done("Changing active project to {value(proj$cur)}")
   }
-  invisible(old)
+  return(invisible(proj$prev))
+}
+
+proj_revert <- function(quiet = FALSE) {
+  proj_set_(proj$prev, quiet = quiet)
 }
 
 proj_path <- function(..., ext = "") path_norm(path(proj_get(), ..., ext = ext))

--- a/R/proj.R
+++ b/R/proj.R
@@ -92,31 +92,26 @@ proj_set <- function(path = ".", force = FALSE, quiet = FALSE) {
   }
   path <- proj_path_prep(path)
 
-  if (force) {
-    return(proj_set_(path, quiet = quiet))
+  if (!force) {
+    new_project <- proj_path_prep(proj_find(path))
+    if (is.null(new_project)) {
+      stop_glue(
+        "Path {value(path)} does not appear to be inside a project or package."
+      )
+    }
+    path <- new_project
   }
 
-  new_proj <- proj_path_prep(proj_find(path))
-  if (is.null(new_proj)) {
-    stop_glue(
-      "Path {value(path)} does not appear to be inside a project or package."
-    )
-  }
-  proj_set_(new_proj, quiet = quiet)
+  proj_set_(path, quiet = quiet)
 }
 
 proj_set_ <- function(path, quiet = FALSE) {
-  force(path)
-  proj$prev <- proj$cur %||% NULL
+  old <- proj$cur
   proj$cur <- path
   if (!quiet) {
     done("Changing active project to {value(proj$cur)}")
   }
-  invisible(proj$prev)
-}
-
-proj_revert <- function(quiet = FALSE) {
-  proj_set_(proj$prev, quiet = quiet)
+  invisible(old)
 }
 
 proj_path <- function(..., ext = "") path_norm(path(proj_get(), ..., ext = ext))

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,3 +1,0 @@
-.onLoad <- function(libname, pkgname) {
-  try(proj_set(".", quiet = TRUE), silent = TRUE)
-}

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,0 +1,3 @@
+.onLoad <- function(libname, pkgname) {
+  try(proj_set(".", quiet = TRUE), silent = TRUE)
+}

--- a/man/proj_get.Rd
+++ b/man/proj_get.Rd
@@ -5,11 +5,13 @@
 \alias{proj_set}
 \title{Get and set the active project}
 \usage{
-proj_get()
+proj_get(quiet = FALSE)
 
-proj_set(path = ".", force = FALSE)
+proj_set(path = ".", force = FALSE, quiet = FALSE)
 }
 \arguments{
+\item{quiet}{Logical. Whether to announce project activation.}
+
 \item{path}{Path to set.}
 
 \item{force}{If \code{TRUE}, use this path without checking the usual criteria.

--- a/principles.md
+++ b/principles.md
@@ -4,9 +4,13 @@
 
 ## Active project
 
-Many usethis functions act on the **active project**, the path to which is stored in the internal environment `proj`, specifically in `proj$cur`. We do this instead of constantly passing around a base path. It is implied that such functions create or modify files inside the active project. This is mostly true of `use_*()` functions, though there are exceptions. For example, `use_course()` makes no reference to the active project.
+Many usethis functions act on the **active project**, the path to which is stored in the internal environment `proj`, specifically in `proj$cur`. We do this instead of constantly passing around a base path or relying on the working directory. It is implied that such functions create or modify files inside the active project. This is mostly true of `use_*()` functions, though there are exceptions. For example, `use_course()` makes no reference to the active project.
 
 The project is activated upon first need, i.e. eventually some function calls `proj_get()` and, if `proj$cur` is `NULL`, we attempt to activate a project at (or above) current working directory.
+
+Direct read/write of `proj$cur` should be rare. Even internally, `proj_get()` and `proj_set()` are preferred. The stored project path should be processed with `proj_path_prep()`.
+
+Form paths to files within the project with `proj_path()`. Get paths relative to the project with `proj_rel_path()`.
 
 ### Activation upon load or attach? No.
 
@@ -17,6 +21,11 @@ We've contemplated project activation in `.onLoad()` or `.onAttach()`, but it's 
   try(proj_set(".", quiet = TRUE), silent = TRUE)
 }
 ```
+
+Why not `.onAttach()`?
+
+  * A package that imported usethis would also need to set project on attach.
+  * Currently user can open R, attach (or load) usethis, and then change working directory to their target project. As long as they are in the project the first time `proj_get()` is called, the correct project will be made active. This is not our preferred workflow, but it is common.
 
 ## Helper functions
 
@@ -29,3 +38,7 @@ The downside is that we aren't exactly sure yet what we're willing to guarantee 
 Current mindset: helpers should *not* make direct use of the active project, i.e. project-based paths should be formed by the caller.
 
 Uncomfortable fact: `write_union()` uses the active project, if such exists, to create a humane path in its message. However, unlike `use_*()` functions, it does not call `proj_get()` to set an active project when `proj$cur` is `NULL`. We like this behaviour but the design feels muddy.
+
+## Home directory
+
+usethis relies on fs for file system operations. The main thing users will notice is the treatment of home directory on Windows. A Windows user's home directory is interpreted as `C:\Users\username` (typical of Unix-oriented tools, like Git and ssh; also matches Python), as opposed to `C:\Users\username\Documents` (R's default on Windows). In order to be consistent everywhere, all paths supplied by the user should be processed with `user_path_prep()`.

--- a/principles.md
+++ b/principles.md
@@ -1,0 +1,21 @@
+# usethis design principles
+
+*This is an experiment in making key package design principles explicit, versus leaving them only as implicit in the code . The goal is to facilitate maintenance work, when spread out over time and across different people.*
+
+## Active project
+
+Many usethis functions act on the **active project**, the path to which is stored in the internal environment `proj`, specifically in `proj$cur`. We do this instead of constantly passing around a "base path". It is implied that such functions create or modify files inside the active project. This is mostly true of `use_*()` functions, though there are exceptions. For example, `use_course()` makes no reference to the active project.
+
+The project is activated upon first need, i.e. eventually some function calls `proj_get()` and, if `proj$cur` is `NULL`, we attempt to activate a project at (or above) current working directory.
+
+## Helper functions
+
+With some ambivalence, internally-oriented helpers like `write_union()` are now exported. This helps developers who are extending usethis to create a package to standardize project setup within their own organization.
+
+The downside is that we still aren't exactly sure what we're willing to guarantee about these helpers.
+
+### Helpers and the active project
+
+Current mindset: helpers should *not* make direct use of the active project, i.e. project-based paths should be formed by the caller.
+
+Uncomfortable fact: `write_union()` uses the active project, if such exists, to create a humane path in its message. However, unlike `use_*()` functions, it does not call `proj_get()` to set an active project when `proj$cur` is `NULL`. We like this behaviour but the design feels muddy.

--- a/principles.md
+++ b/principles.md
@@ -1,18 +1,28 @@
 # usethis design principles
 
-*This is an experiment in making key package design principles explicit, versus leaving them only as implicit in the code . The goal is to facilitate maintenance work, when spread out over time and across different people.*
+*This is an experiment in making key package design principles explicit, versus only implicit in the code. The goal is to make maintenance easier, when spread out over time and across people.*
 
 ## Active project
 
-Many usethis functions act on the **active project**, the path to which is stored in the internal environment `proj`, specifically in `proj$cur`. We do this instead of constantly passing around a "base path". It is implied that such functions create or modify files inside the active project. This is mostly true of `use_*()` functions, though there are exceptions. For example, `use_course()` makes no reference to the active project.
+Many usethis functions act on the **active project**, the path to which is stored in the internal environment `proj`, specifically in `proj$cur`. We do this instead of constantly passing around a base path. It is implied that such functions create or modify files inside the active project. This is mostly true of `use_*()` functions, though there are exceptions. For example, `use_course()` makes no reference to the active project.
 
 The project is activated upon first need, i.e. eventually some function calls `proj_get()` and, if `proj$cur` is `NULL`, we attempt to activate a project at (or above) current working directory.
 
+### Activation upon load or attach? No.
+
+We've contemplated project activation in `.onLoad()` or `.onAttach()`, but it's not clear which is more appropriate. Which suggests that neither is appropriate. If we ever do this, `zzz.R` would include something like this:
+
+``` r
+.onLoad <- function(libname, pkgname) {
+  try(proj_set(".", quiet = TRUE), silent = TRUE)
+}
+```
+
 ## Helper functions
 
-With some ambivalence, internally-oriented helpers like `write_union()` are now exported. This helps developers who are extending usethis to create a package to standardize project setup within their own organization.
+With some ambivalence, internally-oriented helpers like `write_union()` are exported. This helps developers who are extending usethis to create a package to standardize project setup within their own organization.
 
-The downside is that we still aren't exactly sure what we're willing to guarantee about these helpers.
+The downside is that we aren't exactly sure yet what we're willing to guarantee about these helpers.
 
 ### Helpers and the active project
 

--- a/tests/manual/manual-create-from-github.R
+++ b/tests/manual/manual-create-from-github.R
@@ -29,7 +29,7 @@ dir_delete("~/Desktop/TailRank/")
 create_from_github("cran/TailRank", fork = TRUE, credentials = cred)
 ## fork and clone --> should see origin and upstream remotes
 expect_setequal(
-  git2r::remotes(git2r::repository(proj_get())),
+  git2r::remotes(git2r::repository("~/Desktop/TailRank/")),
   c("origin", "upstream")
 )
 dir_delete("~/Desktop/TailRank/")
@@ -39,7 +39,7 @@ dir_delete("~/Desktop/TailRank/")
 create_from_github("cran/TailRank", fork = NA, credentials = cred)
 ## fork and clone --> should see origin and upstream remotes
 expect_setequal(
-  git2r::remotes(git2r::repository(proj_get())),
+  git2r::remotes(git2r::repository("~/Desktop/TailRank/")),
   c("origin", "upstream")
 )
 dir_delete("~/Desktop/TailRank/")
@@ -77,9 +77,12 @@ dir_delete("~/Desktop/TailRank/")
 ## fork = FALSE
 create_from_github("cran/TailRank", fork = FALSE, credentials = cred)
 ## created, clone, origin remote is cran/TailRank
-expect_setequal(git2r::remotes(git2r::repository(proj_get())), "origin")
 expect_setequal(
-  git2r::remote_url(git2r::repository(proj_get())),
+  git2r::remotes(git2r::repository("~/Desktop/TailRank/")),
+  "origin"
+)
+expect_setequal(
+  git2r::remote_url(git2r::repository("~/Desktop/TailRank/")),
   "git@github.com:cran/TailRank.git"
 )
 dir_delete("~/Desktop/TailRank/")
@@ -97,7 +100,9 @@ dir_delete("~/Desktop/TailRank")
 
 ## create from repo I do not have push access to
 ## fork = TRUE, explicitly provide token
-create_from_github("cran/TailRank", fork = TRUE, auth_token = token, credentials = cred)
+create_from_github(
+  "cran/TailRank", fork = TRUE, auth_token = token, credentials = cred
+)
 ## fork and clone
 
 dir_delete("~/Desktop/TailRank")

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -1,3 +1,6 @@
+## attempt to activate a project, which is nice during development
+try(proj_set("."))
+
 ## putting `pattern` in the package or project name is part of our strategy for
 ## suspending the nested project check during testing
 pattern <- "aaa"

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -20,19 +20,14 @@ scoped_temporary_thing <- function(dir = file_temp(pattern = pattern),
                                    thing = c("package", "project")) {
   thing <- match.arg(thing)
 
-  if (proj_active()) {
-    proj_to_restore <- proj_get()
-    ## Can't schedule a deferred project reset if calling this from the R
-    ## console, which is useful when developing tests
-    if (identical(env, globalenv())) {
-      done("Switching to a temporary project!")
-      todo(
-        "Restore current project with: ",
-        "{code('proj_set(\"', proj_to_restore, '\")')}"
-      )
-    } else {
-      withr::defer(proj_set(proj_to_restore, quiet = TRUE), envir = env)
-    }
+  ## Can't schedule a deferred project reset if calling this from the R
+  ## console, which is useful when developing tests
+  if (identical(env, globalenv())) {
+    done("Switching to a temporary project!")
+    todo("Restore current project with: {code('proj_revert()')}"
+    )
+  } else {
+    withr::defer(proj_revert(quiet = TRUE), envir = env)
   }
 
   switch(

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -25,12 +25,13 @@ scoped_temporary_thing <- function(dir = file_temp(pattern = pattern),
     ## Can't schedule a deferred project reset if calling this from the R
     ## console, which is useful when developing tests
     if (identical(env, globalenv())) {
+      done("Switching to a temporary project!")
       todo(
-        "Switching to a temporary project! To restore current project:\n",
-        "proj_set(\"", proj_to_restore, "\")"
+        "Restore current project with: ",
+        "{code('proj_set(\"', proj_to_restore, '\")')}"
       )
     } else {
-      withr::defer(proj_set(proj_to_restore), envir = env)
+      withr::defer(proj_set(proj_to_restore, quiet = TRUE), envir = env)
     }
   }
 

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -23,14 +23,20 @@ scoped_temporary_thing <- function(dir = file_temp(pattern = pattern),
                                    thing = c("package", "project")) {
   thing <- match.arg(thing)
 
+  ## avoid proj_get() because it attempts to activate a project
+  old_project <- proj$cur
   ## Can't schedule a deferred project reset if calling this from the R
   ## console, which is useful when developing tests
   if (identical(env, globalenv())) {
     done("Switching to a temporary project!")
-    todo("Restore current project with: {code('proj_revert()')}"
-    )
+    if (!is.null(old_project)) {
+      todo(
+        "Restore current project with: ",
+        "{code('proj_set(\"', proj_to_restore, '\")')}"
+      )
+    }
   } else {
-    withr::defer(proj_revert(quiet = TRUE), envir = env)
+    withr::defer(proj_set(old_project, force = TRUE, quiet = TRUE), envir = env)
   }
 
   switch(

--- a/tests/testthat/test-create.R
+++ b/tests/testthat/test-create.R
@@ -29,13 +29,11 @@ test_that("create_* works w/ non-existing rel path and absolutizes it", {
   path_package <- path_file(file_temp(pattern = "aaa"))
   withr::with_dir(
     path_temp(), {
-      ## better than proj_get() here because won't error if not in project
-      old_proj <- proj$cur
       capture_output(
         create_package(path_package, rstudio = FALSE, open = FALSE)
       )
       new_proj <- proj_get()
-      if (!is.null(old_proj)) proj_set(old_proj, quiet = TRUE)
+      proj_revert(quiet = TRUE)
     }
   )
   expect_true(dir_exists(new_proj))
@@ -43,12 +41,11 @@ test_that("create_* works w/ non-existing rel path and absolutizes it", {
   path_project <- path_file(file_temp(pattern = "aaa"))
   withr::with_dir(
     path_temp(), {
-      old_proj <- proj$cur
       capture_output(
         create_project(path_project, rstudio = FALSE, open = FALSE)
       )
       new_proj <- proj_get()
-      if (!is.null(old_proj)) proj_set(old_proj, quiet = TRUE)
+      proj_revert(quiet = TRUE)
     }
   )
   expect_true(dir_exists(new_proj))

--- a/tests/testthat/test-create.R
+++ b/tests/testthat/test-create.R
@@ -2,13 +2,13 @@ context("create")
 
 test_that("create_package() creates a package", {
   dir <- scoped_temporary_package()
-  expect_true(is_proj(dir))
+  expect_true(possibly_in_proj(dir))
   expect_true(is_package(dir))
 })
 
 test_that("create_project() creates a non-package project", {
   dir <- scoped_temporary_project()
-  expect_true(is_proj(dir))
+  expect_true(possibly_in_proj(dir))
   expect_false(is_package(dir))
 })
 

--- a/tests/testthat/test-create.R
+++ b/tests/testthat/test-create.R
@@ -35,7 +35,7 @@ test_that("create_* works w/ non-existing rel path and absolutizes it", {
         create_package(path_package, rstudio = FALSE, open = FALSE)
       )
       new_proj <- proj_get()
-      if (!is.null(old_proj)) proj_set(old_proj)
+      if (!is.null(old_proj)) proj_set(old_proj, quiet = TRUE)
     }
   )
   expect_true(dir_exists(new_proj))
@@ -48,7 +48,7 @@ test_that("create_* works w/ non-existing rel path and absolutizes it", {
         create_project(path_project, rstudio = FALSE, open = FALSE)
       )
       new_proj <- proj_get()
-      if (!is.null(old_proj)) proj_set(old_proj)
+      if (!is.null(old_proj)) proj_set(old_proj, quiet = TRUE)
     }
   )
   expect_true(dir_exists(new_proj))

--- a/tests/testthat/test-create.R
+++ b/tests/testthat/test-create.R
@@ -29,11 +29,12 @@ test_that("create_* works w/ non-existing rel path and absolutizes it", {
   path_package <- path_file(file_temp(pattern = "aaa"))
   withr::with_dir(
     path_temp(), {
+      old_project <- proj$cur
       capture_output(
         create_package(path_package, rstudio = FALSE, open = FALSE)
       )
       new_proj <- proj_get()
-      proj_revert(quiet = TRUE)
+      proj_set(old_project, force = TRUE, quiet = TRUE)
     }
   )
   expect_true(dir_exists(new_proj))
@@ -41,11 +42,12 @@ test_that("create_* works w/ non-existing rel path and absolutizes it", {
   path_project <- path_file(file_temp(pattern = "aaa"))
   withr::with_dir(
     path_temp(), {
+      old_project <- proj$cur
       capture_output(
         create_project(path_project, rstudio = FALSE, open = FALSE)
       )
       new_proj <- proj_get()
-      proj_revert(quiet = TRUE)
+      proj_set(old_project, force = TRUE, quiet = TRUE)
     }
   )
   expect_true(dir_exists(new_proj))

--- a/tests/testthat/test-proj.R
+++ b/tests/testthat/test-proj.R
@@ -21,7 +21,7 @@ test_that("proj_set() can be forced, even if no criteria are fulfilled", {
   tmpdir <- file_temp(pattern = "i-am-not-a-project")
   on.exit(dir_delete(tmpdir))
   dir_create(tmpdir)
-  expect_error_free(proj_set(tmpdir, force = TRUE))
+  expect_error_free(proj_set(tmpdir, force = TRUE, quiet = TRUE))
   expect_identical(proj_get(), path_real(tmpdir))
   expect_error(
     proj_set(proj_get()),
@@ -81,12 +81,12 @@ test_that("proj_set() enforces proj path preparation policy", {
   expect_equal(path_rel(path_with_symlinks, a), "b2/d")
 
   ## force = TRUE
-  proj_set(path_with_symlinks, force = TRUE)
+  proj_set(path_with_symlinks, force = TRUE, quiet = TRUE)
   expect_equal(path_rel(proj_get(), a), "b/d")
 
   ## force = FALSE
   file_create(path(b, "d", ".here"))
-  proj_set(path_with_symlinks, force = FALSE)
+  proj_set(path_with_symlinks, force = FALSE, quiet = TRUE)
   expect_equal(path_rel(proj_get(), a), "b/d")
 
   dir_delete(t)

--- a/tests/testthat/test-write.R
+++ b/tests/testthat/test-write.R
@@ -1,5 +1,20 @@
 context("write helpers")
 
+test_that("write_union() does not activate a project", {
+  tmpdir <- file_temp(pattern = "write-tests")
+  on.exit(dir_delete(tmpdir))
+  dir_create(tmpdir)
+  file_create(path(tmpdir, ".here"))
+
+  expect_true(possibly_in_proj(tmpdir))
+  expect_false(is_in_proj(tmpdir))
+  ## don't use `quiet = TRUE` because prevents what I want to test
+  capture_output(
+    write_union(path(tmpdir, "abc"), lines = letters[1:3])
+  )
+  expect_false(is_in_proj(tmpdir))
+})
+
 test_that("same_contents() detects if contents are / are not same", {
   tmp <- file_temp()
   x <- letters[1:3]


### PR DESCRIPTION
Fixes #390 When rstudio = TRUE, don't change active project in create_package()

Generally tightens up project activation:

  * ~Quietly attempt to activate project on load (should this be on attach?)~
  * Announce project activation, by default
  * Rename `is_proj(path)` to `possibly_in_proj(path)` to better reflect what it actually reports
  * ~Store current project *and the previous*, so we can have `proj_revert()`~
