### PR TITLE
Refactor handling of GitHub token

### DIFF
--- a/R/create.R
+++ b/R/create.R
@@ -241,24 +241,21 @@ check_not_nested <- function(path, name) {
 }
 
 rationalize_fork <- function(fork, repo_info, auth_token) {
-  perms <- repo_info$permissions
-  owner <- repo_info$owner$login
+  have_token <- have_github_token(auth_token)
+  can_push <- isTRUE(repo_info$permissions)
+  repo_owner <- repo_info$owner$login
+  user <- if (have_token) github_user(auth_token)[["login"]]
 
   if (is.na(fork)) {
-    fork <- have_github_token(auth_token) && !isTRUE(perms$push)
+    fork <- have_token && !can_push
   }
 
-  if (fork && !have_github_token(auth_token)) {
+  if (fork && !have_token) {
     ## throw the usual error for bad/missing token
     validate_github_token(auth_token)
   }
 
-  user <- if (have_github_token(auth_token)) {
-    github_user(auth_token)[["login"]]
-  } else {
-    NULL
-  }
-  if (fork && identical(user, owner)) {
+  if (fork && identical(user, repo_owner)) {
     ui_stop(
       "Repo {ui_value(repo_info$full_name)} is owned by user \\
       {ui_value(user)}. Can't fork."

--- a/R/create.R
+++ b/R/create.R
@@ -150,7 +150,7 @@ create_from_github <- function(repo_spec,
   create_directory(repo_path)
   check_directory_is_empty(repo_path)
 
-  auth_token <- maybe_github_token(auth_token)
+  auth_token <- check_github_token(auth_token, allow_empty = TRUE)
 
   gh <- function(endpoint, ...) {
     gh::gh(
@@ -252,7 +252,7 @@ rationalize_fork <- function(fork, repo_info, auth_token) {
 
   if (fork && !have_token) {
     ## throw the usual error for bad/missing token
-    validate_github_token(auth_token)
+    check_github_token(auth_token)
   }
 
   if (fork && identical(user, repo_owner)) {

--- a/R/git.R
+++ b/R/git.R
@@ -342,9 +342,8 @@ git2r_credentials <- function(protocol = git_protocol(),
     return(NULL)
   }
 
-  if (nzchar(auth_token)) {
-    check_github_token(auth_token)
-    git2r::cred_user_pass("EMAIL", auth_token)
+  if (have_github_token(auth_token)) {
+    git2r::cred_user_pass("EMAIL", validate_github_token(auth_token))
   } else {
     NULL
   }
@@ -404,20 +403,19 @@ git_sitrep <- function() {
   }
 
   hd_line("GitHub")
-  if (!nzchar(github_token())) {
-    cat_line("No token available")
-  } else {
+  if (have_github_token()) {
+    ui_done("Personal access token found in env var")
     who <- github_user()
     if (is.null(who)) {
-      cat_line("Token not associated with a user")
+      cat_line("Token is invalid")
     } else {
-      ui_done("GitHub personal access token found")
       kv_line("User", who$login)
       kv_line("Name", who$name)
     }
+  } else {
+    cat_line("No personal access token found")
   }
 }
-
 
 # Vaccination -------------------------------------------------------------
 

--- a/R/git.R
+++ b/R/git.R
@@ -343,7 +343,7 @@ git2r_credentials <- function(protocol = git_protocol(),
   }
 
   if (have_github_token(auth_token)) {
-    git2r::cred_user_pass("EMAIL", validate_github_token(auth_token))
+    git2r::cred_user_pass("EMAIL", check_github_token(auth_token))
   } else {
     NULL
   }

--- a/R/github-labels.R
+++ b/R/github-labels.R
@@ -65,7 +65,7 @@ use_github_labels <- function(repo_spec = github_repo_spec(),
                               auth_token = github_token(),
                               host = NULL) {
   check_uses_github()
-  validate_github_token(auth_token)
+  check_github_token(auth_token)
 
   gh <- function(endpoint, ...) {
     out <- gh::gh(

--- a/R/github-labels.R
+++ b/R/github-labels.R
@@ -65,6 +65,7 @@ use_github_labels <- function(repo_spec = github_repo_spec(),
                               auth_token = github_token(),
                               host = NULL) {
   check_uses_github()
+  validate_github_token(auth_token)
 
   gh <- function(endpoint, ...) {
     out <- gh::gh(

--- a/R/github-utils.R
+++ b/R/github-utils.R
@@ -72,10 +72,3 @@ parse_github_remotes <- function(x) {
   match <- stats::setNames(regmatches(as.character(x), m), names(x))
   lapply(match, function(y) list(owner = y[[2]], repo = y[[3]]))
 }
-
-github_user <- function(auth_token = github_token()) {
-  if (!nzchar(auth_token)) {
-    return(NULL)
-  }
-  tryCatch(gh::gh_whoami(auth_token), error = function(e) NULL)
-}

--- a/R/github.R
+++ b/R/github.R
@@ -327,7 +327,7 @@ check_github_token <- function(auth_token = github_token(),
     ))
   }
 
-  if (!is_string(auth_token)) {
+  if (!is_string(auth_token) || is.na(auth_token)) {
     local_stop("GitHub {ui_code('auth_token')} must be a single string.")
   }
   if (!have_github_token(auth_token)) {

--- a/R/github.R
+++ b/R/github.R
@@ -308,17 +308,16 @@ check_no_github_repo <- function(owner, repo, host, auth_token) {
 
 # github token helpers ----------------------------------------------------
 
-## minimal check: token is not ""
+## minimal check: token is not the value that means "we have no PAT",
+## which is currently the empty string "", for compatibility with gh
 have_github_token <- function(auth_token = github_token()) {
   !isTRUE(auth_token == "")
 }
 
-## if allow_empty, tolerate ""
-## else do rigorous checks, including against the GitHub API
 check_github_token <- function(auth_token = github_token(),
                                allow_empty = FALSE) {
   if (allow_empty && !have_github_token(auth_token)) {
-    return("")
+    return(auth_token)
   }
 
   local_stop <- function(msg) {
@@ -328,19 +327,15 @@ check_github_token <- function(auth_token = github_token(),
     ))
   }
 
-  if (length(auth_token) != 1) {
+  if (!is_string(auth_token)) {
     local_stop("GitHub {ui_code('auth_token')} must be a single string.")
   }
-  if (!is_string(auth_token)) {
-    bad_class <- paste(class(auth_token), collapse = "/")
-    local_stop("GitHub {ui_code('auth_token')} must be character, not {bad_class}.")
-  }
-  if (isTRUE(auth_token == "")) {
+  if (!have_github_token(auth_token)) {
     local_stop("No GitHub {ui_code('auth_token')} is available.")
   }
   user <- github_user(auth_token)
   if (is.null(user)) {
-    local_stop("GitHub {ui_code('auth_token')} is not associated with a user.")
+    local_stop("GitHub {ui_code('auth_token')} is invalid.")
   }
   auth_token
 }

--- a/R/github.R
+++ b/R/github.R
@@ -47,7 +47,7 @@ use_github <- function(organisation = NULL,
   check_branch("master")
   check_uncommitted_changes()
   check_no_origin()
-  validate_github_token(auth_token)
+  check_github_token(auth_token)
 
   credentials <- credentials %||% git2r_credentials(protocol, auth_token)
   r <- git_repo()
@@ -165,7 +165,7 @@ use_github_links <- function(auth_token = github_token(),
     owner = github_owner(),
     repo = github_repo(),
     .api_url = host,
-    .token = maybe_github_token(auth_token)
+    .token = check_github_token(auth_token, allow_empty = TRUE)
   )
 
   use_description_field("URL", res$html_url, overwrite = overwrite)
@@ -313,16 +313,14 @@ have_github_token <- function(auth_token = github_token()) {
   !isTRUE(auth_token == "")
 }
 
-## tolerate "", but explicitly validate the token otherwise
-maybe_github_token <- function(auth_token = github_token()) {
-  if (!have_github_token(auth_token)) {
+## if allow_empty, tolerate ""
+## else do rigorous checks, including against the GitHub API
+check_github_token <- function(auth_token = github_token(),
+                               allow_empty = FALSE) {
+  if (allow_empty && !have_github_token(auth_token)) {
     return("")
   }
-  validate_github_token(auth_token)
-}
 
-## rigorous checks, including against the GitHub API
-validate_github_token <- function(auth_token = github_token()) {
   local_stop <- function(msg) {
     ui_stop(c(
       msg,

--- a/R/github.R
+++ b/R/github.R
@@ -337,6 +337,9 @@ validate_github_token <- function(auth_token = github_token()) {
     bad_class <- paste(class(auth_token), collapse = "/")
     local_stop("GitHub {ui_code('auth_token')} must be character, not {bad_class}.")
   }
+  if (isTRUE(auth_token == "")) {
+    local_stop("No GitHub {ui_code('auth_token')} is available.")
+  }
   user <- github_user(auth_token)
   if (is.null(user)) {
     local_stop("GitHub {ui_code('auth_token')} is not associated with a user.")

--- a/R/pr.R
+++ b/R/pr.R
@@ -93,7 +93,7 @@ pr_fetch <- function(number,
   check_uses_github()
   check_uncommitted_changes()
 
-  auth_token <- maybe_github_token()
+  auth_token <- check_github_token(allow_empty = TRUE)
 
   owner <- owner %||% github_owner_upstream() %||% github_owner()
   repo <- github_repo()
@@ -320,7 +320,7 @@ pr_find <- function(owner,
     owner = owner,
     repo = repo,
     .limit = Inf,
-    .token = maybe_github_token()
+    .token = check_github_token(allow_empty = TRUE)
   )
 
   if (identical(prs[[1]], "")) {

--- a/R/pr.R
+++ b/R/pr.R
@@ -93,11 +93,7 @@ pr_fetch <- function(number,
   check_uses_github()
   check_uncommitted_changes()
 
-  auth_token <- github_token()
-  check_github_token(auth_token)
-
-  protocol <- github_remote_protocol()
-  credentials <- git2r_credentials(protocol, auth_token)
+  auth_token <- maybe_github_token()
 
   owner <- owner %||% github_owner_upstream() %||% github_owner()
   repo <- github_repo()
@@ -125,6 +121,8 @@ pr_fetch <- function(number,
     our_branch <- glue("{them}-{their_branch}")
   }
 
+  protocol <- github_remote_protocol()
+
   if (!remote %in% git2r::remotes(git_repo())) {
     url <- switch(
       protocol,
@@ -137,7 +135,7 @@ pr_fetch <- function(number,
 
   if (!git_branch_exists(our_branch)) {
     their_refname <- git_remref(remote, their_branch)
-
+    credentials <- git2r_credentials(protocol, auth_token)
     ui_done("Creating local branch {ui_value(our_branch)}")
     git2r::fetch(
       git_repo(),
@@ -322,7 +320,7 @@ pr_find <- function(owner,
     owner = owner,
     repo = repo,
     .limit = Inf,
-    .token = github_token()
+    .token = maybe_github_token()
   )
 
   if (identical(prs[[1]], "")) {

--- a/R/release.R
+++ b/R/release.R
@@ -111,7 +111,7 @@ use_github_release <- function(host = NULL,
 
   check_uses_github()
   check_branch_pushed()
-  validate_github_token(auth_token)
+  check_github_token(auth_token)
 
   package <- package_data()
 

--- a/R/release.R
+++ b/R/release.R
@@ -111,6 +111,7 @@ use_github_release <- function(host = NULL,
 
   check_uses_github()
   check_branch_pushed()
+  validate_github_token(auth_token)
 
   package <- package_data()
 

--- a/tests/manual/manual-create-from-github-https-private-repo.R
+++ b/tests/manual/manual-create-from-github-https-private-repo.R
@@ -17,8 +17,12 @@ repo_name <- "crewsocks"
 use_git_protocol("https")
 git_protocol()
 
+## remove any pre-existing repo
+dir_delete(path(conspicuous_place(), repo_name))
+expect_false(dir_exists(path(conspicuous_place(), repo_name)))
+
 ## this should work
-x <- create_from_github(paste0(user, "/", repo_name))
+x <- create_from_github(paste0(user, "/", repo_name), open = FALSE)
 
 expect_equal(path_file(x), "crewsocks")
 expect_true(dir_exists(x))

--- a/tests/manual/manual-create-from-github.R
+++ b/tests/manual/manual-create-from-github.R
@@ -7,7 +7,7 @@ library(fs)
 ## the day I made this, i.e., it's totally arbitrary
 
 ## make sure local copy does not exist; this will error if doesn't pre-exist
-dir_delete("~/Desktop/TailRank/")
+dir_delete(path(conspicuous_place(), "TailRank"))
 
 ## check that a GitHub PAT is configured
 gh::gh_whoami()
@@ -22,48 +22,48 @@ gh::gh_whoami()
 #     privatekey = fs::path_home(".ssh/id_rsa")
 #   )
 # }
-create_from_github("cran/TailRank", fork = FALSE)
-dir_delete("~/Desktop/TailRank/")
+create_from_github("cran/TailRank", fork = FALSE, open = FALSE)
+dir_delete(path(conspicuous_place(), "TailRank"))
 
 ## create from repo I do not have push access to
 ## fork = TRUE
-create_from_github("cran/TailRank", fork = TRUE)
+create_from_github("cran/TailRank", fork = TRUE, open = FALSE)
 ## fork and clone --> should see origin and upstream remotes
 expect_setequal(
-  git2r::remotes(git2r::repository("~/Desktop/TailRank/")),
+  git2r::remotes(git2r::repository(path(conspicuous_place(), "TailRank"))),
   c("origin", "upstream")
 )
-dir_delete("~/Desktop/TailRank/")
+dir_delete(path(conspicuous_place(), "TailRank"))
 
 ## create from repo I do not have push access to
 ## fork = NA
-create_from_github("cran/TailRank", fork = NA)
+create_from_github("cran/TailRank", fork = NA, open = FALSE)
 ## fork and clone --> should see origin and upstream remotes
 expect_setequal(
-  git2r::remotes(git2r::repository("~/Desktop/TailRank/")),
+  git2r::remotes(git2r::repository(path(conspicuous_place(), "TailRank"))),
   c("origin", "upstream")
 )
-dir_delete("~/Desktop/TailRank/")
+dir_delete(path(conspicuous_place(), "TailRank"))
 
 ## a repo I created just for testing, make sure local copy doesn't pre-exist
-dir_delete("~/Desktop/ethel/")
+dir_delete(path(conspicuous_place(), "ethel"))
 
 ## create from repo I DO have push access to
 ## fork = FALSE
-create_from_github("jennybc/ethel", fork = FALSE)
+create_from_github("jennybc/ethel", fork = FALSE, open = FALSE)
 ## go make a local edit and push to confirm origin remote is properly setup
-dir_delete("~/Desktop/ethel")
+dir_delete(path(conspicuous_place(), "ethel"))
 
 ## create from repo I do have push access to
 ## fork = TRUE
-create_from_github("jennybc/ethel", fork = TRUE)
+create_from_github("jennybc/ethel", fork = TRUE, open = FALSE)
 ## expect error because I own it and can't fork it
 
 ## create from repo I do have push access to
 ## fork = NA
-create_from_github("jennybc/ethel", fork = NA)
+create_from_github("jennybc/ethel", fork = NA, open = FALSE)
 ## gets created, as clone but no fork
-dir_delete("~/Desktop/ethel")
+dir_delete(path(conspicuous_place(), "ethel"))
 
 ## store my PAT
 token <- github_token()
@@ -72,36 +72,36 @@ token <- github_token()
 Sys.unsetenv(c("GITHUB_PAT", "GITHUB_TOKEN"))
 gh::gh_whoami()
 
-dir_delete("~/Desktop/TailRank/")
+dir_delete(path(conspicuous_place(), "TailRank"))
 
 ## create from repo I do not have push access to
 ## fork = FALSE
-create_from_github("cran/TailRank", fork = FALSE)
+create_from_github("cran/TailRank", fork = FALSE, open = FALSE)
 ## created, clone, origin remote is cran/TailRank
 expect_setequal(
-  git2r::remotes(git2r::repository("~/Desktop/TailRank/")),
+  git2r::remotes(git2r::repository(path(conspicuous_place(), "TailRank"))),
   "origin"
 )
 expect_setequal(
-  git2r::remote_url(git2r::repository("~/Desktop/TailRank/")),
+  git2r::remote_url(git2r::repository(path(conspicuous_place(), "TailRank"))),
   "git@github.com:cran/TailRank.git"
 )
-dir_delete("~/Desktop/TailRank/")
+dir_delete(path(conspicuous_place(), "TailRank"))
 
 ## create from repo I do not have push access to
 ## fork = TRUE
-create_from_github("cran/TailRank", fork = TRUE)
+create_from_github("cran/TailRank", fork = TRUE, open = FALSE)
 ## expect error because PAT not available
 
 ## create from repo I do not have push access to
 ## fork = NA
-create_from_github("cran/TailRank", fork = NA)
+create_from_github("cran/TailRank", fork = NA, open = FALSE)
 ## created as clone (no fork)
-dir_delete("~/Desktop/TailRank")
+dir_delete(path(conspicuous_place(), "TailRank"))
 
 ## create from repo I do not have push access to
 ## fork = TRUE, explicitly provide token
-create_from_github("cran/TailRank", fork = TRUE, auth_token = token)
+create_from_github("cran/TailRank", fork = TRUE, auth_token = token, open = FALSE)
 ## fork and clone
 
-dir_delete("~/Desktop/TailRank")
+dir_delete(path(conspicuous_place(), "TailRank"))

--- a/tests/manual/manual-use-github.R
+++ b/tests/manual/manual-use-github.R
@@ -63,8 +63,8 @@ gh::gh(
 # }
 use_github()
 
-## cleanup
-proj_set("~/rrr/usethis")
+## restore initial project, presunably usethis itself
+proj_set(rstudioapi::getActiveProject())
 setwd(proj_get())
 proj_sitrep()
 

--- a/tests/testthat/test-create.R
+++ b/tests/testthat/test-create.R
@@ -70,7 +70,7 @@ test_that("rationalize_fork() won't attempt to fork w/o auth_token", {
   )
   expect_error(
     rationalize_fork(fork = TRUE, repo_info = list(), auth_token = ""),
-    "GitHub .+auth_token.+ is not associated with a user"
+    "No GitHub .+auth_token.+ is available"
   )
 })
 

--- a/tests/testthat/test-create.R
+++ b/tests/testthat/test-create.R
@@ -57,32 +57,34 @@ test_that("create_* works w/ non-existing rel path and absolutizes it", {
 
 test_that("rationalize_fork() honors fork = FALSE", {
   expect_false(
-    rationalize_fork(fork = FALSE, repo_info = list(), pat_available = TRUE)
+    rationalize_fork(fork = FALSE, repo_info = list(), auth_token = "PAT")
   )
   expect_false(
-    rationalize_fork(fork = FALSE, repo_info = list(), pat_available = FALSE)
+    rationalize_fork(fork = FALSE, repo_info = list(), auth_token = "")
   )
 })
 
-test_that("rationalize_fork() won't attempt to fork w/o PAT", {
+test_that("rationalize_fork() won't attempt to fork w/o auth_token", {
   expect_false(
-    rationalize_fork(fork = NA, repo_info = list(), pat_available = FALSE)
+    rationalize_fork(fork = NA, repo_info = list(), auth_token = "")
   )
   expect_error(
-    rationalize_fork(fork = TRUE, repo_info = list(), pat_available = FALSE),
-    "No GitHub .+auth_token.+"
+    rationalize_fork(fork = TRUE, repo_info = list(), auth_token = ""),
+    "GitHub .+auth_token.+ is not associated with a user"
   )
 })
 
 test_that("rationalize_fork() won't attempt to fork repo owned by user", {
-  expect_error(
-    rationalize_fork(
-      fork = TRUE,
-      repo_info = list(full_name = "USER/REPO", owner = list(login = "USER")),
-      pat_available = TRUE,
-      user = "USER"
-    ),
-    "Can't fork"
+  with_mock(
+    `usethis:::github_user` = function(auth_token) list(login = "USER"),
+    expect_error(
+      rationalize_fork(
+        fork = TRUE,
+        repo_info = list(full_name = "USER/REPO", owner = list(login = "USER")),
+        auth_token = "PAT"
+      ),
+      "Can't fork"
+    )
   )
 })
 
@@ -91,7 +93,7 @@ test_that("rationalize_fork() forks by default iff user cannot push", {
     rationalize_fork(
       fork = NA,
       repo_info = list(permissions = list(push = TRUE)),
-      pat_available = TRUE
+      auth_token = ""
     )
   )
   expect_true(
@@ -101,7 +103,7 @@ test_that("rationalize_fork() forks by default iff user cannot push", {
         owner = list(login = "SOMEONE_ELSE"),
         permissions = list(push = FALSE)
       ),
-      pat_available = TRUE
+      auth_token = "PAT"
     )
   )
 })

--- a/tests/testthat/test-github-utils.R
+++ b/tests/testthat/test-github-utils.R
@@ -32,7 +32,33 @@ test_that("github_token() works", {
   )
 })
 
+test_that("have_github_token() is definitive detector for 'we have no PAT'", {
+  expect_false(have_github_token(""))
+  expect_true(have_github_token("PAT"))
+})
+
+test_that("check_github_token() passes good input through", {
+  expect_identical(check_github_token("", allow_empty = TRUE), "")
+  with_mock(
+    `usethis:::github_user` = function(auth_token) list(login = "USER"),
+    expect_identical(check_github_token("PAT"), "PAT")
+  )
+})
+
+test_that("check_github_token() errors informatively for bad input", {
+  expect_error(check_github_token(c("PAT1", "PAT2")), "single string")
+  expect_error(check_github_token(NA), "single string")
+  expect_error(check_github_token(NA_character_), "single string")
+  expect_error(check_github_token(""), "No.*available")
+  with_mock(
+    `usethis:::github_user` = function(auth_token) NULL,
+    expect_error(check_github_token("PAT"), "invalid")
+  )
+})
+
 test_that("github_user() returns NULL if no auth_token", {
+  skip_if_offline()
+  skip_on_cran()
   withr::with_envvar(
     new = c("GITHUB_PAT" = NA, "GITHUB_TOKEN" = NA),
     expect_null(github_user())
@@ -42,10 +68,7 @@ test_that("github_user() returns NULL if no auth_token", {
 test_that("github_user() returns NULL for bad token", {
   skip_if_offline()
   skip_on_cran()
-  withr::with_envvar(
-    new = c("GITHUB_PAT" = "abc"),
-    expect_null(github_user())
-  )
+  expect_null(github_user("abc"))
 })
 
 test_that("github_remote_protocol() picks up ssh and https", {


### PR DESCRIPTION
Closes #657 Where to check validity of GitHub PAT?

Notes to self are in the issue. Highlights:

  * Put definitions and checks closer to where they are used.
  * `""` is the PAT when we have no PAT. This is expedient, because it's what gh expects.
  *  We have two levels of PAT checking:
    - ~`validate_github_token()`~ `check_github_token()` does a rigorous check, including against the GitHub API. Use this when we know we truly need a token or git credentials.
    - ~`maybe_github_token()`~ `check_github_token(allow_empty = TRUE)` tolerates `""` but, otherwise, does full checks. Use this when we can get away with having no token or credentials, i.e. reading a public resource.