### PR TITLE
Set NOT_CRAN environmental variable

### DIFF
--- a/inst/templates/appveyor.yml
+++ b/inst/templates/appveyor.yml
@@ -13,6 +13,9 @@ install:
 cache:
   - C:\RLibrary
 
+environment:
+  NOT_CRAN: true
+
 # Adapt as necessary starting from here
 
 build_script:


### PR DESCRIPTION
Currently this is not set, leading to `testthat::skip_on_cran()` to also skip tests on Appveyor.  Users should explicitly use `skip_on_appveyor()` to also skip appveyor tests. Closes #641. 