### PR TITLE
Remove leading dots in extension arguments to `fs::file_temp()`

### DIFF
--- a/tests/testthat/test-use-course.R
+++ b/tests/testthat/test-use-course.R
@@ -128,19 +128,19 @@ test_that("top_directory() identifies a unique top directory (or not)", {
 })
 
 test_that("tidy_unzip() deals with loose parts, reports unpack destination", {
-  tmp <- file_temp(ext = ".zip")
+  tmp <- file_temp(ext = "zip")
   file_copy(test_file("yo-loose-regular.zip"), tmp)
   dest <- tidy_unzip(tmp)
   loose_regular_files <- path_file(dir_ls(dest, recursive = TRUE))
   dir_delete(dest)
 
-  tmp <- file_temp(ext = ".zip")
+  tmp <- file_temp(ext = "zip")
   file_copy(test_file("yo-loose-dropbox.zip"), tmp)
   dest <- tidy_unzip(tmp)
   loose_dropbox_files <- path_file(dir_ls(dest, recursive = TRUE))
   dir_delete(dest)
 
-  tmp <- file_temp(ext = ".zip")
+  tmp <- file_temp(ext = "zip")
   file_copy(test_file("yo-not-loose.zip"), tmp)
   dest <- tidy_unzip(tmp)
   not_loose_files <- path_file(dir_ls(dest, recursive = TRUE))


### PR DESCRIPTION
With the current CRAN release of fs, passing a leading dot results in a
doubled dot.

    path_file(file_temp(ext = ".txt"))
    #> file4c8b5cc4167..txt
    path_file(file_temp(ext = "txt"))
    #> file4c8bb172736.txt

However this will be fixed by the upcoming release of fs, so that any leading
dots are ignored, so `ext = ".txt` and `ext = "txt"` will be equivalent.

    path_file(file_temp(ext = ".txt"))
    #> file4c8b24d9d42a.txt
    path_file(file_temp(ext = "txt"))
    #> file4c8b58f8244c.txt

Nonetheless I think it is best practice to supply the extension without
a dot, as I am pretty sure this was just a mistake when porting the
usethis code from using `tempfile()`.