### PR TITLE
Remove sudo: false from templates

### DIFF
--- a/inst/templates/tidy-travis.yml
+++ b/inst/templates/tidy-travis.yml
@@ -1,7 +1,6 @@
 # R for travis: see documentation at https://docs.travis-ci.com/user/languages/r
 
 language: R
-sudo: false
 cache: packages
 
 matrix:

--- a/inst/templates/travis.yml
+++ b/inst/templates/travis.yml
@@ -1,5 +1,4 @@
 # R for travis: see documentation at https://docs.travis-ci.com/user/languages/r
 
 language: R
-sudo: false
 cache: packages


### PR DESCRIPTION
This distinction is no longer needed on travis

See https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration

> If you currently specify sudo: false in your .travis.yml, we recommend removing that configuration soon.