### PR TITLE
fix #782: creates file in correct location: a new directory 

### DIFF
--- a/R/tutorial.R
+++ b/R/tutorial.R
@@ -26,7 +26,8 @@ use_tutorial <- function(name, title, open = interactive()) {
   stopifnot(is_string(name))
   stopifnot(is_string(title))
 
-  dir_path <- path("inst", "tutorials")
+  dir_path <- path("inst", "tutorials", name)
+  dir_create(dir_path)
 
   use_directory(dir_path)
   use_git_ignore("*.html", directory = dir_path)

--- a/tests/testthat/test-use-tutorial.R
+++ b/tests/testthat/test-use-tutorial.R
@@ -14,7 +14,7 @@ test_that("use_tutorial() creates a tutorial", {
     `usethis:::is_installed` = function(pkg) TRUE, {
       scoped_temporary_package()
       use_tutorial(name = "aaa", title = "bbb")
-      tute_file <- path("inst", "tutorials", "aaa", ext = "Rmd")
+      tute_file <- path("inst", "tutorials", "aaa", "aaa", ext = "Rmd")
       expect_proj_file(tute_file)
       expect_equal(rmarkdown::yaml_front_matter(tute_file)$title, "bbb")
     }


### PR DESCRIPTION
Addresses #782:

> use_tutorial() creates R Markdown files in inst/tutorials/ as single files. But learnr requires them in individual folders

@angela-li  @isteves