### PR TITLE
Add option usethis.protocol to change default globally 

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # usethis *development version*
 
+* `protocol` argument is now an option in `use_github()` and `create_from_github()`. The default is still to use `"ssh"` protocol but it can be changed globally to `"https"` with `options(usethis.protocol = "https")`. (#494, @cderv)
+
 * `with_project()` and `local_project()` are new withr-style functions to temporarily set an active usethis project. They make usethis functions easier to use in an *ad hoc* fashion or from another package (#441).
 
 * `proj_get()` and `proj_set()` no longer have a `quiet` argument. The user-facing message about setting a project is now under the same control as other messages, i.e. `getOption("usethis.quiet", default = FALSE)` (#441).

--- a/R/create.R
+++ b/R/create.R
@@ -135,13 +135,13 @@ create_from_github <- function(repo_spec,
                                fork = NA,
                                rstudio = NULL,
                                open = interactive(),
-                               protocol = c("ssh", "https"),
+                               protocol = getOption("usethis.protocol", default = "ssh"),
                                credentials = NULL,
                                auth_token = NULL,
                                host = NULL) {
   destdir <- user_path_prep(destdir %||% conspicuous_place())
   check_is_dir(destdir)
-  protocol <- match.arg(protocol)
+  protocol <- match.arg(protocol, c("ssh", "https"))
 
   owner <- spec_owner(repo_spec)
   repo <- spec_repo(repo_spec)

--- a/R/github.R
+++ b/R/github.R
@@ -28,6 +28,8 @@
 #' Git](http://happygitwithr.com/ssh-keys.html), especially the [troubleshooting
 #' section](http://happygitwithr.com/ssh-keys.html#ssh-troubleshooting).
 #'
+#' You can change the default globally with `options(usethis.protocol = "https")`.
+#'
 #' @inheritParams use_git
 #' @param organisation If supplied, the repo will be created under this
 #'   organisation. You must have access to create repositories.
@@ -39,7 +41,8 @@
 #' @param host GitHub API host to use. Override with the endpoint-root for your
 #'   GitHub enterprise instance, for example,
 #'   "https://github.hostname.com/api/v3"
-#' @param protocol transfer protocol, either "ssh" (the default) or "https"
+#' @param protocol transfer protocol, either "ssh" (the default) or "https".
+#'   You can supply a global default with `options(usethis.protocol = "https")`.
 #' @param credentials A [git2r::cred_ssh_key()] specifying specific ssh
 #'   credentials or `NULL` for default ssh key and ssh-agent behaviour.
 #' @export
@@ -57,7 +60,7 @@
 #' }
 use_github <- function(organisation = NULL,
                        private = FALSE,
-                       protocol = c("ssh", "https"),
+                       protocol = getOption("usethis.protocol", default = "ssh"),
                        credentials = NULL,
                        auth_token = NULL,
                        host = NULL) {
@@ -119,7 +122,7 @@ use_github <- function(organisation = NULL,
 
   done("Adding GitHub remote")
   r <- git2r::repository(proj_get())
-  protocol <- match.arg(protocol)
+  protocol <- match.arg(protocol, c("ssh", "https"))
   origin_url <- switch(protocol,
     https = create$clone_url,
     ssh = create$ssh_url

--- a/man/create_from_github.Rd
+++ b/man/create_from_github.Rd
@@ -5,7 +5,8 @@
 \title{Create a project from a GitHub repo}
 \usage{
 create_from_github(repo_spec, destdir = NULL, fork = NA,
-  rstudio = NULL, open = interactive(), protocol = c("ssh", "https"),
+  rstudio = NULL, open = interactive(),
+  protocol = getOption("usethis.protocol", default = "ssh"),
   credentials = NULL, auth_token = NULL, host = NULL)
 }
 \arguments{
@@ -31,7 +32,8 @@ new instance, if possible, or is switched to, otherwise. If \code{TRUE} and not
 in RStudio (or new project is not an RStudio project), working directory is
 set to the new project.}
 
-\item{protocol}{transfer protocol, either "ssh" (the default) or "https"}
+\item{protocol}{transfer protocol, either "ssh" (the default) or "https".
+You can supply a global default with \code{options(usethis.protocol = "https")}.}
 
 \item{credentials}{A \code{\link[git2r:cred_ssh_key]{git2r::cred_ssh_key()}} specifying specific ssh
 credentials or \code{NULL} for default ssh key and ssh-agent behaviour.}

--- a/man/use_github.Rd
+++ b/man/use_github.Rd
@@ -4,8 +4,9 @@
 \alias{use_github}
 \title{Connect a local repo with GitHub}
 \usage{
-use_github(organisation = NULL, private = FALSE, protocol = c("ssh",
-  "https"), credentials = NULL, auth_token = NULL, host = NULL)
+use_github(organisation = NULL, private = FALSE,
+  protocol = getOption("usethis.protocol", default = "ssh"),
+  credentials = NULL, auth_token = NULL, host = NULL)
 }
 \arguments{
 \item{organisation}{If supplied, the repo will be created under this
@@ -13,7 +14,8 @@ organisation. You must have access to create repositories.}
 
 \item{private}{If \code{TRUE}, creates a private repository.}
 
-\item{protocol}{transfer protocol, either "ssh" (the default) or "https"}
+\item{protocol}{transfer protocol, either "ssh" (the default) or "https".
+You can supply a global default with \code{options(usethis.protocol = "https")}.}
 
 \item{credentials}{A \code{\link[git2r:cred_ssh_key]{git2r::cred_ssh_key()}} specifying specific ssh
 credentials or \code{NULL} for default ssh key and ssh-agent behaviour.}
@@ -55,6 +57,8 @@ default locations, \code{~/.ssh/id_rsa.pub} and \code{~/.ssh/id_rsa}, respective
 that \code{ssh-agent} is configured to manage any associated passphrase.
 Alternatively, specify a \code{\link[git2r:cred_ssh_key]{git2r::cred_ssh_key()}} object via the \code{credentials}
 parameter. Read more about ssh setup in \href{http://happygitwithr.com/ssh-keys.html}{Happy Git}, especially the \href{http://happygitwithr.com/ssh-keys.html#ssh-troubleshooting}{troubleshooting section}.
+
+You can change the default globally with \code{options(usethis.protocol = "https")}.
 }
 
 \examples{


### PR DESCRIPTION
This is an implementation that closes #492 feature request. 

* Keep the "ssh" the default behaviour
* Continue to match `protocol` to `"https"` or `"ssh"`

There are no tests about protocol in https, only manual test with ssh protocol. I could add some for protocol https but I won't be running the manual tests so let me know what you wish on this. 

About `match.arg`, I wanted to use `rlang::arg_match` but it is not use yet so I comply with the current standard for _usethis_. I can do another PR about migrating to `rlang::arg_match`. Error message would be clearer and there would be no partial matching, which is interesting here for `protocol` argument.

