### PR TITLE
add a parameter to choose travis-ci .org or .com

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # usethis *development version*
 
+* `use_travis()` can now be used with `https://travis-ci.com`. It gains an `ext`
+argument, defaulting to `"org"` for use with `https://travis-ci.org`. Use `ext = "com"` 
+to use `https://travis-ci.com`. (@cderv, #500)
+
 * `protocol` argument is now an option in `use_github()` and `create_from_github()`. The default is still to use `"ssh"` protocol but it can be changed globally to `"https"` with `options(usethis.protocol = "https")`. (#494, @cderv)
 
 * `with_project()` and `local_project()` are new withr-style functions to temporarily set an active usethis project. They make usethis functions easier to use in an *ad hoc* fashion or from another package (#441).

--- a/R/browse.R
+++ b/R/browse.R
@@ -51,9 +51,11 @@ browse_github_pulls <- function(package = NULL, number = NULL) {
 
 #' @export
 #' @rdname browse-this
-browse_travis <- function(package = NULL) {
+browse_travis <- function(package = NULL, ext = c("org", "com")) {
   gh <- github_home(package)
-  view_url(sub("github.com", "travis-ci.org", gh))
+  ext <- rlang::arg_match(ext)
+  travis_url <- glue::glue("travis-ci.{ext}")
+  view_url(sub("github.com", travis_url, gh))
 }
 
 #' @export

--- a/R/ci.R
+++ b/R/ci.R
@@ -17,11 +17,13 @@ NULL
 #' integration service.
 #' @param browse Open a browser window to enable automatic builds for the
 #'   package.
+#' @param ext which travis website to use. default to `"org"`for
+#'   https://travis-ci.org. Change to `"com"` for https://travis-ci.com.
 #' @export
 #' @rdname ci
-use_travis <- function(browse = interactive()) {
+use_travis <- function(browse = interactive(), ext = c("org", "com")) {
   check_uses_github()
-
+  ext <- rlang::arg_match(ext)
   new <- use_template(
     "travis.yml",
     ".travis.yml",
@@ -29,22 +31,20 @@ use_travis <- function(browse = interactive()) {
   )
   if (!new) return(invisible(FALSE))
 
-  travis_activate(browse)
-  use_travis_badge()
+  travis_activate(browse, ext = ext)
+  use_travis_badge(ext = ext)
   invisible(TRUE)
 }
 
-use_travis_badge <- function() {
+use_travis_badge <- function(ext = "org") {
   check_uses_github()
-
-  url <- glue("https://travis-ci.org/{github_repo_spec()}")
+  url <- glue("https://travis-ci.{ext}/{github_repo_spec()}")
   img <- glue("{url}.svg?branch=master")
-
   use_badge("Travis build status", url, img)
 }
 
-travis_activate <- function(browse = interactive()) {
-  url <- glue("https://travis-ci.org/profile/{github_owner()}")
+travis_activate <- function(browse = interactive(), ext = "org") {
+  url <- glue("https://travis-ci.{ext}/profile/{github_owner()}")
 
   todo("Turn on travis for your repo at {url}")
   if (browse) {

--- a/man/ci.Rd
+++ b/man/ci.Rd
@@ -6,7 +6,7 @@
 \alias{use_appveyor}
 \title{Continuous integration setup and badges}
 \usage{
-use_travis(browse = interactive())
+use_travis(browse = interactive(), ext = c("org", "com"))
 
 use_coverage(type = c("codecov", "coveralls"))
 
@@ -15,6 +15,9 @@ use_appveyor(browse = interactive())
 \arguments{
 \item{browse}{Open a browser window to enable automatic builds for the
 package.}
+
+\item{ext}{which travis website to use. default to \code{"org"}for
+https://travis-ci.org. Change to \code{"com"} for https://travis-ci.com.}
 
 \item{type}{Which web service to use for test reporting. Currently supports
 \href{https://codecov.io}{Codecov} and \href{https://coveralls.io}{Coveralls}.}

--- a/tests/testthat/test-browse.R
+++ b/tests/testthat/test-browse.R
@@ -46,6 +46,7 @@ test_that("browse_XXX() goes to correct URL", {
   expect_equal(browse_github_pulls("gh", 1), g("r-lib/gh/pull/1"))
 
   expect_equal(browse_travis("usethis"), "https://travis-ci.org/r-lib/usethis")
+  expect_equal(browse_travis("usethis", ext = "com"), "https://travis-ci.com/r-lib/usethis")
 
   expect_equal(browse_cran("usethis"), "https://cran.r-project.org/package=usethis")
 })


### PR DESCRIPTION
This closes #349 by providing a way to choose `https://travis-ci.com/` instead of `https://travis-ci.org/`. 

The website url does not impact .travis.yml but is used to create the badge link and open a browser to activate travis on a project. 

This follows the announcement from travis: [Announcing support for open source projects on travis-ci.com](https://blog.travis-ci.com/2018-05-02-open-source-projects-on-travis-ci-com-with-github-apps)