### PR TITLE
filesystem-dialog for create_from_github()

### DIFF
--- a/R/create.R
+++ b/R/create.R
@@ -144,8 +144,8 @@ create_from_github <- function(repo_spec,
 
     choice <- utils::menu(
       choices = c(
-        "filesystem dialog",
-        glue::glue("default location: {ui_value(conspicuous_place())}")
+        "Filesystem dialog",
+        glue::glue("Default location: {ui_value(conspicuous_place())}")
       ),
       title = "Choose parent directory of project-directory using:"
     )

--- a/R/create.R
+++ b/R/create.R
@@ -141,16 +141,32 @@ create_from_github <- function(repo_spec,
                                host = NULL) {
 
   if (interactive() && is.null(destdir)) {
-    # TODO: on my mac, the output of ui_todo() is rendered *after*
-    #   rstudioapi::selectDirectory() finishes.
-    #   - would like it to render before selectDirectory() starts
-    ui_todo("Select directory where project-directory will be created")
-    caption <- "Create Project as Subdirectory of"
-    destdir <- rstudioapi::selectDirectory(caption = caption)
 
-    if (is.null(destdir)) {
-      ui_stop("directory-selection cancelled")
+    choice <- utils::menu(
+      choices = c(
+        "filesystem dialog",
+        glue::glue("default location: {ui_value(conspicuous_place())}")
+      ),
+      title = "Choose parent directory of project-directory using:"
+    )
+
+    # if user exits, treat as cancelling entire transaction
+    if (identical(choice, 0L)) {
+      ui_stop("cancelled")
     }
+
+    if (identical(choice, 1L)) {
+      # specify destdir using filsesystem dialog
+      caption <- "Create Project as Subdirectory of"
+      destdir <- rstudioapi::selectDirectory(caption = caption)
+
+      # if user hits cancel, treat as cancelling entire transaction
+      if (is.null(destdir)) {
+        ui_stop("directory-selection cancelled")
+      }
+    }
+
+    # choosing "default location" passes through
   }
 
   destdir <- user_path_prep(destdir %||% conspicuous_place())

--- a/R/create.R
+++ b/R/create.R
@@ -139,6 +139,20 @@ create_from_github <- function(repo_spec,
                                credentials = NULL,
                                auth_token = NULL,
                                host = NULL) {
+
+  if (interactive() && is.null(destdir)) {
+    # TODO: on my mac, the output of ui_todo() is rendered *after*
+    #   rstudioapi::selectDirectory() finishes.
+    #   - would like it to render before selectDirectory() starts
+    ui_todo("Select directory where project-directory will be created")
+    caption <- "Create Project as Subdirectory of"
+    destdir <- rstudioapi::selectDirectory(caption = caption)
+
+    if (is.null(destdir)) {
+      ui_stop("directory-selection cancelled")
+    }
+  }
+
   destdir <- user_path_prep(destdir %||% conspicuous_place())
   check_path_is_directory(destdir)
 


### PR DESCRIPTION
This PR addresses #664, to allow you to specify `destdir` using the filesystem dialog, for `create_from_github()`. 

At this point, just a first pass to see if there are any objections or other initial reactions.

If this were extended to `create_project()`, `create_package()`, or `use_course()`, I could see extracting this into its own internal-function.

I'm assuming that as a draft PR, you can react - if not, I'll be happy to change it to a "real" PR