### PR TITLE
Reorder the messages in edit_r_profile, edit_renviron and rprofile-helper functions

### DIFF
--- a/R/edit.R
+++ b/R/edit.R
@@ -60,17 +60,17 @@ NULL
 #' @export
 #' @rdname edit
 edit_r_profile <- function(scope = c("user", "project")) {
-  ui_todo("Restart R for changes to take effect")
   path <- scoped_path_r(scope, ".Rprofile", envvar = "R_PROFILE_USER")
   edit_file(path)
+  ui_todo("Restart R for changes to take effect")
 }
 
 #' @export
 #' @rdname edit
 edit_r_environ <- function(scope = c("user", "project")) {
-  ui_todo("Restart R for changes to take effect")
   path <- scoped_path_r(scope, ".Renviron", envvar = "R_ENVIRON_USER")
   edit_file(path)
+  ui_todo("Restart R for changes to take effect")
 }
 
 #' @export

--- a/R/edit.R
+++ b/R/edit.R
@@ -63,6 +63,7 @@ edit_r_profile <- function(scope = c("user", "project")) {
   path <- scoped_path_r(scope, ".Rprofile", envvar = "R_PROFILE_USER")
   edit_file(path)
   ui_todo("Restart R for changes to take effect")
+  invisible(path)
 }
 
 #' @export
@@ -71,6 +72,7 @@ edit_r_environ <- function(scope = c("user", "project")) {
   path <- scoped_path_r(scope, ".Renviron", envvar = "R_ENVIRON_USER")
   edit_file(path)
   ui_todo("Restart R for changes to take effect")
+  invisible(path)
 }
 
 #' @export

--- a/R/rprofile.R
+++ b/R/rprofile.R
@@ -38,7 +38,6 @@ use_devtools <- function() {
 }
 
 use_rprofile_package <- function(package) {
-  edit_r_profile("user")
   ui_todo(
     "Include this code in {ui_value('.Rprofile')} to make \\
     {ui_field(package)} available in all interactive sessions."
@@ -50,12 +49,13 @@ use_rprofile_package <- function(package) {
     }}
     "
   )
+  edit_r_profile("user")
 }
 
 #' @rdname rprofile-helper
 #' @export
 use_partial_warnings <- function() {
-  edit_r_profile("user")
+  
 
   ui_todo(
     "Include this code in {ui_path('.Rprofile')} to warn on partial matches."
@@ -69,4 +69,5 @@ use_partial_warnings <- function() {
     )
     "
   )
+  edit_r_profile("user")
 }


### PR DESCRIPTION
This PR changes the order of the messages that the user sees when editing the Rprofile and the Renviron file as proposed on #732.