### PR TITLE
Replace @ with HTML ref.

### DIFF
--- a/R/tidyverse.R
+++ b/R/tidyverse.R
@@ -304,7 +304,7 @@ use_tidy_thanks <- function(repo_spec = github_repo_spec(),
   todo("{length(contributors)} contributors identified")
   code_block(
     collapse(
-      glue("[@{contributors}](https://github.com/{contributors})"),
+      glue("[&#xFF20;{contributors}](https://github.com/{contributors})"),
       sep = ", ", last = ", and "
     )
   )


### PR DESCRIPTION
In `use_tidy_thanks()` this replaces the `@` symbol with `&#xFF20;` (per clever suggestion of @hadley) to avoid an issue where RStudio runs pandoc-citeproc to lookup each of the referenced GitHub handles. 

🎉 Renders correctly! (see https://github.com/tidyverse/tidyverse.org/pull/194)