### PR TITLE
Template for use_tidy_contributing() should link to .github/

### DIFF
--- a/inst/templates/tidy-contributing.md
+++ b/inst/templates/tidy-contributing.md
@@ -41,7 +41,7 @@ GitHub username, and links to relevant issue(s)/PR(s).
 ### Code of Conduct
 
 Please note that the {{{ package }}} project is released with a
-[Contributor Code of Conduct](CODE_OF_CONDUCT.md). By contributing to this
+[Contributor Code of Conduct](.github/CODE_OF_CONDUCT.md). By contributing to this
 project you agree to abide by its terms.
 
 ### See tidyverse [development contributing guide](https://rstd.io/tidy-contrib)


### PR DESCRIPTION
This minor pull request ensures that the output of `use_tidy_contributing()` links back to the file created by `use_tidy_coc()`.