### PR TITLE
Newline fix 

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -29,6 +29,9 @@ Git operations).
 
 Other improvements and bug fixes:
 
+* `use_github()` now removes newline `\n` characters when pushing that can cause 
+  `gh::gh` fail (#493, @muschellij2).  
+
 * `use_github()` tries harder but also fails earlier, with more informative
   messages, making it less likely to leave the repo partially configured (#221).
   

--- a/R/github.R
+++ b/R/github.R
@@ -56,6 +56,7 @@ use_github <- function(organisation = NULL,
   check_no_github_repo(owner, repo_name, host, auth_token)
 
   repo_desc <- project_data()$Title %||% ""
+  repo_desc <- gsub("\n", " ", repo_desc)
 
   if (interactive()) {
     ui_todo("Check title and description")

--- a/R/template.R
+++ b/R/template.R
@@ -75,7 +75,7 @@ find_template <- function(template_name, package = "usethis") {
   }
   if (identical(path, "")) {
     ui_stop(
-      "Could not find template {ui_value(template_name)}\\
+      "Could not find template {ui_value(template_name)} \\
       in package {ui_value(package)}."
     )
   }


### PR DESCRIPTION
Fixes #493 with a simple `gsub` so that titles with newlines do not break the push to GitHub.  Also, added a space in the text when failing on template.