### PR TITLE
adding https support in pr_* workflow

### DIFF
--- a/R/git-utils.R
+++ b/R/git-utils.R
@@ -307,11 +307,9 @@ git_has_ssh <- function() {
 
 git_credentials <- function(protocol = getOption("usethis.protocol", default = "ssh")) {
   if(protocol == "https") {
-    env_var <- Sys.getenv(c("GITHUB_PAT", "GITHUB_TOKEN"), unset = "", names = TRUE)
-    which_set  <- env_var != ""
-    if (any(which_set)) {
-      token_env <- names(env_var)[which_set][[1]]
-      git2r::cred_token(token = token_env)
+    token_var <- git_token_var()
+    if (token_var != "") {
+      git2r::cred_token(token = token_var)
     } else {
       ui_stop(
         "
@@ -323,4 +321,15 @@ git_credentials <- function(protocol = getOption("usethis.protocol", default = "
     # use default ssh from git2r
     NULL
   }
+}
+
+git_token_var <- function() {
+  env_var <- Sys.getenv(c("GITHUB_PAT", "GITHUB_TOKEN"), unset = "", names = TRUE)
+  which_set  <- nzchar(env_var)
+  if (any(which_set)) {
+    token_env <- names(env_var)[which_set][[1]]
+  } else {
+    token_env <- ""
+  }
+  token_env
 }

--- a/R/git-utils.R
+++ b/R/git-utils.R
@@ -9,14 +9,16 @@ git_init <- function() {
   git2r::init(proj_get())
 }
 
-git_pull <- function(remote_branch = git_branch_tracking()) {
+git_pull <- function(remote_branch = git_branch_tracking(),
+                     protocol = getOption("usethis.protocol", default = "ssh")) {
   repo <- git_repo()
 
   git2r::fetch(
     git_repo(),
     name = remref_remote(remote_branch),
     refspec = remref_branch(remote_branch),
-    verbose = FALSE
+    verbose = FALSE,
+    credentials = git_credentials(protocol)
   )
   mr <- git2r::merge(git_repo(), remote_branch)
   if (isTRUE(mr$conflicts)) {
@@ -136,18 +138,24 @@ git_branch_switch <- function(branch) {
   invisible(old)
 }
 
-git_branch_compare <- function(branch = git_branch_name()) {
+git_branch_compare <- function(branch = git_branch_name(),
+                               protocol = getOption("usethis.protocol", default = "ssh")) {
   repo <- git_repo()
 
   remref <- git_branch_tracking(branch)
-  git2r::fetch(repo, remref_remote(remref), refspec = branch, verbose = FALSE)
+  git2r::fetch(repo, remref_remote(remref),
+               refspec = branch,
+               verbose = FALSE,
+               credentials = git_credentials(protocol))
   git2r::ahead_behind(
     git_commit_find(branch),
     git_commit_find(remref)
   )
 }
 
-git_branch_push <- function(branch = git_branch_name(), force = FALSE) {
+git_branch_push <- function(branch = git_branch_name(),
+                            force = FALSE,
+                            protocol = getOption("usethis.protocol", default = "ssh")) {
   remote <- git_branch_tracking(branch)
   if (is.null(remote)) {
     remote_name   <- "origin"
@@ -163,7 +171,8 @@ git_branch_push <- function(branch = git_branch_name(), force = FALSE) {
     git_repo(),
     name = remote_name,
     refspec = glue("refs/heads/{branch}:refs/heads/{remote_branch}"),
-    force = force
+    force = force,
+    credentials = git_credentials(protocol)
   )
 }
 
@@ -303,4 +312,3 @@ git_credentials <- function(protocol = getOption("usethis.protocol", default = "
     NULL
   }
 }
-

--- a/R/git-utils.R
+++ b/R/git-utils.R
@@ -307,8 +307,20 @@ git_has_ssh <- function() {
 
 git_credentials <- function(protocol = getOption("usethis.protocol", default = "ssh")) {
   if(protocol == "https") {
-    git2r::cred_token(gh_token())
+    env_var <- Sys.getenv(c("GITHUB_PAT", "GITHUB_TOKEN"), unset = "", names = TRUE)
+    which_set  <- env_var != ""
+    if (any(which_set)) {
+      token_env <- names(env_var)[which_set][[1]]
+      git2r::cred_token(token = token_env)
+    } else {
+      ui_stop(
+        "
+        When using usethis with https protocol,
+        one of GITHUB_PAT or GITHUB_TOKEN environment variable must be set.
+        ")
+    }
   } else {
+    # use default ssh from git2r
     NULL
   }
 }

--- a/R/git-utils.R
+++ b/R/git-utils.R
@@ -296,3 +296,11 @@ git_has_ssh <- function() {
   )
 }
 
+git_credentials <- function(protocol = getOption("usethis.protocol", default = "ssh")) {
+  if(protocol == "https") {
+    git2r::cred_token(gh_token())
+  } else {
+    NULL
+  }
+}
+

--- a/R/git-utils.R
+++ b/R/git-utils.R
@@ -9,8 +9,7 @@ git_init <- function() {
   git2r::init(proj_get())
 }
 
-git_pull <- function(remote_branch = git_branch_tracking(),
-                     protocol = getOption("usethis.protocol", default = "ssh")) {
+git_pull <- function(remote_branch = git_branch_tracking()) {
   repo <- git_repo()
 
   git2r::fetch(
@@ -18,7 +17,7 @@ git_pull <- function(remote_branch = git_branch_tracking(),
     name = remref_remote(remote_branch),
     refspec = remref_branch(remote_branch),
     verbose = FALSE,
-    credentials = git_credentials(protocol)
+    credentials = git_credentials()
   )
   mr <- git2r::merge(git_repo(), remote_branch)
   if (isTRUE(mr$conflicts)) {
@@ -138,15 +137,14 @@ git_branch_switch <- function(branch) {
   invisible(old)
 }
 
-git_branch_compare <- function(branch = git_branch_name(),
-                               protocol = getOption("usethis.protocol", default = "ssh")) {
+git_branch_compare <- function(branch = git_branch_name()) {
   repo <- git_repo()
 
   remref <- git_branch_tracking(branch)
   git2r::fetch(repo, remref_remote(remref),
                refspec = branch,
                verbose = FALSE,
-               credentials = git_credentials(protocol))
+               credentials = git_credentials())
   git2r::ahead_behind(
     git_commit_find(branch),
     git_commit_find(remref)
@@ -154,8 +152,7 @@ git_branch_compare <- function(branch = git_branch_name(),
 }
 
 git_branch_push <- function(branch = git_branch_name(),
-                            force = FALSE,
-                            protocol = getOption("usethis.protocol", default = "ssh")) {
+                            force = FALSE) {
   remote <- git_branch_tracking(branch)
   if (is.null(remote)) {
     remote_name   <- "origin"
@@ -172,7 +169,7 @@ git_branch_push <- function(branch = git_branch_name(),
     name = remote_name,
     refspec = glue("refs/heads/{branch}:refs/heads/{remote_branch}"),
     force = force,
-    credentials = git_credentials(protocol)
+    credentials = git_credentials()
   )
 }
 
@@ -305,7 +302,8 @@ git_has_ssh <- function() {
   )
 }
 
-git_credentials <- function(protocol = getOption("usethis.protocol", default = "ssh")) {
+git_credentials <- function() {
+  protocol <- getOption("usethis.protocol", default = "ssh")
   if(protocol == "https") {
     token_var <- git_token_var()
     if (nzchar(token_var)) {

--- a/R/git-utils.R
+++ b/R/git-utils.R
@@ -308,7 +308,7 @@ git_has_ssh <- function() {
 git_credentials <- function(protocol = getOption("usethis.protocol", default = "ssh")) {
   if(protocol == "https") {
     token_var <- git_token_var()
-    if (token_var != "") {
+    if (nzchar(token_var)) {
       git2r::cred_token(token = token_var)
     } else {
       ui_stop(

--- a/R/git-utils.R
+++ b/R/git-utils.R
@@ -324,8 +324,11 @@ git_credentials <- function(protocol = getOption("usethis.protocol", default = "
 }
 
 git_token_var <- function() {
-  env_var <- Sys.getenv(c("GITHUB_PAT", "GITHUB_TOKEN"), unset = "", names = TRUE)
-  which_set  <- nzchar(env_var)
+  env_var <- Sys.getenv(
+    c("GITHUB_PAT", "GITHUB_TOKEN"),
+    unset = "",
+    names = TRUE)
+  which_set <- nzchar(env_var)
   if (any(which_set)) {
     token_env <- names(env_var)[which_set][[1]]
   } else {

--- a/R/git.R
+++ b/R/git.R
@@ -161,6 +161,7 @@ git_sitrep <- function() {
   kv_line("Email", email)
   kv_line("Has SSH keys", git_has_ssh())
   kv_line("Vaccinated:", git_vaccinated())
+  kv_line("Default protocol:", getOption("usethis.protocol", default = "ssh"))
 
   hd_line("git2r")
   kv_line("Supports SSH", git2r::libgit2_features()$ssh)

--- a/R/pr.R
+++ b/R/pr.R
@@ -102,6 +102,7 @@ pr_fetch <- function(number, owner = NULL) {
 
   if (!remote %in% git2r::remotes(git_repo())) {
     ui_done("Adding remote {ui_value(remote)}")
+    protocol <- getOption("usethis.protocol", default = "ssh")
     remote_url <- if(protocol == "https") {
       pr$head$repo$clone_url
     } else {

--- a/R/pr.R
+++ b/R/pr.R
@@ -74,13 +74,6 @@ pr_init <- function(branch) {
 #'   pull request. Default of `NULL` tries to identify the source repo and uses
 #'   the owner of the `upstream` remote, if present, or the owner of `origin`
 #'   otherwise.
-#' @param protocol transfer protocol, either "ssh" (the default) or "https".
-#'   You can supply a global default with `options(usethis.protocol = "https")`.
-#'
-#'     * if "ssh", the remote url used will be shh one and the ssh key will be
-#'     used as credentials
-#'     * if "https, the remote url used will be https and
-#'     the credentials used will be GITHUB_PAT environment variable..
 #'
 #' @examples
 #' \dontrun{
@@ -88,9 +81,8 @@ pr_init <- function(branch) {
 #' ## 'tidyverse', not you
 #' pr_fetch(123, owner = "tidyverse")
 #' }
-pr_fetch <- function(number, owner = NULL, protocol = getOption("usethis.protocol", default = "ssh")) {
+pr_fetch <- function(number, owner = NULL) {
   check_uncommitted_changes()
-  protocol <- rlang::arg_match(protocol, c("ssh", "https"))
   ui_done("Retrieving data for PR #{number}")
   pr <- gh::gh("GET /repos/:owner/:repo/pulls/:number",
     owner = owner %||% github_source() %||% github_owner(),
@@ -125,7 +117,7 @@ pr_fetch <- function(number, owner = NULL, protocol = getOption("usethis.protoco
     git2r::fetch(git_repo(), remote,
                  refspec = their_branch,
                  verbose = FALSE,
-                 credentials = git_credentials(protocol)
+                 credentials = git_credentials()
     )
     git_branch_create(our_branch, their_refname)
 

--- a/R/pr.R
+++ b/R/pr.R
@@ -74,6 +74,13 @@ pr_init <- function(branch) {
 #'   pull request. Default of `NULL` tries to identify the source repo and uses
 #'   the owner of the `upstream` remote, if present, or the owner of `origin`
 #'   otherwise.
+#' @param protocol transfer protocol, either "ssh" (the default) or "https".
+#'   You can supply a global default with `options(usethis.protocol = "https")`.
+#'
+#'     * if "ssh", the remote url used will be shh one and the ssh key will be
+#'     used as credentials
+#'     * if "https, the remote url used will be https and
+#'     the credentials used will be GITHUB_PAT environment variable..
 #'
 #' @examples
 #' \dontrun{
@@ -81,9 +88,9 @@ pr_init <- function(branch) {
 #' ## 'tidyverse', not you
 #' pr_fetch(123, owner = "tidyverse")
 #' }
-pr_fetch <- function(number, owner = NULL) {
+pr_fetch <- function(number, owner = NULL, protocol = getOption("usethis.protocol", default = "ssh")) {
   check_uncommitted_changes()
-
+  protocol = rlang::arg_match(protocol, c("ssh", "https"))
   ui_done("Retrieving data for PR #{number}")
   pr <- gh::gh("GET /repos/:owner/:repo/pulls/:number",
     owner = owner %||% github_source() %||% github_owner(),
@@ -103,14 +110,25 @@ pr_fetch <- function(number, owner = NULL) {
 
   if (!remote %in% git2r::remotes(git_repo())) {
     ui_done("Adding remote {ui_value(remote)}")
-    git2r::remote_add(git_repo(), remote, pr$head$repo$ssh_url)
+    remote_url <- if(protocol == "ssh") {
+      pr$head$repo$ssh_url
+    } else if (protocol == "https") {
+      pr$head$repo$clone_url
+    }
+    git2r::remote_add(git_repo(), remote, remote_url)
   }
 
   if (!git_branch_exists(our_branch)) {
     their_refname <- git_remref(remote, their_branch)
 
     ui_done("Creating local branch {ui_value(our_branch)}")
-    git2r::fetch(git_repo(), remote, refspec = their_branch, verbose = FALSE)
+    cred <- if(protocol == "https") {
+      git2r::cred_token("GITHUB_PAT")
+    } else {
+      NULL
+    }
+    git2r::fetch(git_repo(), remote, refspec = their_branch,
+                 verbose = FALSE, credentials = cred)
     git_branch_create(our_branch, their_refname)
 
     git_branch_track(our_branch, remote, their_branch)

--- a/man/pr_init.Rd
+++ b/man/pr_init.Rd
@@ -14,7 +14,8 @@
 \usage{
 pr_init(branch)
 
-pr_fetch(number, owner = NULL)
+pr_fetch(number, owner = NULL, protocol = getOption("usethis.protocol",
+  default = "ssh"))
 
 pr_push()
 
@@ -40,6 +41,13 @@ numbers, and \code{-}.}
 pull request. Default of \code{NULL} tries to identify the source repo and uses
 the owner of the \code{upstream} remote, if present, or the owner of \code{origin}
 otherwise.}
+
+\item{protocol}{transfer protocol, either "ssh" (the default) or "https".
+You can supply a global default with \code{options(usethis.protocol = "https")}.\preformatted{* if "ssh", the remote url used will be shh one and the ssh key will be
+used as credentials
+* if "https, the remote url used will be https and
+the credentials used will be GITHUB_PAT environment variable..
+}}
 }
 \description{
 The \code{pr_*} family of functions are designed to make working with GitHub

--- a/man/pr_init.Rd
+++ b/man/pr_init.Rd
@@ -14,8 +14,7 @@
 \usage{
 pr_init(branch)
 
-pr_fetch(number, owner = NULL, protocol = getOption("usethis.protocol",
-  default = "ssh"))
+pr_fetch(number, owner = NULL)
 
 pr_push()
 
@@ -41,13 +40,6 @@ numbers, and \code{-}.}
 pull request. Default of \code{NULL} tries to identify the source repo and uses
 the owner of the \code{upstream} remote, if present, or the owner of \code{origin}
 otherwise.}
-
-\item{protocol}{transfer protocol, either "ssh" (the default) or "https".
-You can supply a global default with \code{options(usethis.protocol = "https")}.\preformatted{* if "ssh", the remote url used will be shh one and the ssh key will be
-used as credentials
-* if "https, the remote url used will be https and
-the credentials used will be GITHUB_PAT environment variable..
-}}
 }
 \description{
 The \code{pr_*} family of functions are designed to make working with GitHub


### PR DESCRIPTION
To contribute in discussion in #533, here are the modification I made in this 📦 so that I can use `pr_*` functions on my windows computer where I use only https remote and github token credential.

There is a few commits because I tried several approach (like passing protocol in all functions) but I have made simpler at the end. Everything is based on the fact that 
* Default behaviour is for `ssh`
* `https` can be use if option `usethis.protocol = "https"` is set. In this case, everything in usethis will not use ssh but http
    * remote creation
    * git credentials in git2r using GITHUB_PAT or GITHUB_TOKEN, both supported by usethis

Mainly there was those two main point to deal with
* remote must be created using `clone_url` not `shh_url`
* credentials must be pass to `git2r` functions through the `credentials` argument, and created with one of `cred_*` functions from `git2r` 📦 

On other approach I had in mind was only take care that usethis creates remote using https not ssh url and that after, credentials must be provide as an option to the package using any of the ones supported in `git2r`. I stayed for now with my fist approach. 

So, this is currently working for me to contribute using usethis and https remote. 

It is note perfect yet but hoping this can contribute to the work on this topic. If you find it interesting and want to build on this PR, please tell me and I can work more to improve it, and maybe make it more clever that just defining behavior from an option.  