### PR TITLE
Preface usethis function call with package name.

### DIFF
--- a/R/github.R
+++ b/R/github.R
@@ -237,7 +237,7 @@ browse_github_pat <- function(scopes = c("repo", "gist"),
   )
   view_url(url)
 
-  ui_todo("Call {ui_code('edit_r_environ()')} to open {ui_path('.Renviron')}")
+  ui_todo("Call {ui_code('usethis::edit_r_environ()')} to open {ui_path('.Renviron')}")
   ui_todo("Store your PAT with a line like:")
   ui_code_block("GITHUB_PAT=xxxyyyzzz")
   ui_todo("Make sure {ui_value('.Renviron')} ends with a newline!")


### PR DESCRIPTION
I didn't have `usethis` library()d, so when I got the instruction to `Call edit_r_environ() to open...` I got a "could not find function" error.

With this change, I would have gotten it right on the first try.