### PR TITLE
Use proper abbrev in use_ccby_license()

### DIFF
--- a/R/license.R
+++ b/R/license.R
@@ -11,7 +11,7 @@
 #'   provides patent protection.
 #' * [GPL v3](https://choosealicense.com/licenses/gpl-3.0/): requires sharing
 #'   of improvements.
-#' * [CCBY 4.0](https://creativecommons.org/licenses/by/4.0/): Free to share and
+#' * [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/): Free to share and
 #'    adapt, must give appropriate credit. Appropriate for data packages.
 #'
 #' See <https://choosealicense.com> for more details and other options.
@@ -101,7 +101,7 @@ use_ccby_license <- function(name = find_name()) {
   force(name)
   check_is_package("use_ccby_license()")
 
-  use_description_field("License", "CCBY-4.0", overwrite = TRUE)
+  use_description_field("License", "CC BY 4.0", overwrite = TRUE)
   use_license_template("ccby-4", name)
 }
 

--- a/man/licenses.Rd
+++ b/man/licenses.Rd
@@ -37,7 +37,7 @@ to public domain. Appropriate for data packages.
 provides patent protection.
 \item \href{https://choosealicense.com/licenses/gpl-3.0/}{GPL v3}: requires sharing
 of improvements.
-\item \href{https://creativecommons.org/licenses/by/4.0/}{CCBY 4.0}: Free to share and
+\item \href{https://creativecommons.org/licenses/by/4.0/}{CC BY 4.0}: Free to share and
 adapt, must give appropriate credit. Appropriate for data packages.
 }
 

--- a/tests/testthat/test-use-license.R
+++ b/tests/testthat/test-use-license.R
@@ -67,7 +67,7 @@ test_that("use_cc0_license() works", {
 test_that("use_ccby_license() works", {
   pkg <- scoped_temporary_package()
   use_ccby_license(name = "CCBY-4.0 License")
-  expect_match(desc::desc_get("License", file = pkg), "CCBY-4.0")
+  expect_match(desc::desc_get("License", file = pkg), "CC BY 4.0")
   expect_proj_file("LICENSE.md")
   expect_true(is_build_ignored("^LICENSE\\.md$"))
 })


### PR DESCRIPTION
Closes r-lib/usethis#898 by using the proper license abbreviation as defined by the R project license documentation on [line 259](https://github.com/wch/r-source/blob/886ab4a0b7536c62fcb7c02d8a76430510d2c396/share/licenses/license.db#L259):

> Name: Creative Commons Attribution 4.0 International License
> **Abbrev: CC BY 4.0**
> FSF: free_and_GPLv3_incompatible
> URL: https://creativecommons.org/licenses/by/4.0
> FOSS: yes
> Extensible: yes

By using "CC BY 4.0" over "CCBY-4.0" packages made with `usethis::use_ccby_license()` pass the `devtools::check()` without any warnings.

```
── R CMD check results ── issue 0.0.0.9001 ──
Duration: 3s

0 errors ✔ | 0 warnings ✔ | 0 notes ✔
```

Previously, `devtools::check()` returned a warning that a "non-standard" license was being used.

```
── R CMD check results ── issue 0.0.0.9000 ──
Duration: 3.1s

❯ checking DESCRIPTION meta-information ... WARNING
  Non-standard license specification:
    CCBY-4.0
  Standardizable: FALSE

0 errors ✔ | 1 warning ✖ | 0 notes ✔
```
