### PR TITLE
Auto-detect protocol in use_github

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 ## New features
 
+* `use_github()` now detects whether to use ssh or https automatically.
+
 * `git_sitrep()` lets you know what's up with your git, git2r and GitHub 
   config (#328).
 

--- a/man/use_github.Rd
+++ b/man/use_github.Rd
@@ -5,7 +5,7 @@
 \title{Connect a local repo with GitHub}
 \usage{
 use_github(organisation = NULL, private = FALSE,
-  protocol = getOption("usethis.protocol", default = "ssh"),
+  protocol = getOption("usethis.protocol", default = NULL),
   credentials = NULL, auth_token = NULL, host = NULL)
 }
 \arguments{


### PR DESCRIPTION
This method is from https://help.github.com/articles/testing-your-ssh-connection/

It certainly seem to work fine if ssh is already setup, but I am unsure what would exactly would happen if github is not in the allowed hosts and you get

> The authenticity of host 'github.com (IP ADDRESS)' can't be established.

The motivation was mass chaos when people tried to use `use_github()` with the default protocol of `ssh` while not having ssh setup during our workshop.