### PR TITLE
remove comma from proj name in use_github

### DIFF
--- a/R/github.R
+++ b/R/github.R
@@ -83,7 +83,7 @@ use_github <- function(organisation = NULL,
     ui_todo("Check title and description")
     ui_code_block(
       "
-      Name:        {repo_name},
+      Name:        {repo_name}
       Description: {repo_desc}
       ",
       copy = FALSE


### PR DESCRIPTION
Fixing issue #569. 

This was a freebie 😁