### PR TITLE
Anticipate PR branch names that contain a slash

### DIFF
--- a/R/git-utils.R
+++ b/R/git-utils.R
@@ -79,6 +79,7 @@ git_remref <- function(remote = "origin", branch = "master") {
 
 ## remref --> remote, branch
 git_parse_remref <- function(remref) {
+  ## changes coming here!
   remref_split <- strsplit(remref, "/")[[1]]
   if (length(remref_split) != 2) {
     ui_stop("{ui_code('rmref')} must be of form {ui_value('remote/branch')}.")

--- a/R/git-utils.R
+++ b/R/git-utils.R
@@ -79,12 +79,11 @@ git_remref <- function(remote = "origin", branch = "master") {
 
 ## remref --> remote, branch
 git_parse_remref <- function(remref) {
-  ## changes coming here!
-  remref_split <- strsplit(remref, "/")[[1]]
-  if (length(remref_split) != 2) {
-    ui_stop("{ui_code('rmref')} must be of form {ui_value('remote/branch')}.")
-  }
-  list(remote = remref_split[[1]], branch = remref_split[[2]])
+  repo <- git_repo()
+  rnames <- git2r::remotes(repo)
+  rnames <- paste0("^", rnames, collapse = "|")
+  regex <- glue("({rnames})/(.*)")
+  list(remote = sub(regex, "\\1", remref), branch = sub(regex, "\\2", remref))
 }
 
 remref_remote <- function(remref) git_parse_remref(remref)$remote


### PR DESCRIPTION
Creating a branch with a slash in the name in order to fix #670