### PR TITLE
Set upstream tracking branch for master in a fork

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # usethis (development version)
 
+* `create_from_github()` sets remote tracking branch of `master` to `upstream/master`, when it creates (and clones) a fork (#792).
+
 * `use_pipe()` gains a logical `export` argument, so it can do the setup necessary to use the pipe operator when it is re-exported (`export = TRUE`, which is the default and preserves the previous behaviour) and when it is not (`export = FALSE`) (#783).
 
 * `use_circleci()` creates a `.circleci/config.yaml` config file for CircleCI

--- a/R/create.R
+++ b/R/create.R
@@ -144,9 +144,9 @@ create_project <- function(path,
 #'   is provided or preconfigured. Otherwise, defaults to `FALSE` if you can
 #'   push to `repo_spec` and `TRUE` if you cannot. In the case of a fork, the
 #'   original target repo is added to the local repo as the `upstream` remote,
-#'   using the preferred `protocol`. The `master` branch is immediately pulled
-#'   from `upstream`, which matters in the case of a pre-existing, out-of-date
-#'   fork.
+#'   using the preferred `protocol`. The `master` branch is set to track
+#'   `upstream/master` and is immediately pulled, which matters in the case of a
+#'   pre-existing, out-of-date fork.
 #' @param rstudio Initiate an [RStudio
 #'   Project](https://support.rstudio.com/hc/en-us/articles/200526207-Using-Projects)?
 #'    Defaults to `TRUE` if in an RStudio session and project has no

--- a/R/create.R
+++ b/R/create.R
@@ -228,6 +228,13 @@ create_from_github <- function(repo_spec,
     ui_done("Adding {ui_value('upstream')} remote: {ui_value(upstream_url)}")
     git2r::remote_add(r, "upstream", upstream_url)
     pr_pull_upstream()
+    ui_done(
+      "
+      Setting remote tracking branch for local {ui_value('master')} branch to \\
+      {ui_value('upstream/master')}
+      "
+    )
+    git2r::branch_set_upstream(git2r::repository_head(r), "upstream/master")
     config_key <- glue("remote.upstream.created-by")
     git_config_set(config_key, "usethis::create_from_github")
   }

--- a/man/create_from_github.Rd
+++ b/man/create_from_github.Rd
@@ -20,9 +20,9 @@ Desktop or some other conspicuous place.}
 is provided or preconfigured. Otherwise, defaults to \code{FALSE} if you can
 push to \code{repo_spec} and \code{TRUE} if you cannot. In the case of a fork, the
 original target repo is added to the local repo as the \code{upstream} remote,
-using the preferred \code{protocol}. The \code{master} branch is immediately pulled
-from \code{upstream}, which matters in the case of a pre-existing, out-of-date
-fork.}
+using the preferred \code{protocol}. The \code{master} branch is set to track
+\code{upstream/master} and is immediately pulled, which matters in the case of a
+pre-existing, out-of-date fork.}
 
 \item{rstudio}{Initiate an \href{https://support.rstudio.com/hc/en-us/articles/200526207-Using-Projects}{RStudio Project}?
 Defaults to \code{TRUE} if in an RStudio session and project has no

--- a/tests/testthat/test-use-circleci.R
+++ b/tests/testthat/test-use-circleci.R
@@ -15,7 +15,8 @@ test_that("check_uses_circleci() can throw error", {
   scoped_temporary_package()
   expect_error(
     check_uses_circleci(),
-    "Do you need to run `use_circleci\\(\\)`"
+    "Do you need to run `use_circleci()`?",
+    fixed = TRUE, class = "usethis_error"
   )
 })
 


### PR DESCRIPTION
Before:
  master --> origin/master
After:
  master --> upstream/master

Now `git pull` will pull from upstream in a fork. This feels like a more correct setup to leave people with.