### PR TITLE
Ensure src/ always has a code file (#720)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,9 @@
 
 * `use_gpl3_license()` now completes the license by providing additional information in a file named LICENSE, just like `use_mit_license()` and friends (#683, @Cervangirard).
 
+* `use_rcpp()` and `use_c()` now adds a langauge example file into `src/` if the
+   directory is empty to ensure the package can be built (#720, @coatless).
+
 * A new article [Pull request helpers](https://usethis.r-lib.org/articles/articles/pr-functions.html) demonstrating the `pr_*()` functions is available in the usethis website (#802, @mine-cetinkaya-rundel).
 
 * Fix typo in Makefile template generated via `use_make()` (#804, @ryapric).

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,8 +10,8 @@
 
 * `use_gpl3_license()` now completes the license by providing additional information in a file named LICENSE, just like `use_mit_license()` and friends (#683, @Cervangirard).
 
-* `use_rcpp()` and `use_c()` now adds a langauge example file into `src/` if the
-   directory is empty to ensure the package can be built (#720, @coatless).
+* `use_rcpp()` and `use_c()` now ensure `src/` contains at least one `.cpp` or
+  `.c` placeholder file, so that the package can be built (#720, @coatless).
 
 * A new article [Pull request helpers](https://usethis.r-lib.org/articles/articles/pr-functions.html) demonstrating the `pr_*()` functions is available in the usethis website (#802, @mine-cetinkaya-rundel).
 

--- a/R/directory.R
+++ b/R/directory.R
@@ -44,10 +44,18 @@ check_path_is_directory <- function(path) {
   }
 }
 
+count_directory_files <- function(x) {
+  length(dir_ls(x))
+}
+
+check_directory_has_files <- function(x) {
+  count_directory_files(x) >= 1
+}
+
 check_directory_is_empty <- function(x) {
-  files <- dir_ls(x)
-  if (length(files) > 0) {
+  if (!check_directory_has_files(x)) {
     ui_stop("{ui_path(x)} exists and is not an empty directory.")
   }
   invisible(x)
 }
+

--- a/R/directory.R
+++ b/R/directory.R
@@ -58,4 +58,3 @@ check_directory_is_empty <- function(x) {
   }
   invisible(x)
 }
-

--- a/R/directory.R
+++ b/R/directory.R
@@ -48,12 +48,12 @@ count_directory_files <- function(x) {
   length(dir_ls(x))
 }
 
-check_directory_has_files <- function(x) {
+directory_has_files <- function(x) {
   count_directory_files(x) >= 1
 }
 
 check_directory_is_empty <- function(x) {
-  if (check_directory_has_files(x)) {
+  if (directory_has_files(x)) {
     ui_stop("{ui_path(x)} exists and is not an empty directory.")
   }
   invisible(x)

--- a/R/directory.R
+++ b/R/directory.R
@@ -53,7 +53,7 @@ check_directory_has_files <- function(x) {
 }
 
 check_directory_is_empty <- function(x) {
-  if (!check_directory_has_files(x)) {
+  if (check_directory_has_files(x)) {
     ui_stop("{ui_path(x)} exists and is not an empty directory.")
   }
   invisible(x)

--- a/R/rcpp.R
+++ b/R/rcpp.R
@@ -16,12 +16,7 @@ use_rcpp <- function(name = NULL) {
   use_dependency("Rcpp", "Imports")
   roxygen_ns_append("@importFrom Rcpp sourceCpp") && roxygen_update()
 
-  if (!is.null(name)) {
-    name <- slug(name, "cpp")
-    check_file_name(name)
-
-    use_template("code.cpp", path("src", name), open = TRUE)
-  }
+  use_src_example_script(name, "cpp")
 
   invisible()
 }
@@ -60,12 +55,7 @@ use_rcpp_eigen <- function(name = NULL) {
 use_c <- function(name = NULL) {
   use_src()
 
-  if (!is.null(name)) {
-    name <- slug(name, "c")
-    check_file_name(name)
-
-    use_template("code.c", path("src", name), open = TRUE)
-  }
+  use_src_example_script(name, "c")
 
   invisible(TRUE)
 }

--- a/R/rcpp.R
+++ b/R/rcpp.R
@@ -1,8 +1,10 @@
 #' Use C, C++, RcppArmadillo, or RcppEigen
 #'
-#' Creates `src/`, adds required packages to `DESCRIPTION`,
-#' optionally creates `.c` or `.cpp` files with a supplied name or
-#' if the `src/` is empty, and where needed, `Makevars` and `Makevars.win` files.
+#' Adds infrastructure commonly needed when using compiled code:
+#'   * Creates `src/`
+#'   * Adds required packages to `DESCRIPTION`
+#'   * May create an initial placeholder `.c` or `.cpp` file
+#'   * Creates `Makevars` and `Makevars.win` files (`use_rcpp_armadillo()` only)
 #'
 #' @param name If supplied, creates and opens `src/name.{c,cpp}`.
 #'

--- a/R/rcpp.R
+++ b/R/rcpp.R
@@ -118,6 +118,6 @@ use_src_example_script <- function(name = NULL, src_type = c("cpp", "c")) {
   if (!is.null(name)) {
     name <- slug(name, src_type)
     check_file_name(name)
-    use_template(slug("code", src_type), path("src", name), open = TRUE)
+    use_template(slug("code", src_type), path("src", name), open = interactive())
   }
 }

--- a/R/rcpp.R
+++ b/R/rcpp.R
@@ -108,7 +108,7 @@ use_makevars <- function(settings = NULL) {
   }
 }
 
-use_src_example_script <- function(name, src_type = c("cpp", "c")) {
+use_src_example_script <- function(name = NULL, src_type = c("cpp", "c")) {
   src_type <- match.arg(src_type)
 
   if (!directory_has_files(path("src"))) {

--- a/R/rcpp.R
+++ b/R/rcpp.R
@@ -1,10 +1,18 @@
 #' Use C, C++, RcppArmadillo, or RcppEigen
 #'
 #' Creates `src/`, adds required packages to `DESCRIPTION`,
-#' optionally creates `.c` or `.cpp` files, and
-#' where needed, `Makevars` and `Makevars.win` files.
+#' optionally creates `.c` or `.cpp` files with a supplied name or
+#' if the `src/` is empty, and where needed, `Makevars` and `Makevars.win` files.
 #'
 #' @param name If supplied, creates and opens `src/name.{c,cpp}`.
+#'
+#' @details
+#'
+#' When using compiled code, please note that there must be at least one file
+#' inside the `src/` directory prior to building the package. As a result,
+#' if an empty `src/` directory is detected, either a `.c` or `.cpp` file will
+#' be added.
+#'
 #' @export
 use_rcpp <- function(name = NULL) {
   check_is_package("use_rcpp()")

--- a/R/rcpp.R
+++ b/R/rcpp.R
@@ -112,8 +112,8 @@ use_src_example_script <- function(name, src_type = c("cpp", "c") ) {
 
   src_type = match.arg(src_type)
 
-  if (is.null(name) && !check_directory_has_files(path("src"))) {
-    name <- "code"
+  if (!directory_has_files(path("src"))) {
+    name <- name %||% "code"
   }
 
   if(!is.null(name)) {

--- a/R/rcpp.R
+++ b/R/rcpp.R
@@ -109,3 +109,18 @@ use_makevars <- function(settings = NULL) {
     edit_file(makevars_win_path)
   }
 }
+
+use_src_example_script <- function(name, src_type = c("cpp", "c") ) {
+
+  src_type = match.arg(src_type)
+
+  if (is.null(name) && !check_directory_has_files(path("src"))) {
+    name <- "code"
+  }
+
+  if(!is.null(name)) {
+    name <- slug(name, src_type)
+    check_file_name(name)
+    use_template(slug("code", src_type), path("src", name), open = TRUE)
+  }
+}

--- a/R/rcpp.R
+++ b/R/rcpp.R
@@ -61,6 +61,9 @@ use_rcpp_eigen <- function(name = NULL) {
 #' @rdname use_rcpp
 #' @export
 use_c <- function(name = NULL) {
+  check_is_package("use_c()")
+  check_uses_roxygen("use_c()")
+
   use_src()
 
   use_src_example_script(name, "c")
@@ -69,9 +72,6 @@ use_c <- function(name = NULL) {
 }
 
 use_src <- function() {
-  check_is_package("use_src()")
-  check_uses_roxygen("use_rcpp()")
-
   use_directory("src")
   use_git_ignore(c("*.o", "*.so", "*.dll"), "src")
   roxygen_ns_append(glue("@useDynLib {project_name()}, .registration = TRUE")) &&

--- a/R/rcpp.R
+++ b/R/rcpp.R
@@ -108,15 +108,14 @@ use_makevars <- function(settings = NULL) {
   }
 }
 
-use_src_example_script <- function(name, src_type = c("cpp", "c") ) {
-
-  src_type = match.arg(src_type)
+use_src_example_script <- function(name, src_type = c("cpp", "c")) {
+  src_type <- match.arg(src_type)
 
   if (!directory_has_files(path("src"))) {
     name <- name %||% "code"
   }
 
-  if(!is.null(name)) {
+  if (!is.null(name)) {
     name <- slug(name, src_type)
     check_file_name(name)
     use_template(slug("code", src_type), path("src", name), open = TRUE)

--- a/man/use_rcpp.Rd
+++ b/man/use_rcpp.Rd
@@ -19,9 +19,13 @@ use_c(name = NULL)
 \item{name}{If supplied, creates and opens \code{src/name.{c,cpp}}.}
 }
 \description{
-Creates \code{src/}, adds required packages to \code{DESCRIPTION},
-optionally creates \code{.c} or \code{.cpp} files with a supplied name or
-if the \code{src/} is empty, and where needed, \code{Makevars} and \code{Makevars.win} files.
+Adds infrastructure commonly needed when using compiled code:
+\itemize{
+\item Creates \code{src/}
+\item Adds required packages to \code{DESCRIPTION}
+\item May create an initial placeholder \code{.c} or \code{.cpp} file
+\item Creates \code{Makevars} and \code{Makevars.win} files (\code{use_rcpp_armadillo()} only)
+}
 }
 \details{
 When using compiled code, please note that there must be at least one file

--- a/man/use_rcpp.Rd
+++ b/man/use_rcpp.Rd
@@ -20,6 +20,12 @@ use_c(name = NULL)
 }
 \description{
 Creates \code{src/}, adds required packages to \code{DESCRIPTION},
-optionally creates \code{.c} or \code{.cpp} files, and
-where needed, \code{Makevars} and \code{Makevars.win} files.
+optionally creates \code{.c} or \code{.cpp} files with a supplied name or
+if the \code{src/} is empty, and where needed, \code{Makevars} and \code{Makevars.win} files.
+}
+\details{
+When using compiled code, please note that there must be at least one file
+inside the \code{src/} directory prior to building the package. As a result,
+if an empty \code{src/} directory is detected, either a \code{.c} or \code{.cpp} file will
+be added.
 }


### PR DESCRIPTION
Fixes #720

This PR modifies both `use_rcpp()` and `use_c()` to ensure at least one source file is present in `src/`. Previously, if a source file wasn't present but the `src/` directory was, then the package would error on build.

In addition, this PR adds two new functions into the `directory.R` variant related to counting files in a directory. 