### PR TITLE
Add pr_*() family to the pkgdown function-references

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -102,6 +102,9 @@ reference:
     - use_readme_rmd
     - matches("browse")
     - matches("edit_git_")
+  - title: Pull requests
+    contents:
+    - starts_with("pr_")
   - title: Edit
     contents:
     - starts_with("edit_")


### PR DESCRIPTION
I don't know if this is premature or not, but it will help me find the reference more-easily on the dev pkgdown site.