### PR TITLE
`use_version()` directly replaces development version NEWS headers

### DIFF
--- a/R/git.R
+++ b/R/git.R
@@ -26,7 +26,7 @@ use_git <- function(message = "Initial commit") {
 }
 
 git_ask_commit <- function(message, untracked = FALSE) {
-  if (!interactive()) {
+  if (!interactive() || !uses_git()) {
     return(invisible())
   }
 

--- a/R/news.R
+++ b/R/news.R
@@ -34,14 +34,10 @@ use_news_heading <- function(version) {
 
   development_title <- glue("# {project_name()} (development version)")
   if (development_title == news[[1]]) {
-    news <- news[-1]
-
-    if ("" == news[[1]]) {
-      news <- news[-1]
-    }
+    news[[1]] <- title
 
     ui_done("Replacing development heading in NEWS.md")
-    return(write_utf8(news_path, c(title, "", news)))
+    return(write_utf8(news_path, news))
   }
 
   ui_done("Adding new heading to NEWS.md")

--- a/R/news.R
+++ b/R/news.R
@@ -32,6 +32,15 @@ use_news_heading <- function(version) {
     return(invisible())
   }
 
+  development_title <- glue("# {project_name()} (development version)")
+  if (development_title == news[[1]]) {
+    news <- news[-1]
+
+    if ("" == news[[1]]) {
+      news <- news[-1]
+    }
+  }
+
   ui_done("Adding new heading to NEWS.md")
   write_utf8(news_path, c(title, "", news))
 }

--- a/R/news.R
+++ b/R/news.R
@@ -39,6 +39,9 @@ use_news_heading <- function(version) {
     if ("" == news[[1]]) {
       news <- news[-1]
     }
+
+    ui_done("Replacing development heading in NEWS.md")
+    return(write_utf8(news_path, c(title, "", news)))
   }
 
   ui_done("Adding new heading to NEWS.md")

--- a/tests/testthat/test-use-version.R
+++ b/tests/testthat/test-use-version.R
@@ -75,11 +75,11 @@ test_that("use_version() updates (development version) directly", {
 
   expect_match(
     readLines(proj_path("NEWS.md"), n = 1),
-    "0\\.0\\.2"
+    "0[.]0[.]2"
   )
 
   expect_match(
     readLines(proj_path("NEWS.md"), n = 3)[3],
-    "0\\.0\\.1"
+    "0[.]0[.]1"
   )
 })

--- a/tests/testthat/test-use-version.R
+++ b/tests/testthat/test-use-version.R
@@ -63,9 +63,6 @@ test_that("use_dev_version() appends .9000 to Version, exactly once", {
 })
 
 test_that("use_version() updates (development version) directly", {
-  # git2r::git2r::discover_repository() not working on R 3.1 (Travis)
-  skip_if(getRversion() < 3.2)
-
   scoped_temporary_package()
   use_description_field(name = "Version", value = "0.0.1", overwrite = TRUE)
   use_news_md()

--- a/tests/testthat/test-use-version.R
+++ b/tests/testthat/test-use-version.R
@@ -61,3 +61,28 @@ test_that("use_dev_version() appends .9000 to Version, exactly once", {
     "0.0.1.9000"
   )
 })
+
+test_that("use_version() updates (development version) directly", {
+  # git2r::git2r::discover_repository() not working on R 3.1 (Travis)
+  skip_if(getRversion() < 3.2)
+
+  scoped_temporary_package()
+  use_description_field(name = "Version", value = "0.0.1", overwrite = TRUE)
+  use_news_md()
+
+  # bump to dev to set (development version)
+  use_dev_version()
+
+  # directly overwrite development header
+  use_version("patch")
+
+  expect_match(
+    readLines(proj_path("NEWS.md"), n = 1),
+    "0\\.0\\.2"
+  )
+
+  expect_match(
+    readLines(proj_path("NEWS.md"), n = 3)[3],
+    "0\\.0\\.1"
+  )
+})


### PR DESCRIPTION
This PR allows you to call `use_version("major")` when you are currently in a state where the first line of NEWS is `# pkg (development version)` and directly replace that header with the bumped version. This means you no longer have to manually delete the temporary dev header.