### PR TITLE
Delete temporary projects/packages

### DIFF
--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -37,6 +37,11 @@ scoped_temporary_thing <- function(dir = file_temp(pattern = pattern),
     }
   } else {
     withr::defer(proj_set(old_project, force = TRUE, quiet = TRUE), envir = env)
+    ## only schedule deletion if it appears 'dir' will be created and,
+    ## therefore, clearly owned by scoped_temporary_thing()
+    if (!fs::dir_exists(dir)) {
+      withr::defer(fs::dir_delete(dir), envir = env)
+    }
   }
 
   withr::local_options(list(usethis.quiet = TRUE))

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -22,6 +22,9 @@ scoped_temporary_thing <- function(dir = file_temp(pattern = pattern),
                                    rstudio = FALSE,
                                    thing = c("package", "project")) {
   thing <- match.arg(thing)
+  if (fs::dir_exists(dir)) {
+    stop_glue("Target {code('dir')} {value(dir)} already exists.")
+  }
 
   ## avoid proj_get() because it attempts to activate a project
   old_project <- proj$cur
@@ -37,11 +40,7 @@ scoped_temporary_thing <- function(dir = file_temp(pattern = pattern),
     }
   } else {
     withr::defer(proj_set(old_project, force = TRUE, quiet = TRUE), envir = env)
-    ## only schedule deletion if it appears 'dir' will be created and,
-    ## therefore, clearly owned by scoped_temporary_thing()
-    if (!fs::dir_exists(dir)) {
-      withr::defer(fs::dir_delete(dir), envir = env)
-    }
+    withr::defer(fs::dir_delete(dir), envir = env)
   }
 
   withr::local_options(list(usethis.quiet = TRUE))

--- a/tests/testthat/test-create.R
+++ b/tests/testthat/test-create.R
@@ -14,13 +14,12 @@ test_that("create_project() creates a non-package project", {
 
 test_that("nested package is disallowed, by default", {
   dir <- scoped_temporary_package()
-  expect_error(scoped_temporary_package(path(dir, "man")), "nested")
+  expect_error(scoped_temporary_package(path(dir, "abcde")), "nested")
 })
 
 test_that("nested project is disallowed, by default", {
   dir <- scoped_temporary_project()
-  subdir <- create_directory(dir, "subdir")
-  expect_error(scoped_temporary_project(subdir), "nested")
+  expect_error(scoped_temporary_project(path(dir, "abcde")), "nested")
 })
 
 ## https://github.com/r-lib/usethis/issues/227


### PR DESCRIPTION
Fixes #250 scoped_temporary_thing(): should the directory be deleted upon frame exit?

Sanity check: I ran this:

``` r
test_that("something", {
  scoped_temporary_package("~/tmp/a123")
  Sys.sleep(10)
})
```

while staring at `~/tmp`. The folder `a123` appeared, persisted while the test was "running" then disappeared when the test completed.