### PR TITLE
Link to topic file and not alias (pipe)

### DIFF
--- a/inst/templates/pipe.R
+++ b/inst/templates/pipe.R
@@ -1,6 +1,6 @@
 #' Pipe operator
 #'
-#' See \code{magrittr::\link[magrittr]{\%>\%}} for details.
+#' See \code{magrittr::\link[magrittr:pipe]{\%>\%}} for details.
 #'
 #' @name %>%
 #' @rdname pipe


### PR DESCRIPTION
This change will prevent Rd warnings during "Install and Restart" on Windows. However, it may make the link more fragile.
https://github.com/klutometis/roxygen/issues/707
https://stackoverflow.com/questions/48430093/how-do-i-resolve-rd-warning-missing-file-link-when-building-packages-in-rstudi/48478698#48478698