### PR TITLE
GitHub host improvement handling for GHE

### DIFF
--- a/R/git.R
+++ b/R/git.R
@@ -402,6 +402,7 @@ have_git2r_credentials <- function() rlang::env_has(git2r_env, "credentials")
 #'   `my_cred`.
 #'
 #' @inheritParams git_protocol
+#' @inheritParams use_github
 #' @param auth_token GitHub personal access token (PAT).
 #' @param credentials A git2r credential object produced with
 #'   [git2r::cred_env()], [git2r::cred_ssh_key()], [git2r::cred_token()], or
@@ -421,7 +422,8 @@ have_git2r_credentials <- function() rlang::env_has(git2r_env, "credentials")
 #' git_credentials(protocol = "https", auth_token = "MY_GITHUB_PAT")
 #' }
 git_credentials <- function(protocol = git_protocol(),
-                            auth_token = github_token()) {
+                            auth_token = github_token(),
+                            host = NULL) {
   if (have_git2r_credentials()) {
     return(git2r_env$credentials)
   }
@@ -431,7 +433,7 @@ git_credentials <- function(protocol = git_protocol(),
   }
 
   if (have_github_token(auth_token)) {
-    git2r::cred_user_pass("EMAIL", check_github_token(auth_token))
+    git2r::cred_user_pass("EMAIL", check_github_token(auth_token, host = host))
   } else {
     NULL
   }

--- a/R/github-labels.R
+++ b/R/github-labels.R
@@ -36,6 +36,7 @@
 #'   not appear in the `labels` vector and that do not have associated issues.
 #'
 #' @inheritParams use_github_links
+#' @inheritParams use_github
 #' @export
 #' @examples
 #' \dontrun{
@@ -67,7 +68,7 @@ use_github_labels <- function(repo_spec = github_repo_spec(),
   if (missing(repo_spec)) {
     check_uses_github()
   }
-  check_github_token(auth_token)
+  check_github_token(auth_token, host = host)
 
   gh <- function(endpoint, ...) {
     out <- gh::gh(

--- a/R/release.R
+++ b/R/release.R
@@ -112,7 +112,7 @@ use_github_release <- function(host = NULL,
 
   check_uses_github()
   check_branch_pushed()
-  check_github_token(auth_token)
+  check_github_token(auth_token, host = host)
 
   package <- package_data()
 

--- a/man/browse_github_token.Rd
+++ b/man/browse_github_token.Rd
@@ -25,7 +25,9 @@ distinguish various tokens on GitHub.}
 
 \item{host}{GitHub API host to use. Override with the endpoint-root for your
 GitHub enterprise instance, for example,
-"https://github.hostname.com/api/v3".}
+"https://github.hostname.com/api/v3".
+You can also set GITHUB_API_URL environment variable that will be used as
+default host by underlying gh package.}
 }
 \value{
 \code{github_token()} returns a string, a GitHub PAT or \code{""}.

--- a/man/create_from_github.Rd
+++ b/man/create_from_github.Rd
@@ -47,7 +47,9 @@ or, in non-interactive sessions, "ssh". \code{NA} triggers the interactive menu.
 
 \item{host}{GitHub API host to use. Override with the endpoint-root for your
 GitHub enterprise instance, for example,
-"https://github.hostname.com/api/v3".}
+"https://github.hostname.com/api/v3".
+You can also set GITHUB_API_URL environment variable that will be used as
+default host by underlying gh package.}
 }
 \description{
 Creates a new local Git repository from a repository on GitHub. It is highly

--- a/man/git_credentials.Rd
+++ b/man/git_credentials.Rd
@@ -5,7 +5,8 @@
 \alias{use_git_credentials}
 \title{Produce or register git credentials}
 \usage{
-git_credentials(protocol = git_protocol(), auth_token = github_token())
+git_credentials(protocol = git_protocol(), auth_token = github_token(),
+  host = NULL)
 
 use_git_credentials(credentials)
 }
@@ -15,6 +16,12 @@ to the option \code{usethis.protocol} and, if unset, to an interactive choice
 or, in non-interactive sessions, "ssh". \code{NA} triggers the interactive menu.}
 
 \item{auth_token}{GitHub personal access token (PAT).}
+
+\item{host}{GitHub API host to use. Override with the endpoint-root for your
+GitHub enterprise instance, for example,
+"https://github.hostname.com/api/v3".
+You can also set GITHUB_API_URL environment variable that will be used as
+default host by underlying gh package.}
 
 \item{credentials}{A git2r credential object produced with
 \code{\link[git2r:cred_env]{git2r::cred_env()}}, \code{\link[git2r:cred_ssh_key]{git2r::cred_ssh_key()}}, \code{\link[git2r:cred_token]{git2r::cred_token()}}, or

--- a/man/pr_init.Rd
+++ b/man/pr_init.Rd
@@ -14,21 +14,21 @@
 \usage{
 pr_init(branch)
 
-pr_fetch(number, owner = NULL)
+pr_fetch(number, owner = NULL, host = host)
 
-pr_push()
+pr_push(host = NULL)
 
-pr_pull()
+pr_pull(host = NULL)
 
-pr_pull_upstream()
+pr_pull_upstream(host = NULL)
 
-pr_sync()
+pr_sync(host = NULL)
 
-pr_view()
+pr_view(host = NULL)
 
 pr_pause()
 
-pr_finish()
+pr_finish(host = NULL)
 }
 \arguments{
 \item{branch}{branch name. Should usually consist of lower case letters,
@@ -40,6 +40,12 @@ numbers, and \code{-}.}
 pull request. Default of \code{NULL} tries to identify the source repo and uses
 the owner of the \code{upstream} remote, if present, or the owner of \code{origin}
 otherwise.}
+
+\item{host}{GitHub API host to use. Override with the endpoint-root for your
+GitHub enterprise instance, for example,
+"https://github.hostname.com/api/v3".
+You can also set GITHUB_API_URL environment variable that will be used as
+default host by underlying gh package.}
 }
 \description{
 The \code{pr_*} family of functions is designed to make working with GitHub

--- a/man/use_github.Rd
+++ b/man/use_github.Rd
@@ -27,7 +27,9 @@ or, in non-interactive sessions, "ssh". \code{NA} triggers the interactive menu.
 
 \item{host}{GitHub API host to use. Override with the endpoint-root for your
 GitHub enterprise instance, for example,
-"https://github.hostname.com/api/v3".}
+"https://github.hostname.com/api/v3".
+You can also set GITHUB_API_URL environment variable that will be used as
+default host by underlying gh package.}
 }
 \description{
 \code{use_github()} takes a local project, creates an associated repo on GitHub,

--- a/man/use_github_labels.Rd
+++ b/man/use_github_labels.Rd
@@ -47,7 +47,9 @@ not appear in the \code{labels} vector and that do not have associated issues.}
 
 \item{host}{GitHub API host to use. Override with the endpoint-root for your
 GitHub enterprise instance, for example,
-"https://github.hostname.com/api/v3".}
+"https://github.hostname.com/api/v3".
+You can also set GITHUB_API_URL environment variable that will be used as
+default host by underlying gh package.}
 }
 \description{
 \code{use_github_labels()} can create new labels, update colours and descriptions,

--- a/man/use_github_links.Rd
+++ b/man/use_github_links.Rd
@@ -12,7 +12,9 @@ use_github_links(auth_token = github_token(),
 
 \item{host}{GitHub API host to use. Override with the endpoint-root for your
 GitHub enterprise instance, for example,
-"https://github.hostname.com/api/v3".}
+"https://github.hostname.com/api/v3".
+You can also set GITHUB_API_URL environment variable that will be used as
+default host by underlying gh package.}
 
 \item{overwrite}{By default, \code{use_github_links()} will not overwrite existing
 fields. Set to \code{TRUE} to overwrite existing links.}

--- a/man/use_github_release.Rd
+++ b/man/use_github_release.Rd
@@ -9,7 +9,9 @@ use_github_release(host = NULL, auth_token = github_token())
 \arguments{
 \item{host}{GitHub API host to use. Override with the endpoint-root for your
 GitHub enterprise instance, for example,
-"https://github.hostname.com/api/v3".}
+"https://github.hostname.com/api/v3".
+You can also set GITHUB_API_URL environment variable that will be used as
+default host by underlying gh package.}
 
 \item{auth_token}{GitHub personal access token (PAT).}
 }


### PR DESCRIPTION
This is to see what it would mean to support GHE on usethis. a `host` argument has been introduce in some functions, but not all. This follow an issue in #834 that has been solved by providing `GITHUB_API_URL` env var that `gh` depends on. 

usethis can also depends on that by default as it uses `gh` and not offer a `host` argument in each function. It could also take the same approach as for token and check internally `github_api_host()` for this environment variable, default to GH if not set. 

```r
github_api_host() <- function() {
  # NULL means use gh default
  Sys.getenv("GITHUB_API_URL", NULL)
}
```
As `gh` does already this, this could be unnecessary in usethis.

Adding a host argument everywhere it is required seems to be a lot (from what I found already - see the changes)

Some functions (`pr_create_gh`) are using a url not configurable for now and won't work with GHE. It is not the API url but the server url. A `GITHUB_URL` env var maybe ? 🤔 

This is just to put the thoughts somewhere. Hence the draft PR for now.