### PR TITLE
Fix use_circleci

### DIFF
--- a/R/ci.R
+++ b/R/ci.R
@@ -173,14 +173,13 @@ check_uses_gitlab_ci <- function(base_path = proj_get()) {
 #' @rdname ci
 use_circleci <- function(browse = interactive(), image = "rocker/verse:latest") {
   check_uses_github()
-  use_directory(".circleci")
+  use_directory(".circleci", ignore = TRUE)
   new <- use_template(
     "circleci-config.yml",
     ".circleci/config.yml",
     data = list(package = project_name(), image = image),
     ignore = TRUE
   )
-  use_build_ignore(".circleci")
   if (!new) {
     return(invisible(FALSE))
   }

--- a/R/ci.R
+++ b/R/ci.R
@@ -180,6 +180,7 @@ use_circleci <- function(browse = interactive(), image = "rocker/verse:latest") 
     data = list(package = project_name(), image = image),
     ignore = TRUE
   )
+  use_build_ignore(".circleci")
   if (!new) {
     return(invisible(FALSE))
   }

--- a/inst/templates/circleci-config.yml
+++ b/inst/templates/circleci-config.yml
@@ -1,8 +1,9 @@
+{{=<% %>=}}
 version: 2
 jobs:
   build:
     docker:
-      - image: {{{ image }}}
+      - image: <% image %>
     environment:
       R_LIBS: ~/R/Library
     steps:
@@ -30,7 +31,7 @@ jobs:
           name: Check package
           command: R CMD check --as-cran --no-manual *tar.gz
       - store_artifacts:
-          path: {{{ package }}}.Rcheck/
+          path: <% package %>.Rcheck/
       - save_cache:
           key: r-pkg-cache-{{ arch }}-{{ .Branch }}
           paths:

--- a/tests/testthat/test-use-circleci.R
+++ b/tests/testthat/test-use-circleci.R
@@ -66,7 +66,7 @@ test_that("use_circleci() properly formats keys for cache", {
   )
 })
 
-test_that("uses_circleci() configures .Rbuildignore", {
+test_that("use_circleci() configures .Rbuildignore", {
   skip_if_no_git_config()
 
   scoped_temporary_package()
@@ -74,9 +74,5 @@ test_that("uses_circleci() configures .Rbuildignore", {
   use_git()
   use_git_remote(name = "origin", url = "https://github.com/fake/fake")
   use_circleci(browse = FALSE)
-  ignored <- readLines(".Rbuildignore")
-  expect_identical(
-    ignored,
-    c("^\\.circleci/config\\.yml$", "^\\.circleci$")
-  )
+  expect_true(is_build_ignored("^\\.circleci$"))
 })

--- a/tests/testthat/test-use-circleci.R
+++ b/tests/testthat/test-use-circleci.R
@@ -55,7 +55,7 @@ test_that("use_circleci() properly formats keys for cache", {
   use_git()
   use_git_remote(name = "origin", url = "https://github.com/fake/fake")
   use_circleci(browse = FALSE)
-  yml <- yaml::yaml.load_file(".circleci/config.yml")
+  yml <- yaml::yaml.load_file(proj_path(".circleci", "config.yml"))
   expect_identical(
     yml$jobs$build$steps[[1]]$restore_cache$keys,
     c("r-pkg-cache-{{ arch }}-{{ .Branch }}", "r-pkg-cache-{{ arch }}-")

--- a/tests/testthat/test-use-circleci.R
+++ b/tests/testthat/test-use-circleci.R
@@ -65,3 +65,18 @@ test_that("use_circleci() properly formats keys for cache", {
     "r-pkg-cache-{{ arch }}-{{ .Branch }}"
   )
 })
+
+test_that("uses_circleci() configures .Rbuildignore", {
+  skip_if_no_git_config()
+
+  scoped_temporary_package()
+  expect_false(uses_circleci())
+  use_git()
+  use_git_remote(name = "origin", url = "https://github.com/fake/fake")
+  use_circleci(browse = FALSE)
+  ignored <- readLines(".Rbuildignore")
+  expect_identical(
+    ignored,
+    c("^\\.circleci/config\\.yml$", "^\\.circleci$")
+  )
+})

--- a/tests/testthat/test-use-circleci.R
+++ b/tests/testthat/test-use-circleci.R
@@ -47,3 +47,21 @@ test_that("use_circleci() specifies Docker image", {
   yml <- yaml::yaml.load_file(".circleci/config.yml")
   expect_identical(yml$jobs$build$docker[[1]]$image, docker)
 })
+
+test_that("use_circleci() properly formats keys for cache", {
+  skip_if_no_git_config()
+
+  scoped_temporary_package()
+  use_git()
+  use_git_remote(name = "origin", url = "https://github.com/fake/fake")
+  use_circleci(browse = FALSE)
+  yml <- yaml::yaml.load_file(".circleci/config.yml")
+  expect_identical(
+    yml$jobs$build$steps[[1]]$restore_cache$keys,
+    c("r-pkg-cache-{{ arch }}-{{ .Branch }}", "r-pkg-cache-{{ arch }}-")
+  )
+  expect_identical(
+    yml$jobs$build$steps[[8]]$save_cache$key,
+    "r-pkg-cache-{{ arch }}-{{ .Branch }}"
+  )
+})


### PR DESCRIPTION
I used `use_circleci()` today and found a few bugs:

* The mustache delimiters caused the cache keys to be corrupted. I fixed this by using alternative delimiters, as suggested [here](https://mustache.github.io/mustache.5.html)

* `R CMD build` mentioned that it removed the empty `.circleci` directory. Apparently ignoring the only file it contains doesn't also ignore the entire directory. Thus I also explicitly ignored the directory itself

I added tests for both of these updates and also ran styler on the code changes.