### PR TITLE
Fix broken link in README.{md,Rmd}

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -42,7 +42,7 @@ devtools::install_github("r-lib/usethis")
 
 ## Usage
 
-Most `use_*()` functions operate on the *active project*: literally, a directory on your computer. If you've just used usethis to create a new package or project, that will be the active project. Otherwise, usethis verifies that current working directory is or is below a valid project directory and that becomes the active project. Use `proj_get()` or `proj_sitrep()` to manually query the project and [read more in the docs](http://usethis.r-lib.org/reference/proj_get.html).
+Most `use_*()` functions operate on the *active project*: literally, a directory on your computer. If you've just used usethis to create a new package or project, that will be the active project. Otherwise, usethis verifies that current working directory is or is below a valid project directory and that becomes the active project. Use `proj_get()` or `proj_sitrep()` to manually query the project and [read more in the docs](https://usethis.r-lib.org/reference/proj_utils.html).
 
 A few usethis functions have no strong connections to projects and will expect you to provide a path.
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ package or project, that will be the active project. Otherwise, usethis
 verifies that current working directory is or is below a valid project
 directory and that becomes the active project. Use `proj_get()` or
 `proj_sitrep()` to manually query the project and [read more in the
-docs](http://usethis.r-lib.org/reference/proj_get.html).
+docs](https://usethis.r-lib.org/reference/proj_utils.html).
 
 A few usethis functions have no strong connections to projects and will
 expect you to provide a path.


### PR DESCRIPTION
Original link goes to 404 page. The `proj_get()` help page is wrapped within proj_utils page. These commits also update the links from `http` to `https`.