### PR TITLE
Use serialization format version 2 by default in use_data()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,9 @@
 
 ## New features
 
+* `use_data()` gains a `version` argument and defaults to serialization format
+  version 2 (#675).
+
 * `use_data_raw()` accepts a name for the to-be-prepared dataset and opens a
   templated R script (#646).
 

--- a/R/data.R
+++ b/R/data.R
@@ -18,6 +18,10 @@
 #'   files. If you really want to do so, set this to `TRUE`.
 #' @param compress Choose the type of compression used by [save()].
 #'   Should be one of "gzip", "bzip2", or "xz".
+#' @param version The serialization format version to use. The default, 2, was
+#'   the default format from R 1.4.0 to 3.5.3. Version 3 became the default from
+#'   R 3.6.0 and can only be read by R versions 3.5.0 and higher.
+#'
 #' @seealso The [data chapter](http://r-pkgs.had.co.nz/data.html) of [R
 #'   Packages](http://r-pkgs.had.co.nz).
 #' @export
@@ -32,7 +36,8 @@
 use_data <- function(...,
                      internal = FALSE,
                      overwrite = FALSE,
-                     compress = "bzip2") {
+                     compress = "bzip2",
+                     version = 2) {
   check_is_package("use_data()")
 
   objs <- get_objs_from_dots(dots(...))
@@ -54,7 +59,7 @@ use_data <- function(...,
     save,
     list = objs,
     file = proj_path(paths),
-    MoreArgs = list(envir = envir, compress = compress)
+    MoreArgs = list(envir = envir, compress = compress, version = version)
   )
 
   invisible()

--- a/man/use_data.Rd
+++ b/man/use_data.Rd
@@ -6,7 +6,7 @@
 \title{Create package data}
 \usage{
 use_data(..., internal = FALSE, overwrite = FALSE,
-  compress = "bzip2")
+  compress = "bzip2", version = 2)
 
 use_data_raw(name = "DATASET", open = interactive())
 }
@@ -28,6 +28,10 @@ files. If you really want to do so, set this to \code{TRUE}.}
 
 \item{compress}{Choose the type of compression used by \code{\link[=save]{save()}}.
 Should be one of "gzip", "bzip2", or "xz".}
+
+\item{version}{The serialization format version to use. The default, 2, was
+the default format from R 1.4.0 to 3.5.3. Version 3 became the default from
+R 3.6.0 and can only be read by R versions 3.5.0 and higher.}
 
 \item{name}{Name of the dataset to be prepared for inclusion in the package.}
 

--- a/tests/testthat/test-use-data.R
+++ b/tests/testthat/test-use-data.R
@@ -62,6 +62,17 @@ test_that("use_data() honors `overwrite` for internal data", {
   expect_identical(letters2, rev(letters))
 })
 
+test_that("use_data() writes version 2 by default", {
+  scoped_temporary_package()
+
+  x <- letters
+  use_data(x, internal = TRUE, version = 2, compress = FALSE)
+  expect_identical(
+    rawToChar(readBin(proj_path("R", "sysdata.rda"), n = 4, what = "raw")),
+    "RDX2"
+  )
+})
+
 test_that("use_data_raw() does setup", {
   scoped_temporary_package()
   use_data_raw(open = FALSE)


### PR DESCRIPTION
Closes #675

From R News:
https://cran.r-project.org/doc/manuals/r-devel/NEWS.html

CHANGES IN R 3.6.0

SIGNIFICANT USER-VISIBLE CHANGES

Serialization format version 3 becomes the default for serialization and saving of the workspace (save(), serialize(), saveRDS(), compiler::cmpfile()). Serialized data in format 3 cannot be read by versions of R prior to version 3.5.0. Serialization format version 2 is still supported and can be selected by version = 2 in the save/serialization functions. The default can be changed back for the whole R session by setting environment variables R_DEFAULT_SAVE_VERSION and R_DEFAULT_SERIALIZE_VERSION to 2. For maximal back-compatibility, files ‘vignette.rds’ and ‘partial.rdb’ generated by R CMD build are in serialization format version 2, and resave by default produces files in serialization format version 2 (unless the original is already in format version 3).