### PR TITLE
Add example to use_build_ignore()

### DIFF
--- a/R/ignore.R
+++ b/R/ignore.R
@@ -6,10 +6,18 @@
 #' expression that will only match that path. Repeated entries will be
 #' silently removed.
 #'
+#' `use_build_ignore` is designed to ignore *individual* files. If you
+#' want to ignore *all* files with a given extension, consider providing
+#' an "as-is" regular expression, using `escape = FALSE`; see examples.
+#'
 #' @param files Character vector of path names.
 #' @param escape If `TRUE`, the default, will escape `.` to
 #'   `\\.` and surround with `^` and `$`.
 #' @export
+#' @examples
+#' # ignore all Excel files
+#' use_build_ignore("[.]xls$", escape = FALSE)
+#'
 use_build_ignore <- function(files, escape = TRUE) {
   if (escape) {
     files <- escape_path(files)

--- a/R/ignore.R
+++ b/R/ignore.R
@@ -17,7 +17,7 @@
 #' @examples
 #' \dontrun{
 #' # ignore all Excel files
-#' use_build_ignore("[.]xls$", escape = FALSE)
+#' use_build_ignore("[.]xlsx$", escape = FALSE)
 #' }
 use_build_ignore <- function(files, escape = TRUE) {
   if (escape) {

--- a/R/ignore.R
+++ b/R/ignore.R
@@ -15,9 +15,10 @@
 #'   `\\.` and surround with `^` and `$`.
 #' @export
 #' @examples
+#' \dontrun{
 #' # ignore all Excel files
 #' use_build_ignore("[.]xls$", escape = FALSE)
-#'
+#' }
 use_build_ignore <- function(files, escape = TRUE) {
   if (escape) {
     files <- escape_path(files)

--- a/man/use_build_ignore.Rd
+++ b/man/use_build_ignore.Rd
@@ -25,7 +25,7 @@ want to ignore \emph{all} files with a given extension, consider providing
 an "as-is" regular expression, using \code{escape = FALSE}; see examples.
 }
 \examples{
-\donttest{
+\dontrun{
 # ignore all Excel files
 use_build_ignore("[.]xls$", escape = FALSE)
 }

--- a/man/use_build_ignore.Rd
+++ b/man/use_build_ignore.Rd
@@ -25,7 +25,8 @@ want to ignore \emph{all} files with a given extension, consider providing
 an "as-is" regular expression, using \code{escape = FALSE}; see examples.
 }
 \examples{
+\donttest{
 # ignore all Excel files
-use_build_ignore("[.]xls$")
-
+use_build_ignore("[.]xls$", escape = FALSE)
+}
 }

--- a/man/use_build_ignore.Rd
+++ b/man/use_build_ignore.Rd
@@ -27,6 +27,6 @@ an "as-is" regular expression, using \code{escape = FALSE}; see examples.
 \examples{
 \dontrun{
 # ignore all Excel files
-use_build_ignore("[.]xls$", escape = FALSE)
+use_build_ignore("[.]xlsx$", escape = FALSE)
 }
 }

--- a/man/use_build_ignore.Rd
+++ b/man/use_build_ignore.Rd
@@ -19,3 +19,13 @@ usually easier to work with specific file names. By default,
 expression that will only match that path. Repeated entries will be
 silently removed.
 }
+\details{
+\code{use_build_ignore} is designed to ignore \emph{individual} files. If you
+want to ignore \emph{all} files with a given extension, consider providing
+an "as-is" regular expression, using \code{escape = FALSE}; see examples.
+}
+\examples{
+# ignore all Excel files
+use_build_ignore("[.]xls$")
+
+}


### PR DESCRIPTION
Fixes #722 

Ready for review.

Adds an example to `use_build_ignore()` to show how to ignore all files that have a given extension.

I tested this manually, the example works for me. It is unclear how to test this, but I am happy to attempt it if you would like.

As well, I did not think this merits a NEWS item, but will be happy to add an item if you like.