### PR TITLE
Adding minimal version requirement for styler

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -42,7 +42,7 @@ Suggests:
     rmarkdown,
     roxygen2,
     spelling,
-    styler,
+    styler (>= 1.0.2),
     testthat (>= 2.0.0),
     withr
 Remotes: 


### PR DESCRIPTION
styler `v1.0.2` is now available on CRAN and I suggest to add a minimal version dependency to usethis to import this version. Most notable fixes (including critical fixes like implicit dependency removal) were already present in a prior release `v1.0.1`, but currently, usethis does not specify a minimal version for styler. You can find the changelog for the styler releases [here](http://styler.r-lib.org/news/index.html).