### PR TITLE
Allow invalid CRAN names

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # usethis (development version)
 
+* `use_description()` and `create_package()` gain the argument `stop_for_name` to control whether to allow names invalid for CRAN (#883 @noamross)
+
 * New `use_lifecycle()` helper to import the lifecycle badges for functions and arguments in your package. See https://lifecycle.r-lib.org/.
 
 * `git_sitrep()` reports email(s) associated with your GitHub account(#724, @dragosmg).

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # usethis (development version)
 
-* `use_description()` and `create_package()` gain the argument `stop_for_name` to control whether to allow names invalid for CRAN (#883 @noamross)
+* `use_description()` and `create_package()` gain the argument `check_name` to control whether to check for package names invalid for CRAN (#883, @noamross).
 
 * New `use_lifecycle()` helper to import the lifecycle badges for functions and arguments in your package. See https://lifecycle.r-lib.org/.
 

--- a/R/create.R
+++ b/R/create.R
@@ -30,14 +30,14 @@
 create_package <- function(path,
                            fields = NULL,
                            rstudio = rstudioapi::isAvailable(),
-                           stop_for_name = TRUE,
+                           check_name = TRUE,
                            open = interactive()) {
   path <- user_path_prep(path)
   check_path_is_directory(path_dir(path))
 
   name <- path_file(path)
-  if (stop_for_name) {
-    check_package_name(name, stop_for_name = stop_for_name)
+  if (check_name) {
+    check_package_name(name)
   }
   check_not_nested(path_dir(path), name)
 
@@ -46,7 +46,7 @@ create_package <- function(path,
   on.exit(proj_set(old_project), add = TRUE)
 
   use_directory("R")
-  use_description(fields, stop_for_name = stop_for_name)
+  use_description(fields, check_name = check_name)
   use_namespace()
 
   if (rstudio) {

--- a/R/create.R
+++ b/R/create.R
@@ -30,12 +30,15 @@
 create_package <- function(path,
                            fields = NULL,
                            rstudio = rstudioapi::isAvailable(),
+                           stop_for_name = TRUE,
                            open = interactive()) {
   path <- user_path_prep(path)
   check_path_is_directory(path_dir(path))
 
   name <- path_file(path)
-  check_package_name(name)
+  if (stop_for_name) {
+    check_package_name(name, stop_for_name = stop_for_name)
+  }
   check_not_nested(path_dir(path), name)
 
   create_directory(path)
@@ -43,7 +46,7 @@ create_package <- function(path,
   on.exit(proj_set(old_project), add = TRUE)
 
   use_directory("R")
-  use_description(fields)
+  use_description(fields, stop_for_name = stop_for_name)
   use_namespace()
 
   if (rstudio) {

--- a/R/description.R
+++ b/R/description.R
@@ -101,7 +101,7 @@ build_description_list <- function(fields = list()) {
   compact(utils::modifyList(defaults, fields))
 }
 
-check_package_name <- function(name, stop_for_name) {
+check_package_name <- function(name) {
   if (!valid_package_name(name)) {
     ui_stop(c(
       "{ui_value(name)} is not a valid package name. To be allowed on CRAN, it should:",

--- a/R/description.R
+++ b/R/description.R
@@ -30,8 +30,8 @@
 #' @param fields A named list of fields to add to `DESCRIPTION`, potentially
 #'   overriding default values. See [use_description()] for how you can set
 #'   personalized defaults using package options
-#' @param stop_for_name Whether to throw an error if the package name is not
-#'   valid for CRAN
+#' @param check_name Whether to check if the name is valid for CRAN and throw an
+#'   error if not
 #' @seealso The [description chapter](https://r-pkgs.org/description.html#dependencies)
 #'   of [R Packages](https://r-pkgs.org).
 #' @export
@@ -43,9 +43,11 @@
 #'
 #' use_description_defaults()
 #' }
-use_description <- function(fields = NULL, stop_for_name = FALSE) {
+use_description <- function(fields = NULL, check_name = TRUE) {
   name <- project_name()
-  check_package_name(name, stop_for_name = stop_for_name)
+  if (check_name) {
+    check_package_name(name)
+  }
   fields <- fields %||% list()
   check_is_named_list(fields)
   fields[["Package"]] <- name
@@ -101,20 +103,14 @@ build_description_list <- function(fields = list()) {
 
 check_package_name <- function(name, stop_for_name) {
   if (!valid_package_name(name)) {
-    msg <- c(
+    ui_stop(c(
       "{ui_value(name)} is not a valid package name. To be allowed on CRAN, it should:",
       "* Contain only ASCII letters, numbers, and '.'",
       "* Have at least two characters",
       "* Start with a letter",
       "* Not end with '.'"
-    )
-    if (stop_for_name) {
-      ui_stop(msg)
-    } else {
-      ui_warn(stop_for_name)
-    }
+    ))
   }
-
 }
 
 valid_package_name <- function(x) {

--- a/R/description.R
+++ b/R/description.R
@@ -30,6 +30,8 @@
 #' @param fields A named list of fields to add to `DESCRIPTION`, potentially
 #'   overriding default values. See [use_description()] for how you can set
 #'   personalized defaults using package options
+#' @param stop_for_name Whether to throw an error if the package name is not
+#'   valid for CRAN
 #' @seealso The [description chapter](https://r-pkgs.org/description.html#dependencies)
 #'   of [R Packages](https://r-pkgs.org).
 #' @export
@@ -41,9 +43,9 @@
 #'
 #' use_description_defaults()
 #' }
-use_description <- function(fields = NULL) {
+use_description <- function(fields = NULL, stop_for_name = FALSE) {
   name <- project_name()
-  check_package_name(name)
+  check_package_name(name, stop_for_name = stop_for_name)
   fields <- fields %||% list()
   check_is_named_list(fields)
   fields[["Package"]] <- name
@@ -97,15 +99,20 @@ build_description_list <- function(fields = list()) {
   compact(utils::modifyList(defaults, fields))
 }
 
-check_package_name <- function(name) {
+check_package_name <- function(name, stop_for_name) {
   if (!valid_package_name(name)) {
-    ui_stop(c(
-      "{ui_value(name)} is not a valid package name. It should:",
+    msg <- c(
+      "{ui_value(name)} is not a valid package name. To be allowed on CRAN, it should:",
       "* Contain only ASCII letters, numbers, and '.'",
       "* Have at least two characters",
       "* Start with a letter",
       "* Not end with '.'"
-    ))
+    )
+    if (stop_for_name) {
+      ui_stop(msg)
+    } else {
+      ui_warn(stop_for_name)
+    }
   }
 
 }

--- a/man/create_package.Rd
+++ b/man/create_package.Rd
@@ -6,7 +6,8 @@
 \title{Create a package or project}
 \usage{
 create_package(path, fields = NULL,
-  rstudio = rstudioapi::isAvailable(), open = interactive())
+  rstudio = rstudioapi::isAvailable(), stop_for_name = TRUE,
+  open = interactive())
 
 create_project(path, rstudio = rstudioapi::isAvailable(),
   open = interactive())
@@ -25,6 +26,9 @@ If \code{FALSE} and a non-package project, a sentinel \code{.here} file is place
 that the directory can be recognized as a project by the
 \href{https://here.r-lib.org}{here} or
 \href{https://rprojroot.r-lib.org}{rprojroot} packages.}
+
+\item{stop_for_name}{Whether to throw an error if the package name is not
+valid for CRAN}
 
 \item{open}{If \code{TRUE}, \link[=proj_activate]{activates} the new project:
 \itemize{

--- a/man/create_package.Rd
+++ b/man/create_package.Rd
@@ -6,7 +6,7 @@
 \title{Create a package or project}
 \usage{
 create_package(path, fields = NULL,
-  rstudio = rstudioapi::isAvailable(), stop_for_name = TRUE,
+  rstudio = rstudioapi::isAvailable(), check_name = TRUE,
   open = interactive())
 
 create_project(path, rstudio = rstudioapi::isAvailable(),
@@ -27,8 +27,8 @@ that the directory can be recognized as a project by the
 \href{https://here.r-lib.org}{here} or
 \href{https://rprojroot.r-lib.org}{rprojroot} packages.}
 
-\item{stop_for_name}{Whether to throw an error if the package name is not
-valid for CRAN}
+\item{check_name}{Whether to check if the name is valid for CRAN and throw an
+error if not}
 
 \item{open}{If \code{TRUE}, \link[=proj_activate]{activates} the new project:
 \itemize{

--- a/man/use_description.Rd
+++ b/man/use_description.Rd
@@ -5,7 +5,7 @@
 \alias{use_description_defaults}
 \title{Create or modify a DESCRIPTION file}
 \usage{
-use_description(fields = NULL, stop_for_name = FALSE)
+use_description(fields = NULL, check_name = TRUE)
 
 use_description_defaults()
 }
@@ -14,8 +14,8 @@ use_description_defaults()
 overriding default values. See \code{\link[=use_description]{use_description()}} for how you can set
 personalized defaults using package options}
 
-\item{stop_for_name}{Whether to throw an error if the package name is not
-valid for CRAN}
+\item{check_name}{Whether to check if the name is valid for CRAN and throw an
+error if not}
 }
 \description{
 usethis consults the following sources, in this order, to set \code{DESCRIPTION}

--- a/man/use_description.Rd
+++ b/man/use_description.Rd
@@ -5,7 +5,7 @@
 \alias{use_description_defaults}
 \title{Create or modify a DESCRIPTION file}
 \usage{
-use_description(fields = NULL)
+use_description(fields = NULL, stop_for_name = FALSE)
 
 use_description_defaults()
 }
@@ -13,6 +13,9 @@ use_description_defaults()
 \item{fields}{A named list of fields to add to \code{DESCRIPTION}, potentially
 overriding default values. See \code{\link[=use_description]{use_description()}} for how you can set
 personalized defaults using package options}
+
+\item{stop_for_name}{Whether to throw an error if the package name is not
+valid for CRAN}
 }
 \description{
 usethis consults the following sources, in this order, to set \code{DESCRIPTION}

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -67,7 +67,7 @@ scoped_temporary_thing <- function(dir = file_temp(pattern = pattern),
   switch(
     thing,
     package = create_package(dir, rstudio = rstudio, open = FALSE,
-                             stop_for_name = FALSE),
+                             check_name = FALSE),
     project = create_project(dir, rstudio = rstudio, open = FALSE)
   )
   proj_set(dir)

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -66,7 +66,8 @@ scoped_temporary_thing <- function(dir = file_temp(pattern = pattern),
   withr::local_options(list(usethis.quiet = TRUE))
   switch(
     thing,
-    package = create_package(dir, rstudio = rstudio, open = FALSE),
+    package = create_package(dir, rstudio = rstudio, open = FALSE,
+                             stop_for_name = FALSE),
     project = create_project(dir, rstudio = rstudio, open = FALSE)
   )
   proj_set(dir)

--- a/tests/testthat/test-use-description.R
+++ b/tests/testthat/test-use-description.R
@@ -71,7 +71,7 @@ test_that("default description is tidy", {
 test_that("valid CRAN names checked", {
   withr::local_options(list(usethis.description = NULL, devtools.desc = NULL))
   scoped_temporary_package(dir = file_temp(pattern = "invalid_pkg_name"))
-  expect_error(use_description(check_name = FALSE), NA)
+  expect_error_free(use_description(check_name = FALSE))
   expect_error(
     use_description(check_name = TRUE),
     "is not a valid package name",

--- a/tests/testthat/test-use-description.R
+++ b/tests/testthat/test-use-description.R
@@ -67,3 +67,13 @@ test_that("default description is tidy", {
   desc_lines_after <- readLines(proj_path("DESCRIPTION"))
   expect_identical(desc_lines_before, desc_lines_after)
 })
+
+test_that("valid CRAN names checked", {
+  withr::local_options(list(usethis.description = NULL, devtools.desc = NULL))
+  suppressWarnings(
+    scoped_temporary_package(dir = file_temp(pattern = "invalid_pkg_name"))
+  )
+  expect_warning(use_description())
+  expect_error(use_description(stop_for_name = TRUE))
+})
+

--- a/tests/testthat/test-use-description.R
+++ b/tests/testthat/test-use-description.R
@@ -70,10 +70,12 @@ test_that("default description is tidy", {
 
 test_that("valid CRAN names checked", {
   withr::local_options(list(usethis.description = NULL, devtools.desc = NULL))
-  suppressWarnings(
-    scoped_temporary_package(dir = file_temp(pattern = "invalid_pkg_name"))
+  scoped_temporary_package(dir = file_temp(pattern = "invalid_pkg_name"))
+  expect_error(use_description(check_name = FALSE), NA)
+  expect_error(
+    use_description(check_name = TRUE),
+    "is not a valid package name",
+    class = "usethis_error"
   )
-  expect_warning(use_description())
-  expect_error(use_description(stop_for_name = TRUE))
 })
 


### PR DESCRIPTION
- `stop_for_name` controls whether to throw error
  for invalid CRAN package names
- Default to warning for `use_description()`, error
  for `create_package()`
- Add tests
- update NEWS

I am unsure if `stop_for_name` is the best argument name, open to other suggestions!

Closes #528 