### PR TITLE
WIP: Introduce concept of main and user repositories

### DIFF
--- a/R/ci.R
+++ b/R/ci.R
@@ -49,7 +49,8 @@ use_travis_badge <- function(ext = "org") {
 }
 
 travis_activate <- function(browse = interactive(), ext = "org") {
-  url <- glue("https://travis-ci.{ext}/profile/{github_owner()}")
+  owner <- github_main_owner()
+  url <- glue("https://travis-ci.{ext}/profile/{owner}")
 
   ui_todo("Turn on travis for your repo at {url}")
   if (browse) {

--- a/R/github-utils.R
+++ b/R/github-utils.R
@@ -40,14 +40,21 @@ github_upstream <- function() {
   parse_github_remotes(r)[[1]]
 }
 
+# The main repository is upstream || origin.
+# The user repository is origin || upstream.
 github_main <- function() {
   r <- github_remote("upstream") %||% github_remote("origin")
   if (is.null(r)) return(r)
   parse_github_remotes(r)[[1]]
 }
+github_user <- function() {
+  r <- github_remote("origin") %||% github_remote("upstream")
+  if (is.null(r)) return(r)
+  parse_github_remotes(r)[[1]]
+}
 
 github_owner <- function() {
-  github_main()[["owner"]]
+  github_user()[["owner"]]
 }
 
 github_owner_upstream <- function() {
@@ -55,7 +62,7 @@ github_owner_upstream <- function() {
 }
 
 github_repo <- function() {
-  github_main()[["repo"]]
+  github_user()[["repo"]]
 }
 
 github_repo_spec <- function(name = NULL) {

--- a/R/github-utils.R
+++ b/R/github-utils.R
@@ -56,6 +56,9 @@ github_user <- function() {
 github_owner <- function() {
   github_user()[["owner"]]
 }
+github_main_owner <- function() {
+  github_main()[["owner"]]
+}
 
 github_owner_upstream <- function() {
   github_upstream()[["owner"]]
@@ -63,6 +66,9 @@ github_owner_upstream <- function() {
 
 github_repo <- function() {
   github_user()[["repo"]]
+}
+github_main_repo <- function() {
+  github_main()[["repo"]]
 }
 
 github_repo_spec <- function(name = NULL) {

--- a/R/github-utils.R
+++ b/R/github-utils.R
@@ -58,8 +58,16 @@ github_repo <- function() {
   github_main()[["repo"]]
 }
 
-github_repo_spec <- function(name = "origin") {
-  url <- github_remote(name)
+github_repo_spec <- function(name = NULL) {
+  if (is.null(name)) {
+    url <- github_remote("upstream") %||% github_remote("origin")
+  } else {
+    url <- github_remote(name)
+  }
+  if (is.null(url)) {
+    rlang::abort("Can't find repository URL.")
+  }
+
   paste0(parse_github_remotes(url)[[1]], collapse = "/")
 }
 

--- a/R/github-utils.R
+++ b/R/github-utils.R
@@ -40,8 +40,14 @@ github_upstream <- function() {
   parse_github_remotes(r)[[1]]
 }
 
+github_main <- function() {
+  r <- github_remote("upstream") %||% github_remote("origin")
+  if (is.null(r)) return(r)
+  parse_github_remotes(r)[[1]]
+}
+
 github_owner <- function() {
-  github_origin()[["owner"]]
+  github_main()[["owner"]]
 }
 
 github_owner_upstream <- function() {
@@ -49,7 +55,7 @@ github_owner_upstream <- function() {
 }
 
 github_repo <- function() {
-  github_origin()[["repo"]]
+  github_main()[["repo"]]
 }
 
 github_repo_spec <- function(name = "origin") {

--- a/R/github.R
+++ b/R/github.R
@@ -252,12 +252,12 @@ github_token <- function() {
   if (token == "") Sys.getenv("GITHUB_TOKEN", "") else token
 }
 
-## checks for existence of 'origin' remote with 'github' in URL
+## checks for existence of 'origin' || 'upstream' remote with 'github' in URL
 uses_github <- function() {
   if (!uses_git()) {
     return(FALSE)
   }
-  length(github_main()) > 0
+  length(github_user()) > 0
 }
 
 check_no_origin <- function() {

--- a/R/github.R
+++ b/R/github.R
@@ -257,7 +257,7 @@ uses_github <- function() {
   if (!uses_git()) {
     return(FALSE)
   }
-  length(github_origin()) > 0
+  length(github_main()) > 0
 }
 
 check_no_origin <- function() {


### PR DESCRIPTION
Part of #781.

I'm currently creating a new package so I thought I'd go ahead and try to make usethis compatible with the origin + upstream workflow.

One idea explored in this tentative PR is to introduce the concepts of main and user repos.

- The main repo is where official development takes place. By default it is `upstream || origin`.
- The user repo is where local development takes place. By default it is `origin || upstream`.

For instance, Travis activation should use the main repo by default (it is occasionally useful to activate it in the user repo but I'm not sure how to accomodate this with the current UI). On the other hand, checking if Github is properly configured should be done with the user repo. I expect most usethis functions should interact with the main repo rather than the user repo.