### PR TITLE
Re-export := in use_tidy_eval().

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -188,6 +188,8 @@ usethis gains tooling to manage part of a file. This currently used for managing
 
 * `use_tidy_description()` sets the `Encoding` field in `DESCRIPTION` 
   (#502, @krlmlr).
+  
+* `use_tidy_eval()` re-exports `:=` (#595, @jonthegeek).
 
 * `use_tidy_versions()` has source argument so that you can choose to use
   local or CRAN versions (#309).

--- a/inst/templates/tidy-eval.R
+++ b/inst/templates/tidy-eval.R
@@ -33,13 +33,13 @@
 #' @name     tidyeval
 #' @keywords internal
 #' @importFrom rlang quo quos enquo enquos quo_name sym ensym syms
-#'                   ensyms expr exprs enexpr enexprs .data
+#'                   ensyms expr exprs enexpr enexprs .data :=
 #' @aliases  quo quos enquo enquos quo_name
 #'           sym ensym syms ensyms
 #'           expr exprs enexpr enexprs
-#'           .data
+#'           .data :=
 #' @export   quo quos enquo enquos quo_name
 #' @export   sym ensym syms ensyms
 #' @export   expr enexpr enexprs
-#' @export   .data
+#' @export   .data :=
 NULL


### PR DESCRIPTION
Closes #595 .

I didn't add a test, because the current test doesn't actually check the contents of the file (only that it exists), and I was already a bit lost in how that test works. I can take a stab at a more specific test if you'd like, though.