### PR TITLE
`use_dependency` fix

### DIFF
--- a/R/helpers.R
+++ b/R/helpers.R
@@ -55,37 +55,37 @@ use_dependency <- function(package, type, min_version = NULL) {
     desc::desc_set_dep(package, type, version = version, file = proj_get())
     return(invisible())
   }
-
-  delta <- sign(match(existing_type, types) - match(type, types))
-  if (delta < 0) {
-    # don't downgrade
-    ui_warn(
-      "Package {ui_value(package)} is already listed in\\
-      {ui_value(existing_type)} in DESCRIPTION, no change made."
-    )
-  } else if (delta == 0 && !is.null(min_version)) {
-    # change version
-    upgrade <- existing_ver == "*" || numeric_version(min_version) > version_spec(existing_ver)
-    if (upgrade) {
-      ui_done(
-        "Increasing {ui_value(package)} version to {ui_value(version)} in DESCRIPTION"
+  for (i in seq_along(existing_type)) {
+    delta <- match(existing_type[i], types) - match(type, types)
+    if (delta < 0) {
+      # don't downgrade
+      ui_warn(
+        "Package {ui_value(package)} is already listed in\\
+        {ui_value(existing_type[i])} in DESCRIPTION, no change made."
       )
-      desc::desc_set_dep(package, type, version = version, file = proj_get())
-    }
-  } else if (delta > 0) {
-    # upgrade
-    if (existing_type != "LinkingTo") {
-      ui_done(
-        "
-        Moving {ui_value(package)} from {ui_field(existing_type)} to {ui_field(type)}\\
-        field in DESCRIPTION
-        "
-      )
-      desc::desc_del_dep(package, existing_type, file = proj_get())
-      desc::desc_set_dep(package, type, version = version, file = proj_get())
+    } else if (delta == 0 && !is.null(min_version)) {
+      # change version
+      upgrade <- existing_ver == "*" || numeric_version(min_version) > version_spec(existing_ver)
+      if (upgrade) {
+        ui_done(
+          "Increasing {ui_value(package)} version to {ui_value(version)} in DESCRIPTION"
+        )
+        desc::desc_set_dep(package, type, version = version, file = proj_get())
+      }
+    } else if (delta > 0) {
+      # upgrade
+      if (existing_type[i] != "LinkingTo") {
+        ui_done(
+          "
+          Moving {ui_value(package)} from {ui_field(existing_type[i])} to {ui_field(type)}\\
+          field in DESCRIPTION
+          "
+        )
+        desc::desc_del_dep(package, existing_type[i], file = proj_get())
+        desc::desc_set_dep(package, type, version = version, file = proj_get())
+      }
     }
   }
-
   invisible()
 }
 

--- a/R/release.R
+++ b/R/release.R
@@ -151,14 +151,12 @@ news_latest <- function() {
   lines <- readLines(path)
   headings <- which(grepl("^#\\s+", lines))
 
-  if (length(headings == 1)) {
-    if (length(headings) == 0) {
-      ui_stop("No top-level headings found in {ui_value(path)}")
-    } else if (length(headings) == 1) {
-      news <- lines[seq2(headings + 1, length(lines))]
-    } else {
-      news <- lines[seq2(headings[[1]] + 1, headings[[2]] - 1)]
-    }
+  if (length(headings) == 0) {
+    ui_stop("No top-level headings found in {ui_value(path)}")
+  } else if (length(headings) == 1) {
+    news <- lines[seq2(headings + 1, length(lines))]
+  } else {
+    news <- lines[seq2(headings[[1]] + 1, headings[[2]] - 1)]
   }
 
   # Remove leading and trailing empty lines

--- a/R/release.R
+++ b/R/release.R
@@ -151,12 +151,14 @@ news_latest <- function() {
   lines <- readLines(path)
   headings <- which(grepl("^#\\s+", lines))
 
-  if (length(headings) == 0) {
-    ui_stop("No top-level headings found in {ui_value(path)}")
-  } else if (length(headings) == 1) {
-    news <- lines[seq2(headings + 1, length(lines))]
-  } else {
-    news <- lines[seq2(headings[[1]] + 1, headings[[2]] - 1)]
+  if (length(headings == 1)) {
+    if (length(headings) == 0) {
+      ui_stop("No top-level headings found in {ui_value(path)}")
+    } else if (length(headings) == 1) {
+      news <- lines[seq2(headings + 1, length(lines))]
+    } else {
+      news <- lines[seq2(headings[[1]] + 1, headings[[2]] - 1)]
+    }
   }
 
   # Remove leading and trailing empty lines


### PR DESCRIPTION
The issue is that `use_dependency()` doesn't account for the fact that you could have the package passed to `use_dependency()` already in two places in `DESCRIPTION` (most likely `LinkingTo` and `Imports`) (I guess some people could erroneously have a package in three or more places). This could cause the variable `delta` (which is used in a few `if` statements e.g. `if (delta > 0)`) to have length two and then the `if` generates a warning. I often get this warning because I use `use_rcpp()` every time I want to create another `.cpp` file in `/src`.
I've fixed this with a `for` loop but that's just an idea. I know you're rightly quite particular about how this package is authored and I'm happy to implement a fix to this as instructed, if you so wish.