### PR TITLE
Fix bug in news_latest().

### DIFF
--- a/R/release.R
+++ b/R/release.R
@@ -151,14 +151,12 @@ news_latest <- function() {
   lines <- readLines(path)
   headings <- which(grepl("^#\\s+", lines))
 
-  if (length(headings == 1)) {
-    if (length(headings) == 0) {
-      ui_stop("No top-level headings found in {ui_value(path)}")
-    } else if (length(headings) == 1) {
-      news <- lines[seq2(headings + 1, length(lines))]
-    } else {
-      news <- lines[seq2(headings[[1]] + 1, headings[[2]] - 1)]
-    }
+  if (length(headings) == 0) {
+    ui_stop("No top-level headings found in {ui_value(path)}")
+  } else if (length(headings) == 1) {
+    news <- lines[seq2(headings + 1, length(lines))]
+  } else {
+    news <- lines[seq2(headings[[1]] + 1, headings[[2]] - 1)]
   }
 
   # Remove leading and trailing empty lines


### PR DESCRIPTION
This is a simple code typo, the `if (length(headings == 1))` statement shouldn't be there. The idea is that if the user's `NEWS.md` file has no top-level headings, then they get the error "No top-level headings found in {ui_value(path)}" but right now what actually happens is that the code falls through to `text <- which(news != "")` and `news` doesn't exist there so the user gets an uninformative error from that.

Sorry for no reprex, kinda hard when the function is searching for a file with a certain name within the current project.