### PR TITLE
Clarify this help message with a bit of verbosity. 

### DIFF
--- a/R/package.R
+++ b/R/package.R
@@ -96,7 +96,7 @@ how_to_use <- function(package, type) {
       code <- glue("requireNamespace(\"{package}\", quietly = TRUE)")
       ui_todo("Use {ui_code(code)} to test if package is installed")
       code <- glue("{package}::fun()")
-      ui_todo("Then use {ui_code(code)} to refer to functions.")
+      ui_todo("Then directly refer to functons like {ui_code(code)} (replacing {ui_code(fun())}).")
     },
     enhances = "",
     linkingto = show_includes(package)


### PR DESCRIPTION
The `fun` reference caused me a bit of "foo confusion." I thought, "is there some magic where I'm supposed to refer to `mutate` like `dplyr::fun(mutate)(...)`?" This update hopes to close that line of confusion by focusing the user on direct reference like `dplyr::mutate`.