### PR TITLE
Replace broken link with closest valid one

### DIFF
--- a/inst/templates/tidy-eval.R
+++ b/inst/templates/tidy-eval.R
@@ -26,7 +26,7 @@
 #'
 #' To learn more about tidy eval and how to use these tools, visit
 #' <http://rlang.r-lib.org> and the [Metaprogramming
-#' section](https://adv-r.hadley.nz/meta.html) of [Advanced
+#' section](https://adv-r.hadley.nz/introduction-16.html) of [Advanced
 #' R](https://adv-r.hadley.nz).
 #'
 #' @md


### PR DESCRIPTION
The old link rose this warning:
```
Found the following (possibly) invalid URLs:
  URL: https://adv-r.hadley.nz/meta.html
    From: man/tidyeval.Rd
    Status: 404
    Message: Not Found
```


Build ID:	fgeo.tool_1.0.0.tar.gz-3899a0ff7f434e2da983e825cdd77a6b
Platform:	Windows Server 2008 R2 SP1, R-devel, 32/64 bit