### PR TITLE
Restrict options of snippet types

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # usethis (development version)
 
+* `edit_rstudio_snippets()` makes it more clear which snippet types are allowed and that user's snippets mask the built-in snippets (#885, @GegznaV).
+
 * `use_description()` and `create_package()` gain the argument `check_name` to control whether to check for package names invalid for CRAN (#883, @noamross).
 
 * New `use_lifecycle()` helper to import the lifecycle badges for functions and arguments in your package. See https://lifecycle.r-lib.org/.

--- a/R/edit.R
+++ b/R/edit.R
@@ -107,7 +107,7 @@ edit_rstudio_snippets <- function(type = "r") {
   if (!file_exists(path)) {
     ui_done("File for snippets created {ui_path(path)}")
     ui_warn(c("The default snippets for {ui_field(type)} may not work!",
-      "To restore the default snippets, this file should be deleted and RStudio restarted."))
+      "If it is needed to restore the default snippets, this file should be deleted and RStudio restarted."))
   }
   edit_file(path)
 }

--- a/R/edit.R
+++ b/R/edit.R
@@ -95,12 +95,15 @@ edit_r_makevars <- function(scope = c("user", "project")) {
 
 #' @export
 #' @rdname edit
-#' @param type Snippet type. One of: "R", "markdown", "C_Cpp", "Tex",
-#'   "Javascript", "HTML", "SQL"
-edit_rstudio_snippets <- function(type = "R") {
+#' @param type Snippet type. One of: "r", "markdown", "c_cpp", "css", "html",
+#' "java", "javascript", "python", "sql", "stan", "tex" (case insensitive).
+edit_rstudio_snippets <- function(type = "r") {
   # RStudio snippets stored using R's definition of ~
   # https://github.com/rstudio/rstudio/blob/4febd2feba912b2a9f8e77e3454a95c23a09d0a2/src/cpp/core/system/Win32System.cpp#L411-L458
-  path <- path_home_r(".R", "snippets", path_ext_set(tolower(type), "snippets"))
+  available_types <- c("r", "markdown", "c_cpp", "css", "html", "java",
+    "javascript", "python", "sql", "stan", "tex")
+  type <- match.arg(tolower(type), available_types)
+  path <- path_home_r(".R", "snippets", path_ext_set(type, "snippets"))
   edit_file(path)
 }
 

--- a/R/edit.R
+++ b/R/edit.R
@@ -105,9 +105,11 @@ edit_rstudio_snippets <- function(type = c("r", "markdown", "c_cpp", "css",
 
   path <- path_home_r(".R", "snippets", path_ext_set(type, "snippets"))
   if (!file_exists(path)) {
-    ui_done("File for snippets created {ui_path(path)}")
-    ui_warn(c("The default snippets for {ui_field(type)} may not work!",
-      "If it is needed to restore the default snippets, this file should be deleted and RStudio restarted."))
+    ui_done("New snippet file at {ui_path(path)}")
+    ui_info(c(
+      "This masks the default snippets for {ui_field(type)}.",
+      "Delete this file and restart RStudio to restore the default snippets."
+    ))
   }
   edit_file(path)
 }

--- a/R/edit.R
+++ b/R/edit.R
@@ -104,6 +104,11 @@ edit_rstudio_snippets <- function(type = "r") {
     "javascript", "python", "sql", "stan", "tex")
   type <- match.arg(tolower(type), available_types)
   path <- path_home_r(".R", "snippets", path_ext_set(type, "snippets"))
+  if (!file_exists(path)) {
+    ui_done("File for snippets created {ui_path(path)}")
+    ui_warn(c("The default snippets for {ui_field(type)} may not work!",
+      "To restore the default snippets, this file should be deleted and RStudio restarted."))
+  }
   edit_file(path)
 }
 

--- a/R/edit.R
+++ b/R/edit.R
@@ -95,14 +95,14 @@ edit_r_makevars <- function(scope = c("user", "project")) {
 
 #' @export
 #' @rdname edit
-#' @param type Snippet type. One of: "r", "markdown", "c_cpp", "css", "html",
-#' "java", "javascript", "python", "sql", "stan", "tex" (case insensitive).
-edit_rstudio_snippets <- function(type = "r") {
+#' @param type Snippet type (case insensitive text).
+edit_rstudio_snippets <- function(type = c("r", "markdown", "c_cpp", "css",
+  "html", "java", "javascript", "python", "sql", "stan", "tex")) {
   # RStudio snippets stored using R's definition of ~
   # https://github.com/rstudio/rstudio/blob/4febd2feba912b2a9f8e77e3454a95c23a09d0a2/src/cpp/core/system/Win32System.cpp#L411-L458
-  available_types <- c("r", "markdown", "c_cpp", "css", "html", "java",
-    "javascript", "python", "sql", "stan", "tex")
-  type <- match.arg(tolower(type), available_types)
+  type <- tolower(type)
+  type <- match.arg(type)
+
   path <- path_home_r(".R", "snippets", path_ext_set(type, "snippets"))
   if (!file_exists(path)) {
     ui_done("File for snippets created {ui_path(path)}")

--- a/man/edit.Rd
+++ b/man/edit.Rd
@@ -19,7 +19,8 @@ edit_r_buildignore(scope = c("user", "project"))
 
 edit_r_makevars(scope = c("user", "project"))
 
-edit_rstudio_snippets(type = "r")
+edit_rstudio_snippets(type = c("r", "markdown", "c_cpp", "css", "html",
+  "java", "javascript", "python", "sql", "stan", "tex"))
 
 edit_git_config(scope = c("user", "project"))
 
@@ -29,8 +30,7 @@ edit_git_ignore(scope = c("user", "project"))
 \item{scope}{Edit globally for the current \strong{user}, or locally for the
 current \strong{project}}
 
-\item{type}{Snippet type. One of: "r", "markdown", "c_cpp", "css", "html",
-"java", "javascript", "python", "sql", "stan", "tex" (case insensitive).}
+\item{type}{Snippet type (case insensitive text).}
 }
 \value{
 Path to the file, invisibly.

--- a/man/edit.Rd
+++ b/man/edit.Rd
@@ -19,7 +19,7 @@ edit_r_buildignore(scope = c("user", "project"))
 
 edit_r_makevars(scope = c("user", "project"))
 
-edit_rstudio_snippets(type = "R")
+edit_rstudio_snippets(type = "r")
 
 edit_git_config(scope = c("user", "project"))
 
@@ -29,8 +29,8 @@ edit_git_ignore(scope = c("user", "project"))
 \item{scope}{Edit globally for the current \strong{user}, or locally for the
 current \strong{project}}
 
-\item{type}{Snippet type. One of: "R", "markdown", "C_Cpp", "Tex",
-"Javascript", "HTML", "SQL"}
+\item{type}{Snippet type. One of: "r", "markdown", "c_cpp", "css", "html",
+"java", "javascript", "python", "sql", "stan", "tex" (case insensitive).}
 }
 \value{
 Path to the file, invisibly.

--- a/tests/testthat/test-edit.R
+++ b/tests/testthat/test-edit.R
@@ -52,9 +52,13 @@ test_that("edit_r_XXX('user') ensures the file exists", {
   edit_r_makevars("user")
   expect_r_file(".R", "Makevars")
 
+  # Expect warning as a new file is created
+  expect_warning(edit_rstudio_snippets(type = "R"))
+  # No warning is expected as the file already exists
   edit_rstudio_snippets(type = "R")
   expect_r_file(".R", "snippets", "r.snippets")
-  edit_rstudio_snippets(type = "HTML")
+  # Expect warning as a new file is created
+  expect_warning(edit_rstudio_snippets(type = "HTML"))
   expect_r_file(".R", "snippets", "html.snippets")
   expect_error(edit_rstudio_snippets("not-existing-type"))
 })

--- a/tests/testthat/test-edit.R
+++ b/tests/testthat/test-edit.R
@@ -51,16 +51,16 @@ test_that("edit_r_XXX('user') ensures the file exists", {
 
   edit_r_makevars("user")
   expect_r_file(".R", "Makevars")
-
-  # Expect warning as a new file is created
-  expect_warning(edit_rstudio_snippets(type = "R"))
-  # No warning is expected as the file already exists
+  
+  
   edit_rstudio_snippets(type = "R")
   expect_r_file(".R", "snippets", "r.snippets")
-  # Expect warning as a new file is created
-  expect_warning(edit_rstudio_snippets(type = "HTML"))
+  edit_rstudio_snippets(type = "HTML")
   expect_r_file(".R", "snippets", "html.snippets")
-  expect_error(edit_rstudio_snippets("not-existing-type"))
+  expect_error(
+    edit_rstudio_snippets("not-existing-type"),
+    regexp = "should be one of"
+  )
 })
 
 test_that("edit_r_profile() respects R_PROFILE_USER", {

--- a/tests/testthat/test-edit.R
+++ b/tests/testthat/test-edit.R
@@ -56,6 +56,7 @@ test_that("edit_r_XXX('user') ensures the file exists", {
   expect_r_file(".R", "snippets", "r.snippets")
   edit_rstudio_snippets(type = "HTML")
   expect_r_file(".R", "snippets", "html.snippets")
+  expect_error(edit_rstudio_snippets("not-existing-type"))
 })
 
 test_that("edit_r_profile() respects R_PROFILE_USER", {


### PR DESCRIPTION
Restrict options of snippet types and warn if the default snippets are masked.
Closes #885
