### PR TITLE
Embed release type in use_version() call

### DIFF
--- a/R/release.R
+++ b/R/release.R
@@ -63,7 +63,7 @@ release_checklist <- function(version) {
     "",
     "Submit to CRAN:",
     "",
-    todo("`usethis::use_version()`"),
+    todo("`usethis::use_version('{type}')`"),
     todo("Update `cran-comments.md`"),
     todo("`devtools::submit_cran()`"),
     todo("Approve email"),


### PR DESCRIPTION
We still have a problem that `use_version()` doesn't quite have the right semantics — it adds a new heading to NEWS instead of replacing the existing.