### PR TITLE
Exit gracefully when calling use_version() and then selecting "0" - fixes #463

### DIFF
--- a/R/version.R
+++ b/R/version.R
@@ -37,7 +37,7 @@ use_version <- function(which = NULL) {
 
   ver <- desc::desc_get_version(proj_get())
 
-  if(is.null(which) && !interactive()) {
+  if (is.null(which) && !interactive()) {
     return(invisible(ver))
   }
 
@@ -45,27 +45,31 @@ use_version <- function(which = NULL) {
 
   if (is.null(which)) {
     choice <- utils::menu(
-      choices = glue("{names(versions)} --> {versions}"),
-      title = glue("Current version is {ver}.\n", "Which part to increment?",
-                   " (0 to Exit)")
+      choices = glue(
+        "{format(names(versions), justify = 'right')} --> {versions}"
+      ),
+      title = glue(
+        "Current version is {ver}.\n", "Which part to increment? (0 to exit)"
+      )
     )
-    which <- names(versions)[choice]
+    # Exit gracefully in case a "0" selection was made
+    if (choice == 0) {
+      return(invisible(FALSE))
+    } else {
+      which <- names(versions)[choice]
+    }
   }
-  # Exit gracefully in case a "0" selection was made
-  if (exists("choice", inherits = FALSE) && choice == 0) {
-    todo("You selected to quit! No changes will be made.")
-  } else {
-    which <- match.arg(which, c("major", "minor", "patch", "dev"))
-    new_ver <- versions[which]
 
-    use_description_field("Version", new_ver, overwrite = TRUE)
-    use_news_heading(new_ver)
-    git_check_in(
-      base_path = proj_get(),
-      paths = c("DESCRIPTION", "NEWS.md"),
-      message = "Increment version number"
-    )
-  }
+  which <- match.arg(which, c("major", "minor", "patch", "dev"))
+  new_ver <- versions[which]
+
+  use_description_field("Version", new_ver, overwrite = TRUE)
+  use_news_heading(new_ver)
+  git_check_in(
+    base_path = proj_get(),
+    paths = c("DESCRIPTION", "NEWS.md"),
+    message = "Increment version number"
+  )
   invisible(TRUE)
 }
 

--- a/R/version.R
+++ b/R/version.R
@@ -46,20 +46,26 @@ use_version <- function(which = NULL) {
   if (is.null(which)) {
     choice <- utils::menu(
       choices = glue("{names(versions)} --> {versions}"),
-      title = glue("Current version is {ver}.\n", "Which part to increment?")
+      title = glue("Current version is {ver}.\n", "Which part to increment?",
+                   " (0 to Exit)")
     )
     which <- names(versions)[choice]
   }
-  which <- match.arg(which, c("major", "minor", "patch", "dev"))
-  new_ver <- versions[which]
+  # Exit gracefully in case a "0" selection was made
+  if (exists("choice", inherits = FALSE) && choice == 0) {
+    todo("You selected to quit! No changes will be made.")
+  } else {
+    which <- match.arg(which, c("major", "minor", "patch", "dev"))
+    new_ver <- versions[which]
 
-  use_description_field("Version", new_ver, overwrite = TRUE)
-  use_news_heading(new_ver)
-  git_check_in(
-    base_path = proj_get(),
-    paths = c("DESCRIPTION", "NEWS.md"),
-    message = "Increment version number"
-  )
+    use_description_field("Version", new_ver, overwrite = TRUE)
+    use_news_heading(new_ver)
+    git_check_in(
+      base_path = proj_get(),
+      paths = c("DESCRIPTION", "NEWS.md"),
+      message = "Increment version number"
+    )
+  }
   invisible(TRUE)
 }
 


### PR DESCRIPTION
This would fix #463, leading to graceful exit if the user selects "0" after calling `use_version()` without arguments. 