### PR TITLE
add encoding argument to readLines calls

### DIFF
--- a/R/badge.R
+++ b/R/badge.R
@@ -132,6 +132,6 @@ has_badge <- function(href) {
     return(FALSE)
   }
 
-  readme <- readLines(readme_path)
+  readme <- readLines(readme_path, encoding = "UTF-8")
   any(grepl(href, readme, fixed = TRUE))
 }

--- a/R/logo.R
+++ b/R/logo.R
@@ -40,6 +40,6 @@ has_logo <- function() {
     return(FALSE)
   }
 
-  readme <- readLines(readme_path)
+  readme <- readLines(readme_path, encoding = "UTF-8")
   any(grepl("<img src=\"man/figures/logo.png\" align=\"right\" />", readme, fixed = TRUE))
 }

--- a/R/news.R
+++ b/R/news.R
@@ -18,7 +18,7 @@ use_news_heading <- function(version) {
     return(invisible())
   }
 
-  news <- readLines(news_path)
+  news <- readLines(news_path, encoding = "UTF-8")
   title <- glue("# {project_name()} {version}")
 
   if (title == news[[1]]) {

--- a/R/rstudio.R
+++ b/R/rstudio.R
@@ -117,7 +117,7 @@ in_rstudio_server <- function() {
 }
 
 parse_rproj <- function(file) {
-  lines <- as.list(readLines(file))
+  lines <- as.list(readLines(file, encoding = "UTF-8"))
   has_colon <- grepl(":", lines)
   fields <- lapply(lines[has_colon], function(x) strsplit(x, split = ": ")[[1]])
   lines[has_colon] <- vapply(fields, `[[`, "character", 2)

--- a/R/template.R
+++ b/R/template.R
@@ -54,7 +54,7 @@ use_template <- function(template,
 
 render_template <- function(template, data = list(), package = "usethis") {
   template_path <- find_template(template, package = package)
-  strsplit(whisker::whisker.render(readLines(template_path), data), "\n")[[1]]
+  strsplit(whisker::whisker.render(readLines(template_path, encoding = "UTF-8"), data), "\n")[[1]]
 }
 
 find_template <- function(template_name, package = "usethis") {

--- a/R/write.R
+++ b/R/write.R
@@ -44,7 +44,7 @@ write_union <- function(path, lines, quiet = FALSE) {
   path <- user_path_prep(path)
 
   if (file_exists(path)) {
-    existing_lines <- readLines(path, warn = FALSE)
+    existing_lines <- readLines(path, warn = FALSE, encoding = "UTF-8")
   } else {
     existing_lines <- character()
   }
@@ -106,5 +106,5 @@ same_contents <- function(path, contents) {
     return(FALSE)
   }
 
-  identical(readLines(path), contents)
+  identical(readLines(path, encoding = "UTF-8"), contents)
 }


### PR DESCRIPTION
This is a small fix that adds the encoding argument to all `readLines()` calls in `R`. 

I noticed that the LICENSE.md file had some encoding issues when adding it via e.g. `use_gpl3_license()` (on Windows of course). Line 5 would for example read: 

`_Copyright Â© 2007 Free Software Foundation, Inc. &lt;<http://fsf.org/>&gt;_`

The problem is, is that incoming strings are not marked as "UTF-8". I tracked the problem to `use_template` which calls `readLines` without the `encoding` argument, which on Windows means that they are assumed to be in the "native" encoding. All template files are UTF-8 encoded, however. So I added `encoding = "UTF-8"`. 

I assume that all files generated and read by usethis are also supposed to be UTF-8 as well, so I looked up the other `readLines` calls in `R` as well and added the `encoding = "UTF-8"` argument there as well. 

I was not able to run the relevant tests because I get a lot of `could not find function "file_temp"` errors and unfortunately don't have time to sort those out at the moment. 