### PR TITLE
Add "__MACOSX" and ".DS_Store" to ignores

### DIFF
--- a/R/course.R
+++ b/R/course.R
@@ -269,7 +269,7 @@ conspicuous_place <- function() {
 }
 
 keep_lgl <- function(file,
-                     ignores = c(".Rproj.user", ".rproj.user", ".Rhistory", ".RData", ".git")) {
+                     ignores = c(".Rproj.user", ".rproj.user", ".Rhistory", ".RData", ".git", "__MACOSX", ".DS_Store")) {
   ignores <- paste0(
     "((\\/|\\A)", gsub("\\.", "[.]", ignores), "(\\/|\\Z))",
     collapse = "|"


### PR DESCRIPTION
The `keep_lgl` function is very handy to ensure certain files and folders are removed when using `use_course`. Two other candidates are the "__MACSOSX" directory and ".DS_Store". This PR adds to the default value for the `ignores` argument.