### PR TITLE
Muffle setup and teardown of scoped_temporary_things

### DIFF
--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -39,7 +39,10 @@ scoped_temporary_thing <- function(dir = file_temp(pattern = pattern),
     }
   } else {
     withr::defer({
-      proj_set(old_project, force = TRUE)
+      withr::with_options(
+        list(usethis.quiet = TRUE),
+        proj_set(old_project, force = TRUE)
+      )
       setwd(old_project)
       fs::dir_delete(dir)
     }, envir = env)

--- a/tests/testthat/test-roxygen.R
+++ b/tests/testthat/test-roxygen.R
@@ -2,8 +2,8 @@ context("test-roxygen")
 
 test_that("use_package_doc() compatible with roxygen_ns_append()", {
   scoped_temporary_package()
-
   withr::local_options(list(usethis.quiet = FALSE))
+
   expect_output(use_package_doc())
   expect_output(roxygen_ns_append("test"), "Adding 'test'")
   expect_silent(roxygen_ns_append("test"))

--- a/tests/testthat/test-roxygen.R
+++ b/tests/testthat/test-roxygen.R
@@ -3,11 +3,8 @@ context("test-roxygen")
 test_that("use_package_doc() compatible with roxygen_ns_append()", {
   scoped_temporary_package()
 
-  withr::with_options(
-    list(usethis.quiet = FALSE), {
-      expect_output(use_package_doc())
-      expect_output(roxygen_ns_append("test"), "Adding 'test'")
-      expect_output(roxygen_ns_append("test"), NA)
-    }
-  )
+  withr::local_options(list(usethis.quiet = FALSE))
+  expect_output(use_package_doc())
+  expect_output(roxygen_ns_append("test"), "Adding 'test'")
+  expect_output(roxygen_ns_append("test"), NA)
 })

--- a/tests/testthat/test-roxygen.R
+++ b/tests/testthat/test-roxygen.R
@@ -6,5 +6,5 @@ test_that("use_package_doc() compatible with roxygen_ns_append()", {
   withr::local_options(list(usethis.quiet = FALSE))
   expect_output(use_package_doc())
   expect_output(roxygen_ns_append("test"), "Adding 'test'")
-  expect_output(roxygen_ns_append("test"), NA)
+  expect_silent(roxygen_ns_append("test"))
 })

--- a/tests/testthat/test-use-badge.R
+++ b/tests/testthat/test-use-badge.R
@@ -30,11 +30,8 @@ test_that("use_badge() does nothing if badge seems to pre-exist", {
 test_that("default readme has placeholders / can add to empty badge block", {
   scoped_temporary_package()
 
-  withr::with_options(
-    list(usethis.quiet = FALSE), {
-      expect_output(use_readme_md())
-      expect_output(use_cran_badge(), "Adding CRAN status badge")
-      expect_output(use_cran_badge(), NA)
-    }
-  )
+  withr::local_options(list(usethis.quiet = FALSE))
+  expect_output(use_readme_md())
+  expect_output(use_cran_badge(), "Adding CRAN status badge")
+  expect_output(use_cran_badge(), NA)
 })

--- a/tests/testthat/test-use-badge.R
+++ b/tests/testthat/test-use-badge.R
@@ -33,5 +33,5 @@ test_that("default readme has placeholders / can add to empty badge block", {
   withr::local_options(list(usethis.quiet = FALSE))
   expect_output(use_readme_md())
   expect_output(use_cran_badge(), "Adding CRAN status badge")
-  expect_output(use_cran_badge(), NA)
+  expect_silent(use_cran_badge())
 })

--- a/tests/testthat/test-use-badge.R
+++ b/tests/testthat/test-use-badge.R
@@ -29,8 +29,8 @@ test_that("use_badge() does nothing if badge seems to pre-exist", {
 
 test_that("default readme has placeholders / can add to empty badge block", {
   scoped_temporary_package()
-
   withr::local_options(list(usethis.quiet = FALSE))
+
   expect_output(use_readme_md())
   expect_output(use_cran_badge(), "Adding CRAN status badge")
   expect_silent(use_cran_badge())

--- a/tests/testthat/test-use-dependency.R
+++ b/tests/testthat/test-use-dependency.R
@@ -8,10 +8,7 @@ test_that("we message for new type and are silent for same type", {
     use_dependency("crayon", "Imports"),
     "Adding 'crayon' to Imports field"
   )
-  expect_output(
-    use_dependency("crayon", "Imports"),
-    NA
-  )
+  expect_silent(use_dependency("crayon", "Imports"))
 })
 
 test_that("we message for version change and are silent for same version", {
@@ -28,20 +25,14 @@ test_that("we message for version change and are silent for same version", {
     "Increasing 'crayon'"
   )
 
-  expect_output(
-    use_dependency("crayon", "Imports", min_version = "1.0.0"),
-    NA
-  )
+  expect_silent(use_dependency("crayon", "Imports", min_version = "1.0.0"))
 
   expect_output(
     use_dependency("crayon", "Imports", min_version = "2.0.0"),
     "Increasing 'crayon'"
   )
 
-  expect_output(
-    use_dependency("crayon", "Imports", min_version = "1.0.0"),
-    NA
-  )
+  expect_silent(use_dependency("crayon", "Imports", min_version = "1.0.0"))
 })
 
 ## https://github.com/r-lib/usethis/issues/99

--- a/tests/testthat/test-use-dependency.R
+++ b/tests/testthat/test-use-dependency.R
@@ -1,14 +1,13 @@
 context("use_dependency")
 
 test_that("we message for new type and are silent for same type", {
-  withr::local_options(list(usethis.quiet = FALSE))
   scoped_temporary_package()
 
+  withr::local_options(list(usethis.quiet = FALSE))
   expect_output(
     use_dependency("crayon", "Imports"),
     "Adding 'crayon' to Imports field"
   )
-
   expect_output(
     use_dependency("crayon", "Imports"),
     NA
@@ -16,9 +15,9 @@ test_that("we message for new type and are silent for same type", {
 })
 
 test_that("we message for version change and are silent for same version", {
-  withr::local_options(list(usethis.quiet = FALSE))
   scoped_temporary_package()
 
+  withr::local_options(list(usethis.quiet = FALSE))
   expect_output(
     use_dependency("crayon", "Imports"),
     "Adding 'crayon"
@@ -47,9 +46,9 @@ test_that("we message for version change and are silent for same version", {
 
 ## https://github.com/r-lib/usethis/issues/99
 test_that("use_dependency() upgrades a dependency", {
-  withr::local_options(list(usethis.quiet = FALSE))
   scoped_temporary_package()
 
+  withr::local_options(list(usethis.quiet = FALSE))
   expect_output(use_dependency("usethis", "Suggests"))
   expect_match(desc::desc_get("Suggests", proj_get()), "usethis")
 
@@ -60,9 +59,9 @@ test_that("use_dependency() upgrades a dependency", {
 
 ## https://github.com/r-lib/usethis/issues/99
 test_that("use_dependency() declines to downgrade a dependency", {
-  withr::local_options(list(usethis.quiet = FALSE))
   scoped_temporary_package()
 
+  withr::local_options(list(usethis.quiet = FALSE))
   expect_output(use_dependency("usethis", "Imports"))
   expect_match(desc::desc_get("Imports", proj_get()), "usethis")
 
@@ -72,17 +71,17 @@ test_that("use_dependency() declines to downgrade a dependency", {
 })
 
 test_that("can add LinkingTo dependency if other dependency already exists", {
-  withr::local_options(list(usethis.quiet = FALSE))
   scoped_temporary_package()
 
+  withr::local_options(list(usethis.quiet = FALSE))
   expect_output(use_dependency("Rcpp", "Imports"))
   expect_output(use_dependency("Rcpp", "LinkingTo"), "Adding 'Rcpp'")
 })
 
 test_that("can add any dependency if LinkingTo dependency already exists", {
-  withr::local_options(list(usethis.quiet = FALSE))
   scoped_temporary_package()
 
+  withr::local_options(list(usethis.quiet = FALSE))
   expect_output(use_dependency("Rcpp", "LinkingTo"))
   expect_output(use_dependency("Rcpp", "Import"), "Adding 'Rcpp'")
 })

--- a/tests/testthat/test-use-dependency.R
+++ b/tests/testthat/test-use-dependency.R
@@ -2,8 +2,8 @@ context("use_dependency")
 
 test_that("we message for new type and are silent for same type", {
   scoped_temporary_package()
-
   withr::local_options(list(usethis.quiet = FALSE))
+
   expect_output(
     use_dependency("crayon", "Imports"),
     "Adding 'crayon' to Imports field"
@@ -13,33 +13,29 @@ test_that("we message for new type and are silent for same type", {
 
 test_that("we message for version change and are silent for same version", {
   scoped_temporary_package()
-
   withr::local_options(list(usethis.quiet = FALSE))
+
   expect_output(
     use_dependency("crayon", "Imports"),
     "Adding 'crayon"
   )
-
   expect_output(
     use_dependency("crayon", "Imports", min_version = "1.0.0"),
     "Increasing 'crayon'"
   )
-
   expect_silent(use_dependency("crayon", "Imports", min_version = "1.0.0"))
-
   expect_output(
     use_dependency("crayon", "Imports", min_version = "2.0.0"),
     "Increasing 'crayon'"
   )
-
   expect_silent(use_dependency("crayon", "Imports", min_version = "1.0.0"))
 })
 
 ## https://github.com/r-lib/usethis/issues/99
 test_that("use_dependency() upgrades a dependency", {
   scoped_temporary_package()
-
   withr::local_options(list(usethis.quiet = FALSE))
+
   expect_output(use_dependency("usethis", "Suggests"))
   expect_match(desc::desc_get("Suggests", proj_get()), "usethis")
 
@@ -51,8 +47,8 @@ test_that("use_dependency() upgrades a dependency", {
 ## https://github.com/r-lib/usethis/issues/99
 test_that("use_dependency() declines to downgrade a dependency", {
   scoped_temporary_package()
-
   withr::local_options(list(usethis.quiet = FALSE))
+
   expect_output(use_dependency("usethis", "Imports"))
   expect_match(desc::desc_get("Imports", proj_get()), "usethis")
 
@@ -63,8 +59,8 @@ test_that("use_dependency() declines to downgrade a dependency", {
 
 test_that("can add LinkingTo dependency if other dependency already exists", {
   scoped_temporary_package()
-
   withr::local_options(list(usethis.quiet = FALSE))
+
   expect_output(use_dependency("Rcpp", "Imports"))
   expect_output(use_dependency("Rcpp", "LinkingTo"), "Adding 'Rcpp'")
 })

--- a/tests/testthat/test-use-rcpp.R
+++ b/tests/testthat/test-use-rcpp.R
@@ -25,5 +25,6 @@ test_that("use_src() doesn't message if not needed", {
   use_src()
 
   withr::local_options(list(usethis.quiet = FALSE))
+
   expect_silent(use_src())
 })

--- a/tests/testthat/test-use-rcpp.R
+++ b/tests/testthat/test-use-rcpp.R
@@ -24,8 +24,6 @@ test_that("use_src() doesn't message if not needed", {
   use_package_doc()
   use_src()
 
-  withr::with_options(
-    list(usethis.quiet = FALSE),
-    expect_silent(use_src())
-  )
+  withr::local_options(list(usethis.quiet = FALSE))
+  expect_silent(use_src())
 })


### PR DESCRIPTION
This is how the helper should have been in the first place. Now it's symmetric: setup and teardown are both quiet.

This makes it easier to manipulate `usethis.quiet` in a test, i.e. you can use `withr::local_options()` instead of `withr::with_options()`.