### PR TITLE
Encourage ORCID use

### DIFF
--- a/R/description.R
+++ b/R/description.R
@@ -19,7 +19,8 @@
 #' ```
 #' options(
 #'   usethis.description = list(
-#'     `Authors@R` = 'person("Jane", "Doe", email = "jane@example.com", role = c("aut", "cre"))',
+#'     `Authors@R` = 'person("Jane", "Doe", email = "jane@example.com", role = c("aut", "cre"),
+#'                           comment = c(ORCID = "YOUR-ORCID-ID"))',
 #'     License = "MIT + file LICENSE",
 #'     Language =  "es"
 #'   )
@@ -70,7 +71,7 @@ use_description_defaults <- function() {
       Version = "0.0.0.9000",
       Title = "What the Package Does (One Line, Title Case)",
       Description = "What the package does (one paragraph).",
-      "Authors@R" = 'person("First", "Last", , "first.last@example.com", c("aut", "cre"))',
+      "Authors@R" = 'person("First", "Last", , "first.last@example.com", c("aut", "cre"), comment = c(ORCID = "YOUR-ORCID-ID"))',
       License = "What license it uses",
       Encoding = "UTF-8",
       LazyData = "true"

--- a/man/use_description.Rd
+++ b/man/use_description.Rd
@@ -32,7 +32,8 @@ If you create a lot of packages, consider storing personalized defaults as a
 named list in an option named \code{"usethis.description"}. Here's an example of
 code to include in \code{.Rprofile}:\preformatted{options(
   usethis.description = list(
-    `Authors@R` = 'person("Jane", "Doe", email = "jane@example.com", role = c("aut", "cre"))',
+    `Authors@R` = 'person("Jane", "Doe", email = "jane@example.com", role = c("aut", "cre"),
+                          comment = c(ORCID = "YOUR-ORCID-ID"))',
     License = "MIT + file LICENSE",
     Language =  "es"
   )

--- a/vignettes/articles/usethis-setup.Rmd
+++ b/vignettes/articles/usethis-setup.Rmd
@@ -162,7 +162,8 @@ Here is an example of R code that sets the authors, license, and version in all 
 options(
   usethis.name = "Jane Doe",
   usethis.description = list(
-    `Authors@R` = 'person("Jane", "Doe", email = "jane@example.com", role = c("aut", "cre"))',
+    `Authors@R` = 'person("Jane", "Doe", email = "jane@example.com", role = c("aut", "cre"), 
+    comment = c(ORCID = "YOUR-ORCID-ID"))',
     License = "MIT + file LICENSE",
     Version = "0.0.0.9000"
   )


### PR DESCRIPTION
cf #108 in particular https://github.com/r-lib/usethis/issues/108#issuecomment-443096619

# About the changes made
I'm not sure whether (not) to introduce a line break in `person()`.

# About the changes not made
I had been considering adding links to `desc` (convenience) functions but I'm not sure how to and it's actually maybe a topic for another issue.
* Making sure `whoami` finds all your info could be part of the recommended setup (in the setup article) but `usethis` doesn't use `whoami` at all, only `desc::desc_add_me()` does.
* `desc` convenience functions [support ORCID](https://github.com/r-lib/desc/pull/70) but their use is actually beyond setup, it's more about managing authors later in a package life?
End of long comment. 😸  