### PR TITLE
Fix #571 in_rstudio() returns FALSE if in RStudio and no active project

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -212,6 +212,10 @@ usethis gains tooling to manage part of a file. This currently used for managing
 * `use_vignette` now checks if the vignette name is valid (starts with letter 
   and consists of letters, numbers, hyphen, and underscore) and throws an error 
   if not (@akgold, #555).
+  
+* `restart_rstudio()` now returns `FALSE` in RStudio if no project is open,
+  fixing an issue that caused errors in helpers that suggest restarting 
+  RStudio (@gadenbuie, #571).
 
 # usethis 1.4.0
 

--- a/R/rstudio.R
+++ b/R/rstudio.R
@@ -106,6 +106,10 @@ in_rstudio <- function(base_path = proj_get()) {
 
   proj <- rstudioapi::getActiveProject()
 
+  if (is.null(proj)) {
+    return(FALSE)
+  }
+
   path_real(proj) == path_real(base_path)
 }
 


### PR DESCRIPTION
See discussion in https://github.com/r-lib/usethis/issues/571#issuecomment-459733807

This PR is a simple modification to `in_rstudio()` such that this function returns `FALSE` when called from an RStudio session without an active project.

In this case, `rstudioapi::getActiveProject()` returns `NULL`, which caused `path_real()` to throw an error.

```
Error in enc2utf8(path) : argument is not a character vector
```