### PR TITLE
Better approach to remote branches

### DIFF
--- a/R/git-utils.R
+++ b/R/git-utils.R
@@ -94,7 +94,7 @@ git_branch_exists <- function(branch) {
   branch %in% names(git2r::branches(repo))
 }
 
-git_branch_upstream <- function(branch = git_branch_name()) {
+git_branch_tracking <- function(branch = git_branch_name()) {
   b <- git_branch(name = branch)
   git2r::branch_get_upstream(b)$name
 }
@@ -112,23 +112,21 @@ git_branch_compare <- function(branch = git_branch_name()) {
   git2r::fetch(repo, "origin", refspec = branch, verbose = FALSE)
   git2r::ahead_behind(
     git_commit_find(branch),
-    git_commit_find(git_branch_upstream(branch))
+    git_commit_find(git_branch_tracking(branch))
   )
 }
 
 git_branch_push <- function(branch = git_branch_name(), force = FALSE) {
-  branch_obj <- git_branch(branch)
-
-  upstream <- git_branch_upstream(branch)
-  if (is.null(upstream)) {
+  remote <- git_branch_tracking(branch)
+  if (is.null(remote)) {
     remote_name   <- "origin"
     remote_branch <- branch
   } else {
-    remote_name   <- remref_remote(upstream)
-    remote_branch <- remref_branch(upstream)
+    remote_name   <- remref_remote(remote)
+    remote_branch <- remref_branch(remote)
   }
 
-  ui_done("Pushing local {ui_value(branch)} branch to {ui_value(upstream)}")
+  ui_done("Pushing local {ui_value(branch)} branch to {ui_value(remote)}")
   git2r::push(
     git_repo(),
     name = remote_name,

--- a/R/git-utils.R
+++ b/R/git-utils.R
@@ -37,6 +37,10 @@ git_remote_find <- function(rname = "origin") {
   remotes[[rname]]
 }
 
+git_remote_exists <- function(rname = "origin") {
+  rname %in% git_remotes()
+}
+
 # Commit ------------------------------------------------------------------
 
 git_commit_find <- function(refspec = NULL) {
@@ -95,8 +99,14 @@ git_branch_exists <- function(branch) {
 }
 
 git_branch_tracking <- function(branch = git_branch_name()) {
-  b <- git_branch(name = branch)
-  git2r::branch_get_upstream(b)$name
+  if (identical(branch, "master") && git_remote_exists("upstream")) {
+    # We always pretend that the master branch of a fork tracks the
+    # master branch in the source repo
+    "upstream/master"
+  } else {
+    b <- git_branch(name = branch)
+    git2r::branch_get_upstream(b)$name
+  }
 }
 
 git_branch_create <- function(branch, commit = NULL) {

--- a/R/git-utils.R
+++ b/R/git-utils.R
@@ -119,10 +119,12 @@ git_branch_switch <- function(branch) {
 
 git_branch_compare <- function(branch = git_branch_name()) {
   repo <- git_repo()
-  git2r::fetch(repo, "origin", refspec = branch, verbose = FALSE)
+
+  remref <- git_branch_tracking(branch)
+  git2r::fetch(repo, remref_remote(remref), refspec = branch, verbose = FALSE)
   git2r::ahead_behind(
     git_commit_find(branch),
-    git_commit_find(git_branch_tracking(branch))
+    git_commit_find(remref)
   )
 }
 

--- a/R/git.R
+++ b/R/git.R
@@ -160,7 +160,7 @@ git_sitrep <- function() {
   kv_line("Name", name)
   kv_line("Email", email)
   kv_line("Has SSH keys", git_has_ssh())
-  kv_line("Vaccinated: ", git_vaccinated())
+  kv_line("Vaccinated:", git_vaccinated())
 
   hd_line("git2r")
   kv_line("Supports SSH", git2r::libgit2_features()$ssh)
@@ -170,8 +170,8 @@ git_sitrep <- function() {
     if (uses_git()) {
       repo <- git_repo()
       kv_line("Path", repo$path)
-      kv_line("Branch", git_branch_name())
-      kv_line("Upstream", git_branch_upstream())
+      kv_line("Local branch", git_branch_name())
+      kv_line("Remote branch", git_branch_tracking())
     } else {
       cat_line("Git not activated")
     }

--- a/R/pr.R
+++ b/R/pr.R
@@ -118,14 +118,14 @@ pr_push <- function() {
   check_uncommitted_changes()
 
   branch <- git_branch_name()
-  has_upstream <- !is.null(git_branch_upstream(branch))
-  if (has_upstream) {
+  has_remote_branch <- !is.null(git_branch_tracking(branch))
+  if (has_remote_branch) {
     check_branch_current()
   }
 
   git_branch_push(branch)
 
-  if (!has_upstream) {
+  if (!has_remote_branch) {
     git_branch_track(branch)
   }
 
@@ -195,13 +195,13 @@ pr_url <- function(branch = git_branch_name()) {
     return(url)
   }
 
-  upstream <- git_branch_upstream(branch)
-  if (is.null(upstream)) {
+  remote_branch <- git_branch_tracking(branch)
+  if (is.null(remote_branch)) {
     pr_owner  <- github_owner()
     pr_branch <- branch
   } else {
-    pr_owner  <- remref_remote(upstream)
-    pr_branch <- remref_branch(upstream)
+    pr_owner  <- remref_remote(remote_branch)
+    pr_branch <- remref_branch(remote_branch)
   }
 
   urls <- pr_find(github_owner(), github_repo(), pr_owner, pr_branch)


### PR DESCRIPTION
This includes:

* `git_branch_remote()` -> `git_branch_tracking()`
* Pretending the master branch of a fork tracks `upstream/master` not `origin/master`
* Looking for the correct remote when checking a branch is up-to-date