### PR TITLE
add ci section to index use_travis and use_appeyor on pkgdown site

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -70,6 +70,10 @@ reference:
     contents:
     - matches("cran_comments|revdep")
     - use_version
+  - title: Continuous integration
+    contents:
+    - use_travis
+    - use_appveyor
   - title: Tidyverse development
     desc: >
       Conventions used in the tidyverse and r-lib organisations


### PR DESCRIPTION
This addresses issue #594. 

I took my best guess for where to place this section in the `_pkgdown.yml`. 

Also noting that the following are missing from the pkgdown index:
`Warning: Topics missing from index: git_sitrep, git_vaccinate, pr_init, use_citation, use_github_release, use_release_issue`