### PR TITLE
Create way to pass args to git2r::status()

### DIFF
--- a/R/git-utils.R
+++ b/R/git-utils.R
@@ -28,8 +28,8 @@ git_pull <- function(remote_branch = git_branch_tracking_FIXME(),
   invisible()
 }
 
-git_status <- function() {
-  git2r::status(git_repo())
+git_status <- function(...) {
+  git2r::status(..., repo = git_repo())
 }
 
 uses_git <- function(path = proj_get()) {

--- a/R/git.R
+++ b/R/git.R
@@ -19,18 +19,18 @@ use_git <- function(message = "Initial commit") {
   git_init()
 
   use_git_ignore(c(".Rhistory", ".RData", ".Rproj.user"))
-  git_ask_commit(message)
+  git_ask_commit(message, untracked = TRUE)
 
   restart_rstudio("A restart of RStudio is required to activate the Git pane")
   invisible(TRUE)
 }
 
-git_ask_commit <- function(message) {
+git_ask_commit <- function(message, untracked = FALSE) {
   if (!interactive()) {
     return(invisible())
   }
 
-  paths <- unlist(git_status(), use.names = FALSE)
+  paths <- unlist(git_status(untracked = untracked), use.names = FALSE)
   if (length(paths) == 0) {
     return(invisible())
   }


### PR DESCRIPTION
Fixes #708

Use this to change our default for git_ask_commit() to NOT include untracked files.