### PR TITLE
Fix tidy eval template

### DIFF
--- a/inst/templates/tidy-eval.R
+++ b/inst/templates/tidy-eval.R
@@ -6,42 +6,42 @@
 #'   \code{\link[rlang]{syms}()} creates a list of symbols from a
 #'   character vector.
 #'
-#' * \code{\link[rlang]{expr}()} and \code{\link[rlang]{quo}()} quote
-#'   one expression. `quo()` wraps the quoted expression in a quosure.
+#' * \code{\link[rlang]{enquo}()} and \code{\link[rlang]{enquos}()}
+#'   delay the execution of one or several function arguments.
+#'   \code{enquo()} returns a single quoted expression, which is like
+#'   a blueprint for the delayed computation. \code{enquos()} returns
+#'   a list of such quoted expressions.
 #'
-#'   The plural variants [rlang::exprs()] and
-#'   \code{\link[rlang]{quos}()} return a list of quoted expressions or
-#'   quosures.
+#' * \code{\link[rlang]{expr}()} quotes a new expression _locally_. It
+#'   is mostly useful to build new expressions around arguments
+#'   captured with [enquo()] or [enquos()]:
+#'   \code{expr(mean(!!enquo(arg), na.rm = TRUE))}.
 #'
-#' * \code{\link[rlang]{enexpr}()} and \code{\link[rlang]{enquo}()}
-#'   capture the expression supplied as argument by the user of the
-#'   current function (`enquo()` wraps this expression in a quosure).
+#' * \code{\link[rlang]{as_name()}} transforms a quoted variable name
+#'   into a string. Supplying something else than a quoted variable
+#'   name is an error.
 #'
-#'   \code{\link[rlang]{enexprs}()} and \code{\link[rlang]{enquos}()}
-#'   capture multiple expressions supplied as arguments, including
-#'   `...`.
+#'   That's unlike \code{\link[rlang]{as_label}()} which also returns
+#'   a single string but supports any kind of R object as input,
+#'   including quoted function calls and vectors. Its purpose is to
+#'   summarise that object into a single label. That label is often
+#'   suitable as a default name.
 #'
-#' `exprs()` is not exported to avoid conflicts with `Biobase::exprs()`,
-#' therefore one should always use `rlang::exprs()`.
+#'   If you don't know what a quoted expression contains (for instance
+#'   expressions captured with \code{enquo()} could be a variable
+#'   name, a call to a function, or an unquoted constant), then use
+#'   \code{as_label()}. If you know you have quoted a simple variable
+#'   name, or would like to enforce this, use \code{as_name()}.
 #'
 #' To learn more about tidy eval and how to use these tools, visit
-#' <http://rlang.r-lib.org> and the [Metaprogramming
-#' section](https://adv-r.hadley.nz/metaprogramming.html) of [Advanced
-#' R](https://adv-r.hadley.nz).
+#' \url{http://tidyeval.tidyverse.org} and the
+#' \href{https://adv-r.hadley.nz/metaprogramming.html}{Metaprogramming
+#' section} of \href{https://adv-r.hadley.nz}{Advanced R}.
 #'
 #' @md
-#' @name     tidyeval
+#' @name tidyeval
 #' @keywords internal
-#' @importFrom rlang quo quos enquo enquos sym ensym syms
-#'                   ensyms expr exprs enexpr enexprs .data :=
-#'                   as_name as_label
-#' @aliases  quo quos enquo enquos
-#'           sym ensym syms ensyms
-#'           expr exprs enexpr enexprs
-#'           .data := as_name as_label
-#' @export   quo quos enquo enquos
-#' @export   sym ensym syms ensyms
-#' @export   expr enexpr enexprs
-#' @export   .data :=
-#' @export   as_name as_label
+#' @importFrom rlang expr enquo enquos sym syms .data := as_name as_label
+#' @aliases expr enquo enquos sym syms .data := as_name as_label
+#' @export expr enquo enquos sym syms .data := as_name as_label
 NULL

--- a/inst/templates/tidy-eval.R
+++ b/inst/templates/tidy-eval.R
@@ -32,14 +32,16 @@
 #' @md
 #' @name     tidyeval
 #' @keywords internal
-#' @importFrom rlang quo quos enquo enquos quo_name sym ensym syms
+#' @importFrom rlang quo quos enquo enquos sym ensym syms
 #'                   ensyms expr exprs enexpr enexprs .data :=
-#' @aliases  quo quos enquo enquos quo_name
+#'                   as_name as_label
+#' @aliases  quo quos enquo enquos
 #'           sym ensym syms ensyms
 #'           expr exprs enexpr enexprs
-#'           .data :=
-#' @export   quo quos enquo enquos quo_name
+#'           .data := as_name as_label
+#' @export   quo quos enquo enquos
 #' @export   sym ensym syms ensyms
 #' @export   expr enexpr enexprs
 #' @export   .data :=
+#' @export   as_name as_label
 NULL

--- a/inst/templates/tidy-eval.R
+++ b/inst/templates/tidy-eval.R
@@ -17,7 +17,7 @@
 #'   captured with [enquo()] or [enquos()]:
 #'   \code{expr(mean(!!enquo(arg), na.rm = TRUE))}.
 #'
-#' * \code{\link[rlang]{as_name()}} transforms a quoted variable name
+#' * \code{\link[rlang]{as_name}()} transforms a quoted variable name
 #'   into a string. Supplying something else than a quoted variable
 #'   name is an error.
 #'


### PR DESCRIPTION
* Reexport `as_name()` and `as_label()` instead of `quo_name()`

* No longer reexport `enexpr()` and `enexprs()` which should basically never be used.

* No longer reexport `quo()` and `quos()` which are rarely useful. Keep `expr()` which should be used instead.

* Revisit documentation.