### PR TITLE
add seealso links to R packages website

### DIFF
--- a/R/data.R
+++ b/R/data.R
@@ -18,6 +18,8 @@
 #'   files. If you really want to do so, set this to `TRUE`.
 #' @param compress Choose the type of compression used by [save()].
 #'   Should be one of "gzip", "bzip2", or "xz".
+#' @seealso The [data chapter](http://r-pkgs.had.co.nz/data.html) of [R
+#'   Packages](http://r-pkgs.had.co.nz).
 #' @export
 #' @examples
 #' \dontrun{

--- a/R/description.R
+++ b/R/description.R
@@ -29,6 +29,8 @@
 #' @param fields A named list of fields to add to DESCRIPTION, potentially
 #'   overriding default values. See [use_description()] for how you can set
 #'   personalized defaults using package options
+#' @seealso The [description chapter](http://r-pkgs.had.co.nz/description.html)
+#'   of [R Packages](http://r-pkgs.had.co.nz).
 #' @export
 #' @examples
 #' \dontrun{

--- a/R/license.R
+++ b/R/license.R
@@ -23,6 +23,9 @@
 #' @param name Name of the copyright holder or holders. Separate multiple
 #'   individuals with `;`. You can supply a global default with
 #'   `options(usethis.full_name = "My name")`.
+#' @seealso The [license
+#'   section](http://r-pkgs.had.co.nz/description.html#license) of [R
+#'   Packages](http://r-pkgs.had.co.nz).
 #' @aliases NULL
 NULL
 

--- a/R/namespace.R
+++ b/R/namespace.R
@@ -3,6 +3,9 @@
 #' This `NAMESPACE` exports everything, except functions that start
 #' with a `.`.
 #'
+#' @seealso The [namespace chapter](http://r-pkgs.had.co.nz/namespace.html) of
+#'   [R Packages](http://r-pkgs.had.co.nz).
+#'
 #' @export
 use_namespace <- function() {
   check_is_package("use_namespace()")

--- a/R/news.R
+++ b/R/news.R
@@ -3,6 +3,9 @@
 #' This creates a basic `NEWS.md` in the root directory.
 #'
 #' @inheritParams use_template
+#' @seealso The [important files
+#'   section](http://r-pkgs.had.co.nz/release.html#important-files) of [R
+#'   Packages](http://r-pkgs.had.co.nz).
 #' @export
 use_news_md <- function(open = interactive()) {
   use_template(

--- a/R/package.R
+++ b/R/package.R
@@ -9,6 +9,9 @@
 #' @param type Type of dependency: must be one of "Imports", "Depends",
 #'   "Suggests", "Enhances", or "LinkingTo" (or unique abbreviation). Matching
 #'   is case insensitive.
+#' @seealso The [dependencies
+#'   section](http://r-pkgs.had.co.nz/description.html#dependencies) of [R
+#'   Packages](http://r-pkgs.had.co.nz).
 #' @export
 #' @examples
 #' \dontrun{

--- a/R/r.R
+++ b/R/r.R
@@ -3,7 +3,9 @@
 #' @param name File name, without extension; will create if it doesn't already
 #'   exist. If not specified, and you're currently in a test file, will guess
 #'   name based on test name.
-#' @seealso [use_test()]
+#' @seealso [use_test()], and also the [R code
+#'   chapter](http://r-pkgs.had.co.nz/r.html) of [R
+#'   Packages](http://r-pkgs.had.co.nz).
 #' @export
 use_r <- function(name = NULL) {
   name <- name %||% get_active_r_file(path = "tests/testthat")

--- a/R/readme.R
+++ b/R/readme.R
@@ -12,6 +12,9 @@
 #' YAML frontmatter and R fenced code blocks (`md`) or chunks (`Rmd`).
 #'
 #' @inheritParams use_template
+#' @seealso The [important files
+#'   section](http://r-pkgs.had.co.nz/release.html#important-files) of [R
+#'   Packages](http://r-pkgs.had.co.nz).
 #' @export
 #' @examples
 #' \dontrun{

--- a/R/test.R
+++ b/R/test.R
@@ -5,6 +5,8 @@
 #' adding \pkg{testthat} to the suggested packages. `use_test()`
 #' creates \file{tests/testthat/test-<name>.R} and opens it for editing.
 #'
+#' @seealso The [testing chapter](http://r-pkgs.had.co.nz/tests.html) of [R
+#'   Packages](http://r-pkgs.had.co.nz).
 #' @export
 #' @inheritParams use_template
 use_testthat <- function() {

--- a/R/version.R
+++ b/R/version.R
@@ -12,6 +12,10 @@
 #' @param which A string specifying which level to increment, one of: "major",
 #'   "minor", "patch", "dev". If `NULL`, user can choose interactively.
 #'
+#' @seealso The [version
+#'   section](http://r-pkgs.had.co.nz/description.html#version) of [R
+#'   Packages](http://r-pkgs.had.co.nz).
+#'
 #' @examples
 #' \dontrun{
 #' ## for interactive selection, do this:

--- a/R/vignette.R
+++ b/R/vignette.R
@@ -9,6 +9,8 @@
 #'
 #' @param name Base for file name to use for new vignette. Should consist only
 #'   of numbers, letters, _ and -. I recommend using lower case.
+#' @seealso The [vignettes chapter](http://r-pkgs.had.co.nz/vignettes.html) of
+#'   [R Packages](http://r-pkgs.had.co.nz).
 #' @export
 #' @examples
 #' \dontrun{

--- a/man/licenses.Rd
+++ b/man/licenses.Rd
@@ -40,3 +40,6 @@ CRAN does not allow you to include copies of standard licenses in your
 package, so these functions save the license as \code{LICENSE.md} and add it
 to \code{.Rbuildignore}.
 }
+\seealso{
+The \href{http://r-pkgs.had.co.nz/description.html#license}{license section} of \href{http://r-pkgs.had.co.nz}{R Packages}.
+}

--- a/man/use_data.Rd
+++ b/man/use_data.Rd
@@ -42,3 +42,6 @@ use_data(x, y) # For external use
 use_data(x, y, internal = TRUE) # For internal use
 }
 }
+\seealso{
+The \href{http://r-pkgs.had.co.nz/data.html}{data chapter} of \href{http://r-pkgs.had.co.nz}{R Packages}.
+}

--- a/man/use_description.Rd
+++ b/man/use_description.Rd
@@ -48,3 +48,7 @@ use_description(fields = list(Language = "es"))
 use_description_defaults()
 }
 }
+\seealso{
+The \href{http://r-pkgs.had.co.nz/description.html}{description chapter}
+of \href{http://r-pkgs.had.co.nz}{R Packages}.
+}

--- a/man/use_namespace.Rd
+++ b/man/use_namespace.Rd
@@ -10,3 +10,7 @@ use_namespace()
 This \code{NAMESPACE} exports everything, except functions that start
 with a \code{.}.
 }
+\seealso{
+The \href{http://r-pkgs.had.co.nz/namespace.html}{namespace chapter} of
+\href{http://r-pkgs.had.co.nz}{R Packages}.
+}

--- a/man/use_news_md.Rd
+++ b/man/use_news_md.Rd
@@ -13,3 +13,6 @@ applicable, or via \code{\link[utils:file.edit]{utils::file.edit()}} otherwise.}
 \description{
 This creates a basic \code{NEWS.md} in the root directory.
 }
+\seealso{
+The \href{http://r-pkgs.had.co.nz/release.html#important-files}{important files section} of \href{http://r-pkgs.had.co.nz}{R Packages}.
+}

--- a/man/use_package.Rd
+++ b/man/use_package.Rd
@@ -28,3 +28,6 @@ use_package("ggplot2")
 use_package("dplyr", "suggests")
 }
 }
+\seealso{
+The \href{http://r-pkgs.had.co.nz/description.html#dependencies}{dependencies section} of \href{http://r-pkgs.had.co.nz}{R Packages}.
+}

--- a/man/use_r.Rd
+++ b/man/use_r.Rd
@@ -15,5 +15,5 @@ name based on test name.}
 Create a new R file
 }
 \seealso{
-\code{\link[=use_test]{use_test()}}
+\code{\link[=use_test]{use_test()}}, and also the \href{http://r-pkgs.had.co.nz/r.html}{R code chapter} of \href{http://r-pkgs.had.co.nz}{R Packages}.
 }

--- a/man/use_readme_rmd.Rd
+++ b/man/use_readme_rmd.Rd
@@ -31,3 +31,6 @@ use_readme_rmd()
 use_readme_md()
 }
 }
+\seealso{
+The \href{http://r-pkgs.had.co.nz/release.html#important-files}{important files section} of \href{http://r-pkgs.had.co.nz}{R Packages}.
+}

--- a/man/use_testthat.Rd
+++ b/man/use_testthat.Rd
@@ -22,3 +22,6 @@ applicable, or via \code{\link[utils:file.edit]{utils::file.edit()}} otherwise.}
 adding \pkg{testthat} to the suggested packages. \code{use_test()}
 creates \file{tests/testthat/test-<name>.R} and opens it for editing.
 }
+\seealso{
+The \href{http://r-pkgs.had.co.nz/tests.html}{testing chapter} of \href{http://r-pkgs.had.co.nz}{R Packages}.
+}

--- a/man/use_version.Rd
+++ b/man/use_version.Rd
@@ -34,3 +34,6 @@ use_dev_version()
 }
 
 }
+\seealso{
+The \href{http://r-pkgs.had.co.nz/description.html#version}{version section} of \href{http://r-pkgs.had.co.nz}{R Packages}.
+}

--- a/man/use_vignette.Rd
+++ b/man/use_vignette.Rd
@@ -25,3 +25,7 @@ opens it for editing
 use_vignette("how-to-do-stuff")
 }
 }
+\seealso{
+The \href{http://r-pkgs.had.co.nz/vignettes.html}{vignettes chapter} of
+\href{http://r-pkgs.had.co.nz}{R Packages}.
+}


### PR DESCRIPTION
This is a start at addressing #191 which adds links to relevant sections of the R packages website. 

I'm not sure how exhaustive the linking should be so I've assumed this PR alone isn't enough to close the issue. 

I hope this helps! 