### PR TITLE
Check file name for non-ascii characters and remove tolower() to ensure file name fidelity in use_test()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -183,6 +183,8 @@ usethis gains tooling to manage part of a file. This currently used for managing
 * `use_pkgdown()` is now configurable with site options (@jayhesselberth, #467),
   and no longer creates the `docs/` directory (#495).
 
+* `use_test()` no longer forces the filename to be lowercase (#613, @stufield).
+
 * `use_test()` will not include a `context()` in the generated file if used 
   with testthat 2.1.0 and above (the future release of testthat) (#325).
 

--- a/R/rmarkdown.R
+++ b/R/rmarkdown.R
@@ -19,7 +19,7 @@
 #' use_rmarkdown_template()
 #' }
 use_rmarkdown_template <- function(template_name = "Template Name",
-                                   template_dir = asciify(template_name),
+                                   template_dir = tolower(asciify(template_name)),
                                    template_description = "A description of the template",
                                    template_create_dir = FALSE) {
 

--- a/R/test.R
+++ b/R/test.R
@@ -13,10 +13,10 @@ use_testthat <- function() {
   check_installed("testthat")
 
   use_dependency("testthat", "Suggests")
-  use_directory("tests/testthat")
+  use_directory(path("tests", "testthat"))
   use_template(
     "testthat.R",
-    "tests/testthat.R",
+    save_as = path("tests", "testthat.R"),
     data = list(name = project_name())
   )
 }
@@ -60,16 +60,16 @@ use_test <- function(name = NULL, open = interactive()) {
 
   # As of testthat 2.1.0, a context() is no longer needed/wanted
   if (utils::packageVersion("testthat") >= "2.1.0") {
-    use_dependency("testthat", "suggests", "2.1.0")
+    use_dependency("testthat", "Suggests", "2.1.0")
     use_template(
       "test-example-2.1.R",
-      path,
+      save_as = path,
       open = open
     )
   } else {
     use_template(
       "test-example.R",
-      path,
+      save_as = path,
       data = list(test_name = path_ext_remove(name)),
       open = open
     )

--- a/R/test.R
+++ b/R/test.R
@@ -32,9 +32,24 @@ use_test <- function(name = NULL, open = interactive()) {
   }
 
   name <- name %||% get_active_r_file(path = "R")
+  check_file_name(name)
+  # REMOVE THIS PRIOR TO MERGE: #581
+  # if (is.null(name)) {
+  #   name <- get_active_r_file(path = "R")
+  #   if (!valid_file_name(fs::path_ext_remove(name))) {
+  #     warning(
+  #       stringr::str_glue(
+  #         "Active file contains non-ASCII characters.
+  #         Consider renaming file using only ASCII letters, numbers,
+  #         '-', and '_'."
+  #       ),
+  #       call. = FALSE)
+  #   }
+  # } else {
+  # }
+  # RM ABOVE -> issue #581
   name <- paste0("test-", name)
   name <- slug(name, "R")
-
   path <- path("tests", "testthat", name)
 
   if (file_exists(proj_path(path))) {

--- a/R/test.R
+++ b/R/test.R
@@ -30,23 +30,12 @@ use_test <- function(name = NULL, open = interactive()) {
     use_testthat()
   }
 
-  name <- name %||% get_active_r_file(path = "R")
-  check_file_name(name)
-  # REMOVE THIS PRIOR TO MERGE: #581
-  # if (is.null(name)) {
-  #   name <- get_active_r_file(path = "R")
-  #   if (!valid_file_name(fs::path_ext_remove(name))) {
-  #     warning(
-  #       stringr::str_glue(
-  #         "Active file contains non-ASCII characters.
-  #         Consider renaming file using only ASCII letters, numbers,
-  #         '-', and '_'."
-  #       ),
-  #       call. = FALSE)
-  #   }
-  # } else {
-  # }
-  # RM ABOVE -> issue #581
+  if (is.null(name)) {
+    name <- get_active_r_file(path = "R")
+  } else {
+    check_file_name(name)
+  }
+
   name <- paste0("test-", name)
   name <- slug(name, "R")
   path <- path("tests", "testthat", name)

--- a/R/test.R
+++ b/R/test.R
@@ -1,12 +1,11 @@
 #' Create tests
 #'
-#' `use_testthat()` sets up testing infrastructure, creating
-#' \file{tests/testthat.R} and \file{tests/testthat/}, and
-#' adding \pkg{testthat} to the suggested packages. `use_test()`
-#' creates \file{tests/testthat/test-<name>.R} and opens it for editing.
+#' `use_testthat()` sets up testing infrastructure, creating `tests/testthat.R`
+#' and `tests/testthat/`, and adding testthat as a Suggested package.
+#' `use_test()` creates `tests/testthat/test-<name>.R` and opens it for editing.
 #'
-#' @seealso The [testing chapter](http://r-pkgs.had.co.nz/tests.html) of [R
-#'   Packages](http://r-pkgs.had.co.nz).
+#' @seealso The [testing chapter](https://r-pkgs.org/tests.html) of [R
+#'   Packages](https://r-pkgs.org).
 #' @export
 #' @inheritParams use_template
 use_testthat <- function() {
@@ -23,8 +22,8 @@ use_testthat <- function() {
 }
 
 #' @rdname use_testthat
-#' @param name Test name. if `NULL`, and you're using RStudio, will use
-#'   the name of the file open in the source editor.
+#' @param name Base of test file name. If `NULL`, and you're using RStudio, will
+#'   be based on the name of the file open in the source editor.
 #' @export
 use_test <- function(name = NULL, open = interactive()) {
   if (!uses_testthat()) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -29,13 +29,11 @@ dots <- function(...) {
 
 asciify <- function(x) {
   stopifnot(is.character(x))
-
-  x <- tolower(x)
-  gsub("[^a-z0-9_-]+", "-", x)
+  gsub("[^a-zA-Z0-9_-]+", "-", x)
 }
 
 slug <- function(x, ext) {
-  x_base <- asciify(path_ext_remove(x))
+  x_base <- path_ext_remove(x)
   x_ext <- path_ext(x)
   ext <- if (identical(tolower(x_ext), tolower(ext))) x_ext else ext
   path_ext_set(x_base, ext)

--- a/man/use_rmarkdown_template.Rd
+++ b/man/use_rmarkdown_template.Rd
@@ -5,7 +5,7 @@
 \title{Add an RMarkdown Template}
 \usage{
 use_rmarkdown_template(template_name = "Template Name",
-  template_dir = asciify(template_name),
+  template_dir = tolower(asciify(template_name)),
   template_description = "A description of the template",
   template_create_dir = FALSE)
 }

--- a/man/use_testthat.Rd
+++ b/man/use_testthat.Rd
@@ -10,18 +10,17 @@ use_testthat()
 use_test(name = NULL, open = interactive())
 }
 \arguments{
-\item{name}{Test name. if \code{NULL}, and you're using RStudio, will use
-the name of the file open in the source editor.}
+\item{name}{Base of test file name. If \code{NULL}, and you're using RStudio, will
+be based on the name of the file open in the source editor.}
 
 \item{open}{Open the newly created file for editing? Happens in RStudio, if
 applicable, or via \code{\link[utils:file.edit]{utils::file.edit()}} otherwise.}
 }
 \description{
-\code{use_testthat()} sets up testing infrastructure, creating
-\file{tests/testthat.R} and \file{tests/testthat/}, and
-adding \pkg{testthat} to the suggested packages. \code{use_test()}
-creates \file{tests/testthat/test-<name>.R} and opens it for editing.
+\code{use_testthat()} sets up testing infrastructure, creating \code{tests/testthat.R}
+and \code{tests/testthat/}, and adding testthat as a Suggested package.
+\code{use_test()} creates \code{tests/testthat/test-<name>.R} and opens it for editing.
 }
 \seealso{
-The \href{http://r-pkgs.had.co.nz/tests.html}{testing chapter} of \href{http://r-pkgs.had.co.nz}{R Packages}.
+The \href{https://r-pkgs.org/tests.html}{testing chapter} of \href{https://r-pkgs.org}{R Packages}.
 }

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -9,8 +9,8 @@ test_that("check_is_named_list() works", {
   expect_error(check_is_named_list(list("a", b = 2)), "Names of .+ must be")
 })
 
-test_that("asciify() substitutes", {
-  expect_identical(asciify("aB!d$F+_h"), "ab-d-f-_h")
+test_that("asciify() substitutes non-ASCII but respects case", {
+  expect_identical(asciify("aB!d$F+_h"), "aB-d-F-_h")
 })
 
 test_that("slug() sets file extension, iff 'ext' not aleady the extension", {


### PR DESCRIPTION
Check file name for non-ascii characters, remove `asciify()` from `slug()`, remove `tolower()` from `asciify()` to ensure name fidelity, update unit tests accordingly.

Fixes #581