### PR TITLE
allow "." to be used with create_package()

### DIFF
--- a/R/proj.R
+++ b/R/proj.R
@@ -150,7 +150,7 @@ proj_path_prep <- function(path) {
 user_path_prep <- function(path) {
   ## usethis uses fs's notion of home directory
   ## this ensures we are consistent about that
-  path_expand(path)
+  path_real(path)
 }
 
 proj_rel_path <- function(path) {

--- a/tests/testthat/test-create.R
+++ b/tests/testthat/test-create.R
@@ -55,6 +55,16 @@ test_that("create_* works w/ non-existing rel path and absolutizes it", {
   expect_true(dir_exists(path_temp(path_project)))
 })
 
+test_that("create_package works with . for current directory", {
+  pkg_path <- path_temp()
+  withr::with_dir(
+           pkg_path,
+           create_package(".", rstudio = FALSE, open = FALSE)
+         )
+  expect_true(is_package(pkg_path))
+  dir_delete(pkg_path)
+})
+
 test_that("rationalize_fork() honors fork = FALSE", {
   expect_false(
     rationalize_fork(fork = FALSE, repo_info = list(), auth_token = "PAT")


### PR DESCRIPTION
- fixes #777 
- replaced `path_expand` with `path_real` in `user_path_prep`
- added a to check a valid package can be created using "." within a temp dir.