### PR TITLE
Added learner-friendly option to use_tutorial

### DIFF
--- a/R/tutorial.R
+++ b/R/tutorial.R
@@ -14,6 +14,7 @@
 #' @param name Base for file name to use for new `.Rmd` tutorial. Should consist
 #'   only of numbers, letters, `_` and `-`. We recommend using lower case.
 #' @param title The human-facing title of the tutorial.
+#' @param learner_friendly If `TRUE`, adds `learnr` to Imports instead of Suggests to install `learnr` alongside the tutorial package. Re-exports `run_tutorial()` to make it immediately available to tutorial package users.
 #' @inheritParams use_template
 #' @seealso The [learnr package
 #'   documentation](https://rstudio.github.io/learnr/index.html).
@@ -22,7 +23,8 @@
 #' \dontrun{
 #' use_tutorial("learn-to-do-stuff", "Learn to do stuff")
 #' }
-use_tutorial <- function(name, title, open = interactive()) {
+use_tutorial <- function(name, title, learner_friendly = FALSE,
+                         open = interactive()) {
   stopifnot(is_string(name))
   stopifnot(is_string(title))
 
@@ -31,8 +33,14 @@ use_tutorial <- function(name, title, open = interactive()) {
 
   use_directory(dir_path)
   use_git_ignore("*.html", directory = dir_path)
-  use_dependency("learnr", "Suggests")
-
+  
+  if(learner_friendly) {
+    use_dependency("learnr", "Imports")
+    use_template("run-tutorial.R", "R/utils-run-tutorial.R")
+  } else {
+    use_dependency("learnr", "Suggests")
+  }
+  
   path <- path(dir_path, asciify(name), ext = "Rmd")
 
   data <- project_data()
@@ -45,6 +53,6 @@ use_tutorial <- function(name, title, open = interactive()) {
     ignore = TRUE,
     open = open
   )
-
+  
   invisible(new)
 }

--- a/inst/templates/run-tutorial.R
+++ b/inst/templates/run-tutorial.R
@@ -1,0 +1,5 @@
+#' Run a tutorial
+#' @keywords NULL
+#' @export
+#' @name run_tutorial
+learnr::run_tutorial

--- a/man/use_tutorial.Rd
+++ b/man/use_tutorial.Rd
@@ -4,13 +4,16 @@
 \alias{use_tutorial}
 \title{Create a learnr tutorial}
 \usage{
-use_tutorial(name, title, open = interactive())
+use_tutorial(name, title, learner_friendly = FALSE,
+  open = interactive())
 }
 \arguments{
 \item{name}{Base for file name to use for new \code{.Rmd} tutorial. Should consist
 only of numbers, letters, \code{_} and \code{-}. We recommend using lower case.}
 
 \item{title}{The human-facing title of the tutorial.}
+
+\item{learner_friendly}{If \code{TRUE}, adds \code{learnr} to Imports instead of Suggests to install \code{learnr} alongside the tutorial package. Re-exports \code{run_tutorial()} to make it immediately available to tutorial package users.}
 
 \item{open}{Open the newly created file for editing? Happens in RStudio, if
 applicable, or via \code{\link[utils:file.edit]{utils::file.edit()}} otherwise.}

--- a/tests/testthat/test-use-tutorial.R
+++ b/tests/testthat/test-use-tutorial.R
@@ -2,7 +2,7 @@ context("test-use-tutorial")
 
 test_that("use_tutorial() checks its inputs", {
   skip_if_not_installed("rmarkdown")
-
+  
   scoped_temporary_package()
   expect_error(use_tutorial(), "no default")
   expect_error(use_tutorial(name = "tutorial-file"), "no default")
@@ -17,6 +17,17 @@ test_that("use_tutorial() creates a tutorial", {
       tute_file <- path("inst", "tutorials", "aaa", "aaa", ext = "Rmd")
       expect_proj_file(tute_file)
       expect_equal(rmarkdown::yaml_front_matter(tute_file)$title, "bbb")
+    }
+  )
+})
+
+test_that("use_tutorial(learner_friendly = TRUE) adds promised file, Imports learnr", {
+  with_mock(
+    `usethis:::uses_roxygen` = function(base_path) TRUE, {
+      scoped_temporary_package()
+      use_tutorial(name = "aaa", title = "bbb", learner_friendly = TRUE)
+      expect_match(desc::desc_get("Imports", proj_get()), "learnr")
+      expect_proj_file("R", "utils-run-tutorial.R")
     }
   )
 })


### PR DESCRIPTION
Added a new argument, `learner_friendly`, to `use_tutorial()` with @angela-li and @jules32. Defaults to FALSE. If TRUE, then:

- re-exports `learnr::run_tutorial()`
- places `learnr` in Imports instead of Suggests

@mine-cetinkaya-rundel any further comments/suggestions?
https://github.com/r-lib/usethis/issues/822