### PR TITLE
typo in @description section

### DIFF
--- a/R/description.R
+++ b/R/description.R
@@ -21,7 +21,7 @@
 #'   usethis.description = list(
 #'     `Authors@R` = 'person("Jane", "Doe", email = "jane@example.com", role = c("aut", "cre"))',
 #'     License = "MIT + file LICENSE",
-#'     Language: es
+#'     Language =  "es"
 #'   )
 #' )
 #' ```


### PR DESCRIPTION
example code in @description of the roxygen documentation has colon and unqouted string