### PR TITLE
Allow create_package() to use "." once more

### DIFF
--- a/R/create.R
+++ b/R/create.R
@@ -35,7 +35,7 @@ create_package <- function(path,
   path <- user_path_prep(path)
   check_path_is_directory(path_dir(path))
 
-  name <- path_file(path)
+  name <- path_file(path_real(path))
   if (check_name) {
     check_package_name(name)
   }

--- a/tests/testthat/test-create.R
+++ b/tests/testthat/test-create.R
@@ -37,6 +37,12 @@ test_that("nested project is disallowed, by default", {
   expect_usethis_error(scoped_temporary_project(path(dir, "abcde")), "anyway")
 })
 
+test_that("can create package in current directory", {
+  dir <- dir_create(path(file_temp(), "mypackage"))
+  withr::local_dir(dir)
+  expect_error_free(create_package("."))
+})
+
 ## https://github.com/r-lib/usethis/issues/227
 test_that("create_* works w/ non-existing rel path and absolutizes it", {
   ## take care to provide a **non-absolute** path


### PR DESCRIPTION
Fixes #777

I think this should be safe because it's only affects the name of the package, and it doesn't break any tests, but I'd appreciate a second pair of eyes
