### PR TITLE
Prepare externally-created paths under our policy

### DIFF
--- a/R/edit.R
+++ b/R/edit.R
@@ -105,7 +105,7 @@ scoped_path_r  <- function(scope = c("user", "project"), ..., envvar = NULL) {
   if (scope == "user" && !is.null(envvar)) {
     env <- Sys.getenv(envvar, unset = "")
     if (!identical(env, "")) {
-      return(env)
+      return(user_path_prep(env))
     }
   }
 

--- a/R/edit.R
+++ b/R/edit.R
@@ -111,9 +111,10 @@ scoped_path_r  <- function(scope = c("user", "project"), ..., envvar = NULL) {
 
   # Try environment variable in user scopes
   if (scope == "user" && !is.null(envvar)) {
-    ## unset = "" does not work reliably on Windows for R_ENVIRON_USER
-    env <- Sys.getenv(envvar, unset = "UNSET")
-    if (!identical(env, "UNSET")) {
+    env <- Sys.getenv(envvar, unset = "")
+    ## some Windows systems (notably AppVeyor) inexplicably return
+    ## 'no_such_file' for R_ENVIRON_USER
+    if (!env %in% c("", "no_such_file")) {
       return(user_path_prep(env))
     }
   }

--- a/R/edit.R
+++ b/R/edit.R
@@ -113,8 +113,8 @@ scoped_path_r  <- function(scope = c("user", "project"), ..., envvar = NULL) {
   if (scope == "user" && !is.null(envvar)) {
     env <- Sys.getenv(envvar, unset = "")
     ## some Windows systems (notably AppVeyor) inexplicably return
-    ## 'no_such_file' for R_ENVIRON_USER
-    if (!env %in% c("", "no_such_file")) {
+    ## 'no_such_file' for R_ENVIRON_USER (yes, quoted)
+    if (!env %in% c("", "'no_such_file'")) {
       return(user_path_prep(env))
     }
   }

--- a/R/edit.R
+++ b/R/edit.R
@@ -61,6 +61,9 @@ NULL
 #' @rdname edit
 edit_r_profile <- function(scope = c("user", "project")) {
   ui_todo("Restart R for changes to take effect")
+  if (scope == "user") {
+    cat("R_PROFILE_USER = ", Sys.getenv("R_PROFILE_USER", unset = "<unset>"), "\n")
+  }
   path <- scoped_path_r(scope, ".Rprofile", envvar = "R_PROFILE_USER")
   if (scope == "user") cat("path to .Rprofile: ", path, "\n")
   edit_file(path)
@@ -70,6 +73,9 @@ edit_r_profile <- function(scope = c("user", "project")) {
 #' @rdname edit
 edit_r_environ <- function(scope = c("user", "project")) {
   ui_todo("Restart R for changes to take effect")
+  if (scope == "user") {
+    cat("R_ENVIRON_USER = ", Sys.getenv("R_ENVIRON_USER", unset = "<unset>"), "\n")
+  }
   path <- scoped_path_r(scope, ".Renviron", envvar = "R_ENVIRON_USER")
   if (scope == "user") cat("path to .Renviron: ", path, "\n")
   edit_file(path)

--- a/R/edit.R
+++ b/R/edit.R
@@ -70,6 +70,7 @@ edit_r_profile <- function(scope = c("user", "project")) {
 edit_r_environ <- function(scope = c("user", "project")) {
   ui_todo("Restart R for changes to take effect")
   path <- scoped_path_r(scope, ".Renviron", envvar = "R_ENVIRON_USER")
+  if (scope == "user") cat("path to .Renviron: ", path, "\n")
   edit_file(path)
 }
 

--- a/R/edit.R
+++ b/R/edit.R
@@ -62,6 +62,7 @@ NULL
 edit_r_profile <- function(scope = c("user", "project")) {
   ui_todo("Restart R for changes to take effect")
   path <- scoped_path_r(scope, ".Rprofile", envvar = "R_PROFILE_USER")
+  if (scope == "user") cat("path to .Rprofile: ", path, "\n")
   edit_file(path)
 }
 

--- a/R/edit.R
+++ b/R/edit.R
@@ -111,8 +111,9 @@ scoped_path_r  <- function(scope = c("user", "project"), ..., envvar = NULL) {
 
   # Try environment variable in user scopes
   if (scope == "user" && !is.null(envvar)) {
-    env <- Sys.getenv(envvar, unset = "")
-    if (!identical(env, "")) {
+    ## unset = "" does not work reliably on Windows for R_ENVIRON_USER
+    env <- Sys.getenv(envvar, unset = "UNSET")
+    if (!identical(env, "UNSET")) {
       return(user_path_prep(env))
     }
   }

--- a/R/edit.R
+++ b/R/edit.R
@@ -61,11 +61,7 @@ NULL
 #' @rdname edit
 edit_r_profile <- function(scope = c("user", "project")) {
   ui_todo("Restart R for changes to take effect")
-  if (scope == "user") {
-    cat("R_PROFILE_USER = ", Sys.getenv("R_PROFILE_USER", unset = "<unset>"), "\n")
-  }
   path <- scoped_path_r(scope, ".Rprofile", envvar = "R_PROFILE_USER")
-  if (scope == "user") cat("path to .Rprofile: ", path, "\n")
   edit_file(path)
 }
 
@@ -73,11 +69,7 @@ edit_r_profile <- function(scope = c("user", "project")) {
 #' @rdname edit
 edit_r_environ <- function(scope = c("user", "project")) {
   ui_todo("Restart R for changes to take effect")
-  if (scope == "user") {
-    cat("R_ENVIRON_USER = ", Sys.getenv("R_ENVIRON_USER", unset = "<unset>"), "\n")
-  }
   path <- scoped_path_r(scope, ".Renviron", envvar = "R_ENVIRON_USER")
-  if (scope == "user") cat("path to .Renviron: ", path, "\n")
   edit_file(path)
 }
 

--- a/tests/testthat/test-edit.R
+++ b/tests/testthat/test-edit.R
@@ -49,7 +49,7 @@ test_that("edit_r_XXX('user') ensures the file exists", {
 })
 
 test_that("edit_r_profile() respects R_PROFILE_USER", {
-  path1 <- tempfile()
+  path1 <- user_path_prep(tempfile())
   withr::local_envvar(list(R_PROFILE_USER = path1))
 
   path2 <- edit_r_profile("user")


### PR DESCRIPTION
This was causing test failure for me locally, in the test I've edited:

```
>   expect_equal(path1, as.character(path2))
Error: `path1` not equal to as.character(path2).
1/1 mismatches
x[1]: "/var/folders/yx/3p5dt4jj1019st0x90vhm9rr0000gn/T//RtmpMtS78Z/file167c347ea5
x[1]: f6b"
y[1]: "/var/folders/yx/3p5dt4jj1019st0x90vhm9rr0000gn/T/RtmpMtS78Z/file167c347ea5f
y[1]: 6b"
```

It makes sense to treat a path stored in `R_PROFILE_USER` as a "user provided path" anyway.