### PR TITLE
Updated `use_data_raw()` template for unquoted use_data and overwrite

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 * Fix typo in Makefile template generated via `use_make()` (#804, @ryapric).
 
+* Fix quoting of dataset name in template for `use_data_raw()` (#736, @mitchelloharawild).
+
 # usethis 1.5.1
 
 This is a patch release with various small features and bug fixes.

--- a/inst/templates/packagename-data-prep.R
+++ b/inst/templates/packagename-data-prep.R
@@ -1,3 +1,3 @@
 ## code to prepare `{{{name}}}` dataset goes here
 
-usethis::use_data("{{{name}}}")
+usethis::use_data({{{name}}}, overwrite = TRUE)


### PR DESCRIPTION
Resolves #736


```r
usethis::use_data_raw("daisy")
```

```
## code to prepare `daisy` dataset goes here

usethis::use_data(daisy, overwrite = TRUE)
```