### PR TITLE
use_readme_rmd(): make git hooks optional -- closes #556

### DIFF
--- a/man/use_readme_rmd.Rd
+++ b/man/use_readme_rmd.Rd
@@ -5,13 +5,18 @@
 \alias{use_readme_md}
 \title{Create README files}
 \usage{
-use_readme_rmd(open = interactive())
+use_readme_rmd(open = interactive(), use_hook = NULL)
 
 use_readme_md(open = interactive())
 }
 \arguments{
 \item{open}{Open the newly created file for editing? Happens in RStudio, if
 applicable, or via \code{\link[utils:file.edit]{utils::file.edit()}} otherwise.}
+
+\item{use_hook}{Use pre commit Git hook to enforce README.Rmd and README.md
+to be in sync or not. Defaults to NULL which will result in asking user
+in interactive session and simple not set the hook in non-interactive
+session.}
 }
 \description{
 Creates skeleton README files with sections for

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -99,6 +99,7 @@ is_build_ignored <- function(pattern, ..., base_path = proj_get()) {
 test_file <- function(fname) testthat::test_path("ref", fname)
 
 expect_proj_file <- function(...) expect_true(file_exists(proj_path(...)))
+expect_no_proj_file <- function(...) expect_true(!file_exists(proj_path(...)))
 expect_proj_dir <- function(...) expect_true(dir_exists(proj_path(...)))
 
 ## use from testthat once > 2.0.0 is on CRAN

--- a/tests/testthat/test-use-readme.R
+++ b/tests/testthat/test-use-readme.R
@@ -1,5 +1,6 @@
 context("use_readme")
 
+
 test_that("use_readme_md() creates README.md", {
   scoped_temporary_package()
   use_readme_md()
@@ -14,7 +15,8 @@ test_that("use_readme_rmd() creates README.Rmd", {
   expect_proj_file("README.Rmd")
 })
 
-test_that("use_readme_rmd() sets up git pre-commit hook if pkg uses git", {
+
+test_that("use_readme_rmd() does not set up git pre-commit hook", {
   # git2r::git2r::discover_repository() not working on R 3.1 (Travis)
   skip_if(getRversion() < 3.2)
   skip_if_no_git_config()
@@ -23,5 +25,19 @@ test_that("use_readme_rmd() sets up git pre-commit hook if pkg uses git", {
   scoped_temporary_package()
   use_git()
   use_readme_rmd(open = FALSE)
+  expect_no_proj_file(".git", "hooks", "pre-commit")
+})
+
+
+
+test_that("use_readme_rmd() sets up git pre-commit hook if pkg uses git", {
+  # git2r::git2r::discover_repository() not working on R 3.1 (Travis)
+  skip_if(getRversion() < 3.2)
+  skip_if_no_git_config()
+  skip_if_not_installed("rmarkdown")
+
+  scoped_temporary_package()
+  use_git()
+  use_readme_rmd(open = FALSE, use_hook = TRUE)
   expect_proj_file(".git", "hooks", "pre-commit")
 })


### PR DESCRIPTION
See issue #556 for further information. 