### PR TITLE
Add NEWS bullet for CircleCI fix in PR #835.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,8 @@
 
 * Remove unexported function from the signature of `use_markdown_template()` (#761, @fmichonneau).
 
+* Fix delimiters in CircleCI template used by `use_circleci()` (#835, @jdblischak)
+
 # usethis 1.5.1
 
 This is a patch release with various small features and bug fixes.


### PR DESCRIPTION
I forgot to add a NEWS bullet for my fix in PR #835. Since the version of `use_circleci()` in the current CRAN release (1.5.1) contains the bug, it will be useful for users to know they need to install the development version to use `use_circleci()`.