### PR TITLE
Make authentication to GitHub via SSH keys easier on Windows users. (#746)

### DIFF
--- a/R/create.R
+++ b/R/create.R
@@ -108,6 +108,29 @@ create_project <- function(path,
 #'   [use_course()] for one-time download of all files in a Git repo, without
 #'   any local or remote Git operations.
 #'
+#' @section Using SSH Keys on Windows:
+#' If you are a Windows user and want to use SSH keys to authenticate to Github,
+#' we advise that you explicitly specify the paths to your keys and register them
+#' in the current R session.
+#'
+#' Note: *This is for SSH authentication only.*
+#'
+#' In the snippet below, replace <USERNAME> with your Windows username. Replace
+#' <OWNER/REPO> with the appropriate GitHub specificaction.
+#'
+#'```
+#' use_git_protocol("ssh")
+#'
+#' creds <- git2r::cred_ssh_key(publickey = "C:/Users/<USERNAME>/.ssh/id_rsa.pub",
+#'                              privatekey = "C:/Users/<USERNAME>/.ssh/id_rsa",
+#'                              passphrase = character(0))
+#'
+#' use_git_credentials(credentials = creds)
+#'
+#' create_from_github(repo_spec = "<OWNER/REPO>",
+#'                    destdir = "C:/Users/<USERNAME>/Desktop")
+#'```
+#'
 #' @inheritParams create_package
 #' @param repo_spec GitHub repo specification in this form: `owner/repo`. The
 #'   `repo` part will be the name of the new local repo.

--- a/R/create.R
+++ b/R/create.R
@@ -109,27 +109,31 @@ create_project <- function(path,
 #'   any local or remote Git operations.
 #'
 #' @section Using SSH Keys on Windows:
-#' If you are a Windows user and want to use SSH keys to authenticate to Github,
-#' we advise that you explicitly specify the paths to your keys and register them
-#' in the current R session.
+#' If you are a Windows user who connects to GitHub using SSH, as opposed to
+#' HTTPS, you may need to explicitly specify the paths to your keys and register
+#' this credential in the current R session. This helps if git2r, which usethis
+#' uses for Git operations, does not automatically find your keys or handle your
+#' passphrase.
 #'
-#' Note: *This is for SSH authentication only.*
+#' In the snippet below, do whatever is necessary to make the paths correct,
+#' e.g., replace `<USERNAME>` with your Windows username. Omit the `passphrase`
+#' part if you don't have one. Replace `<OWNER/REPO>` with the appropriate
+#' GitHub specification. You get the idea.
 #'
-#' In the snippet below, replace <USERNAME> with your Windows username. Replace
-#' <OWNER/REPO> with the appropriate GitHub specificaction.
-#'
-#'```
+#' ```
+#' creds <- git2r::cred_ssh_key(
+#'   publickey  = "C:/Users/<USERNAME>/.ssh/id_rsa.pub",
+#'   privatekey = "C:/Users/<USERNAME>/.ssh/id_rsa",
+#'   passphrase = character(0)
+#' )
 #' use_git_protocol("ssh")
-#'
-#' creds <- git2r::cred_ssh_key(publickey = "C:/Users/<USERNAME>/.ssh/id_rsa.pub",
-#'                              privatekey = "C:/Users/<USERNAME>/.ssh/id_rsa",
-#'                              passphrase = character(0))
-#'
 #' use_git_credentials(credentials = creds)
 #'
-#' create_from_github(repo_spec = "<OWNER/REPO>",
-#'                    destdir = "C:/Users/<USERNAME>/Desktop")
-#'```
+#' create_from_github(
+#'   repo_spec = "<OWNER/REPO>",
+#'   ...
+#' )
+#' ```
 #'
 #' @inheritParams create_package
 #' @param repo_spec GitHub repo specification in this form: `owner/repo`. The

--- a/man/create_from_github.Rd
+++ b/man/create_from_github.Rd
@@ -57,23 +57,27 @@ by \code{\link[=use_github]{use_github()}}, which connects existing local projec
 }
 \section{Using SSH Keys on Windows}{
 
-If you are a Windows user and want to use SSH keys to authenticate to Github,
-we advise that you explicitly specify the paths to your keys and register them
-in the current R session.
+If you are a Windows user who connects to GitHub using SSH, as opposed to
+HTTPS, you may need to explicitly specify the paths to your keys and register
+this credential in the current R session. This helps if git2r, which usethis
+uses for Git operations, does not automatically find your keys or handle your
+passphrase.
 
-Note: \emph{This is for SSH authentication only.}
-
-In the snippet below, replace <USERNAME> with your Windows username. Replace
-<OWNER/REPO> with the appropriate GitHub specificaction.\preformatted{use_git_protocol("ssh")
-
-creds <- git2r::cred_ssh_key(publickey = "C:/Users/<USERNAME>/.ssh/id_rsa.pub",
-                             privatekey = "C:/Users/<USERNAME>/.ssh/id_rsa",
-                             passphrase = character(0))
-
+In the snippet below, do whatever is necessary to make the paths correct,
+e.g., replace \code{<USERNAME>} with your Windows username. Omit the \code{passphrase}
+part if you don't have one. Replace \code{<OWNER/REPO>} with the appropriate
+GitHub specification. You get the idea.\preformatted{creds <- git2r::cred_ssh_key(
+  publickey  = "C:/Users/<USERNAME>/.ssh/id_rsa.pub",
+  privatekey = "C:/Users/<USERNAME>/.ssh/id_rsa",
+  passphrase = character(0)
+)
+use_git_protocol("ssh")
 use_git_credentials(credentials = creds)
 
-create_from_github(repo_spec = "<OWNER/REPO>",
-                   destdir = "C:/Users/<USERNAME>/Desktop")
+create_from_github(
+  repo_spec = "<OWNER/REPO>",
+  ...
+)
 }
 }
 

--- a/man/create_from_github.Rd
+++ b/man/create_from_github.Rd
@@ -55,6 +55,28 @@ recommended that you pre-configure or pass a GitHub personal access token
 is required in order for \code{create_from_github()} to do \href{https://help.github.com/articles/fork-a-repo/}{"fork and clone"}. It is also required
 by \code{\link[=use_github]{use_github()}}, which connects existing local projects to GitHub.
 }
+\section{Using SSH Keys on Windows}{
+
+If you are a Windows user and want to use SSH keys to authenticate to Github,
+we advise that you explicitly specify the paths to your keys and register them
+in the current R session.
+
+Note: \emph{This is for SSH authentication only.}
+
+In the snippet below, replace <USERNAME> with your Windows username. Replace
+<OWNER/REPO> with the appropriate GitHub specificaction.\preformatted{use_git_protocol("ssh")
+
+creds <- git2r::cred_ssh_key(publickey = "C:/Users/<USERNAME>/.ssh/id_rsa.pub",
+                             privatekey = "C:/Users/<USERNAME>/.ssh/id_rsa",
+                             passphrase = character(0))
+
+use_git_credentials(credentials = creds)
+
+create_from_github(repo_spec = "<OWNER/REPO>",
+                   destdir = "C:/Users/<USERNAME>/Desktop")
+}
+}
+
 \examples{
 \dontrun{
 create_from_github("r-lib/usethis")

--- a/man/use_jenkins.Rd
+++ b/man/use_jenkins.Rd
@@ -13,7 +13,7 @@ calling this function will also run \code{use_make()} if a Makefile does not
 already exist at the project root.
 }
 \seealso{
-The \href{https://jenkins.io/doc/book/pipeline/jenkinsfile/}{documentation on Jekins Pipelines}.
+The \href{https://jenkins.io/doc/book/pipeline/jenkinsfile}{documentation on Jenkins Pipelines}.
 
 \code{\link[=use_make]{use_make()}}
 }


### PR DESCRIPTION
Closes #746

Added @section on authenticating to GitHub in the `create_from_github()` docs. The hope is that this addition will help Windows users who want to authenticate via SSH. I collaborated with @jennybc on this PR, which addresses #746. 