### PR TITLE
Avoid byte-compiling when installing from RStudio

### DIFF
--- a/inst/templates/template.Rproj
+++ b/inst/templates/template.Rproj
@@ -12,5 +12,5 @@ StripTrailingWhitespace: Yes
 
 BuildType: Package
 PackageUseDevtools: Yes
-PackageInstallArgs: --no-multiarch --with-keep.source
+PackageInstallArgs: --no-multiarch --with-keep.source --no-byte-compile
 PackageRoxygenize: rd,collate,namespace


### PR DESCRIPTION
This settings shaves off ~1 second or more for installing a package using Ctrl + Shift + B (Cmd + Shift + B).