### PR TITLE
Fix typo

### DIFF
--- a/R/git.R
+++ b/R/git.R
@@ -260,7 +260,7 @@ git_sitrep <- function() {
   kv_line("Email", email)
   kv_line("Protocol", getOption("usethis.protocol"))
   kv_line("Has SSH keys", git_has_ssh())
-  kv_line("Vaccinated:", git_vaccinated())
+  kv_line("Vaccinated", git_vaccinated())
 
   hd_line("git2r")
   kv_line("Supports SSH", git2r::libgit2_features()$ssh)


### PR DESCRIPTION
There is/was an extra `:`