### PR TITLE
pr_sitrep()

### DIFF
--- a/R/git.R
+++ b/R/git.R
@@ -382,7 +382,7 @@ git_sitrep <- function() {
     hd_line("Project")
     if (uses_git()) {
       repo <- git_repo()
-      kv_line("Path", repo$path)
+      kv_line("Path", path_dir(repo$path))
       kv_line("Local branch", git_branch_name())
       kv_line("Remote branch", git_branch_tracking())
     } else {

--- a/R/pr.R
+++ b/R/pr.R
@@ -333,3 +333,34 @@ pr_find <- function(owner,
 
   urls[refs == pr_branch & user == pr_owner]
 }
+
+pr_sitrep <- function() {
+  if (!proj_active()) {
+    cat_line("No active usethis project")
+    return()
+  }
+  if (!uses_git()) {
+    cat_line("Active project is not a Git repo")
+    return()
+  }
+
+  repo <- git_repo()
+  hd_line("Repo")
+  kv_line("Path", path_dir(repo$path))
+  kv_line("Uncommitted changes", git_uncommitted())
+
+  hd_line("Remotes")
+  remotes <- github_remotes()
+  if (length(remotes) == 0) {
+    cat_line("This repo does not have any GitHub remotes")
+    return()
+  }
+  purrr::walk2(names(remotes), remotes, kv_line)
+
+  hd_line("Branch")
+  kv_line("Local branch", git_branch_name())
+  kv_line("Remote branch", git_branch_tracking())
+
+  hd_line("Pull Request")
+  kv_line("PR URL", pr_url())
+}


### PR DESCRIPTION
Closes #609 

I'm finding this hard to write. Since #609 was opened, the whole `pr_*()` family has matured and I think it does a decent job of performing checks and delivering advice at the moment of need.

Am I trying to tell the user if they are in a good position to initiate a PR? Or report on whether they're currently working on a PR? The goal is not clear.

I propose that we mine this PR and #609 for a few items to add to `git_sitrep()` and call it a day. For example, I think reporting on the current remotes is a nice addition. Below is a look at the current crude state.

---

``` r
> pr_sitrep()
Repo
* Path: '/Users/jenny/rrr/usethis'
* Uncommitted changes: FALSE
Remotes
* origin: 'git@github.com:r-lib/usethis.git'
Branch
* Local branch: 'pr-sitrep'
* Remote branch: 'origin/pr-sitrep'
Pull Request
* PR URL: <unset>
```