### PR TITLE
Use messages rather than cat to output

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -49,7 +49,7 @@ Suggests:
     styler (>= 1.0.2),
     testthat (>= 2.1.0)
 Remotes:
-    rlang
+    r-lib/rlang
 Encoding: UTF-8
 Language: en-US
 LazyData: true

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -54,4 +54,4 @@ Encoding: UTF-8
 Language: en-US
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 6.1.99.9001
+RoxygenNote: 6.1.1

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,7 +30,7 @@ Imports:
     git2r (>= 0.23),
     glue (>= 1.3.0),
     purrr,
-    rlang,
+    rlang (>= 0.4.1.9000),
     rprojroot (>= 1.2),
     rstudioapi,
     stats,
@@ -48,6 +48,8 @@ Suggests:
     spelling (>= 1.2),
     styler (>= 1.0.2),
     testthat (>= 2.1.0)
+Remotes:
+    rlang
 Encoding: UTF-8
 Language: en-US
 LazyData: true

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 * New `use_github_actions()`, `use_github_action_check_release()`, `use_github_action_check_full()`,
   `use_github_action_pr_commands()`, `use_github_actions_tidy()` to set up a GitHub Actions
   for a package (@jimhester).
+* usethis now outputs with message conditions on standard output. (@jimhester)
 
 * New `use_data_table()` to set up a package for Import-ing `data.table` (#897, @michaelchirico).
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,7 +3,8 @@
 * New `use_github_actions()`, `use_github_action_check_release()`, `use_github_action_check_full()`,
   `use_github_action_pr_commands()`, `use_github_actions_tidy()` to set up a GitHub Actions
   for a package (@jimhester).
-* usethis now outputs with message conditions on standard output. (@jimhester)
+
+* usethis now outputs with message conditions. (@jimhester)
 
 * New `use_data_table()` to set up a package for Import-ing `data.table` (#897, @michaelchirico).
 

--- a/R/ui.R
+++ b/R/ui.R
@@ -272,7 +272,9 @@ cat_line <- function(..., quiet = getOption("usethis.quiet", default = FALSE)) {
   }
 
   lines <- paste0(..., "\n")
-  cat(lines, sep = "")
+  inform_on_stdout(lines)
+
+  invisible()
 }
 
 # Sitrep helpers ---------------------------------------------------------------
@@ -288,4 +290,20 @@ kv_line <- function(key, value) {
     value <- ui_value(value)
   }
   cat_line("* ", key, ": ", value)
+}
+
+# This is a version of rlang::inform / base::message which outputs on stdout
+# instead of stderr, which avoids red text in RStudio and the Windows GUI
+inform_on_stdout <- function(message, ..., .file = stdout(), .subclass = NULL) {
+  message <- paste0(message, collapse = "\n")
+  message <- paste0(message, "\n")
+  cnd <- rlang::message_cnd(.subclass, ..., message = message)
+  message(cnd)
+  #withRestarts(
+    #expr = {
+      #signalCondition(cnd)
+      #cat(conditionMessage(cnd), file = .file, sep = "")
+    #},
+    #muffleMessage = function() NULL
+  #)
 }

--- a/R/ui.R
+++ b/R/ui.R
@@ -272,7 +272,7 @@ cat_line <- function(..., quiet = getOption("usethis.quiet", default = FALSE)) {
   }
 
   lines <- paste0(..., "\n")
-  inform_on_stdout(lines)
+  rlang::inform(lines)
 
   invisible()
 }
@@ -290,20 +290,4 @@ kv_line <- function(key, value) {
     value <- ui_value(value)
   }
   cat_line("* ", key, ": ", value)
-}
-
-# This is a version of rlang::inform / base::message which outputs on stdout
-# instead of stderr, which avoids red text in RStudio and the Windows GUI
-inform_on_stdout <- function(message, ..., .file = stdout(), .subclass = NULL) {
-  message <- paste0(message, collapse = "\n")
-  message <- paste0(message, "\n")
-  cnd <- rlang::message_cnd(.subclass, ..., message = message)
-  message(cnd)
-  #withRestarts(
-    #expr = {
-      #signalCondition(cnd)
-      #cat(conditionMessage(cnd), file = .file, sep = "")
-    #},
-    #muffleMessage = function() NULL
-  #)
 }

--- a/revdep/README.md
+++ b/revdep/README.md
@@ -2,56 +2,63 @@
 
 |field    |value                        |
 |:--------|:----------------------------|
-|version  |R version 3.6.0 (2019-04-26) |
-|os       |macOS Mojave 10.14.4         |
+|version  |R version 3.6.1 (2019-07-05) |
+|os       |macOS Mojave 10.14.6         |
 |system   |x86_64, darwin15.6.0         |
 |ui       |X11                          |
 |language |(EN)                         |
-|collate  |en_CA.UTF-8                  |
-|ctype    |en_CA.UTF-8                  |
-|tz       |America/Vancouver            |
-|date     |2019-07-03                   |
+|collate  |en_US.UTF-8                  |
+|ctype    |en_US.UTF-8                  |
+|tz       |America/New_York             |
+|date     |2019-11-12                   |
 
 # Dependencies
 
 |package    |old    |new        |Δ  |
 |:----------|:------|:----------|:--|
-|usethis    |1.5.0  |1.5.0.9000 |*  |
+|usethis    |1.5.1  |1.5.1.9000 |*  |
 |askpass    |1.1    |1.1        |   |
 |assertthat |0.2.1  |0.2.1      |   |
-|backports  |1.1.4  |1.1.4      |   |
-|clipr      |0.6.0  |0.6.0      |   |
+|backports  |1.1.5  |1.1.5      |   |
+|clipr      |0.7.0  |0.7.0      |   |
 |clisymbols |1.2.0  |1.2.0      |   |
 |crayon     |1.3.4  |1.3.4      |   |
-|curl       |3.3    |3.3        |   |
+|curl       |4.2    |4.2        |   |
 |desc       |1.2.0  |1.2.0      |   |
 |fs         |1.3.1  |1.3.1      |   |
 |gh         |1.0.1  |1.0.1      |   |
 |git2r      |0.26.1 |0.26.1     |   |
 |glue       |1.3.1  |1.3.1      |   |
-|httr       |1.4.0  |1.4.0      |   |
+|httr       |1.4.1  |1.4.1      |   |
 |ini        |0.3.1  |0.3.1      |   |
 |jsonlite   |1.6    |1.6        |   |
 |magrittr   |1.5    |1.5        |   |
 |mime       |0.7    |0.7        |   |
-|openssl    |1.4    |1.4        |   |
-|purrr      |0.3.2  |0.3.2      |   |
+|openssl    |1.4.1  |1.4.1      |   |
+|purrr      |0.3.3  |0.3.3      |   |
 |R6         |2.4.0  |2.4.0      |   |
-|Rcpp       |1.0.1  |1.0.1      |   |
-|rlang      |0.4.0  |0.4.0      |   |
+|Rcpp       |1.0.3  |1.0.3      |   |
+|rlang      |0.4.1  |0.4.1.9000 |*  |
 |rprojroot  |1.3-2  |1.3-2      |   |
 |rstudioapi |0.10   |0.10       |   |
-|sys        |3.2    |3.2        |   |
-|whisker    |0.3-2  |0.3-2      |   |
+|sys        |3.3    |3.3        |   |
+|whisker    |0.4    |0.4        |   |
 |withr      |2.1.2  |2.1.2      |   |
 |yaml       |2.2.0  |2.2.0      |   |
 
 # Revdeps
 
-## Failed to check (2)
+## Failed to check (1)
 
-|package |version |error |warning |note |
-|:-------|:-------|:-----|:-------|:----|
-|portalr |0.2.5   |1     |        |     |
-|POUMM   |2.1.5   |1     |        |     |
+|package   |version |error |warning |note |
+|:---------|:-------|:-----|:-------|:----|
+|codemetar |0.1.8   |1     |        |1    |
+
+## New problems (3)
+
+|package                                  |version |error  |warning |note |
+|:----------------------------------------|:-------|:------|:-------|:----|
+|[DataPackageR](problems.md#datapackager) |0.15.7  |__+1__ |        |     |
+|[devtools](problems.md#devtools)         |2.2.1   |       |__+1__  |     |
+|[portalr](problems.md#portalr)           |0.2.7   |__+1__ |        |     |
 

--- a/revdep/failures.md
+++ b/revdep/failures.md
@@ -1,15 +1,15 @@
-# portalr
+# codemetar
 
 <details>
 
-* Version: 0.2.5
-* Source code: https://github.com/cran/portalr
-* URL: https://weecology.github.io/portalr/, https://github.com/weecology/portalr
-* BugReports: https://github.com/weecology/portalr/issues
-* Date/Publication: 2019-06-22 04:40:04 UTC
-* Number of recursive dependencies: 127
+* Version: 0.1.8
+* Source code: https://github.com/cran/codemetar
+* URL: https://github.com/ropensci/codemetar, https://ropensci.github.io/codemetar
+* BugReports: https://github.com/ropensci/codemetar/issues
+* Date/Publication: 2019-04-22 04:20:03 UTC
+* Number of recursive dependencies: 80
 
-Run `revdep_details(,"portalr")` for more info
+Run `revdep_details(,"codemetar")` for more info
 
 </details>
 
@@ -18,56 +18,9 @@ Run `revdep_details(,"portalr")` for more info
 *   R CMD check timed out
     
 
-# POUMM
-
-<details>
-
-* Version: 2.1.5
-* Source code: https://github.com/cran/POUMM
-* URL: https://venelin.github.io/POUMM/index.html, https://github.com/venelin/POUMM
-* BugReports: https://github.com/venelin/POUMM/issues
-* Date/Publication: 2019-03-27 12:20:03 UTC
-* Number of recursive dependencies: 82
-
-Run `revdep_details(,"POUMM")` for more info
-
-</details>
-
-## In both
-
-*   checking whether package ‘POUMM’ can be installed ... ERROR
+*   checking dependencies in R code ... NOTE
     ```
-    Installation failed.
-    See ‘/Users/jenny/rrr/usethis/revdep/checks.noindex/POUMM/new/POUMM.Rcheck/00install.out’ for details.
+    Namespace in Imports field not imported from: ‘memoise’
+      All declared Imports should be used.
     ```
 
-## Installation
-
-### Devel
-
-```
-* installing *source* package ‘POUMM’ ...
-** package ‘POUMM’ successfully unpacked and MD5 sums checked
-** using staged installation
-** libs
-clang++ -std=gnu++11 -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG  -I"/Users/jenny/rrr/usethis/revdep/library.noindex/usethis/new/Rcpp/include" -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk -I/usr/local/include -fopenmp  -fPIC  -Wall -g -O2  -c Rcpp.cpp -o Rcpp.o
-clang: error: unsupported option '-fopenmp'
-make: *** [Rcpp.o] Error 1
-ERROR: compilation failed for package ‘POUMM’
-* removing ‘/Users/jenny/rrr/usethis/revdep/checks.noindex/POUMM/new/POUMM.Rcheck/POUMM’
-
-```
-### CRAN
-
-```
-* installing *source* package ‘POUMM’ ...
-** package ‘POUMM’ successfully unpacked and MD5 sums checked
-** using staged installation
-** libs
-clang++ -std=gnu++11 -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG  -I"/Users/jenny/rrr/usethis/revdep/library.noindex/usethis/old/Rcpp/include" -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk -I/usr/local/include -fopenmp  -fPIC  -Wall -g -O2  -c Rcpp.cpp -o Rcpp.o
-clang: error: unsupported option '-fopenmp'
-make: *** [Rcpp.o] Error 1
-ERROR: compilation failed for package ‘POUMM’
-* removing ‘/Users/jenny/rrr/usethis/revdep/checks.noindex/POUMM/old/POUMM.Rcheck/POUMM’
-
-```

--- a/revdep/problems.md
+++ b/revdep/problems.md
@@ -1,1 +1,110 @@
-*Wow, no problems at all. :)*
+# DataPackageR
+
+<details>
+
+* Version: 0.15.7
+* Source code: https://github.com/cran/DataPackageR
+* URL: https://github.com/ropensci/DataPackageR
+* BugReports: https://github.com/ropensci/DataPackageR/issues
+* Date/Publication: 2019-03-30 17:40:03 UTC
+* Number of recursive dependencies: 105
+
+Run `revdep_details(,"DataPackageR")` for more info
+
+</details>
+
+## Newly broken
+
+*   checking tests ...
+    ```
+     ERROR
+    Running the tests in ‘tests/testthat.R’ failed.
+    Last 13 lines of output:
+        files:
+          subsetCars.Rmd:
+            enabled: yes
+          extra.rmd:
+            enabled: yes
+        objects: cars_over_20
+        render_root: dummy
+      
+      subsetCars.Rmd extra.rmd
+      cars_over_20══ testthat results  ═══════════════════════════════════════════════════════════
+      [ OK: 209 | SKIPPED: 0 | WARNINGS: 0 | FAILED: 1 ]
+      1. Failure: use_ignore works (@test-ignore.R#16) 
+      
+      Error: testthat unit tests failed
+      Execution halted
+    ```
+
+# devtools
+
+<details>
+
+* Version: 2.2.1
+* Source code: https://github.com/cran/devtools
+* URL: https://github.com/r-lib/devtools
+* BugReports: https://github.com/r-lib/devtools/issues
+* Date/Publication: 2019-09-24 15:00:02 UTC
+* Number of recursive dependencies: 123
+
+Run `revdep_details(,"devtools")` for more info
+
+</details>
+
+## Newly broken
+
+*   checking for code/documentation mismatches ... WARNING
+    ```
+    Codoc mismatches from documentation object 'create':
+    create
+      Code: function(path, fields = NULL, rstudio =
+                     rstudioapi::isAvailable(), check_name = TRUE, open =
+                     interactive())
+      Docs: function(path, fields = NULL, rstudio =
+                     rstudioapi::isAvailable(), open = interactive())
+      Argument names in code not in docs:
+        check_name
+      Mismatches in argument names:
+        Position: 4 Code: check_name Docs: open
+    ```
+
+# portalr
+
+<details>
+
+* Version: 0.2.7
+* Source code: https://github.com/cran/portalr
+* URL: https://weecology.github.io/portalr/, https://github.com/weecology/portalr
+* BugReports: https://github.com/weecology/portalr/issues
+* Date/Publication: 2019-10-04 22:00:02 UTC
+* Number of recursive dependencies: 121
+
+Run `revdep_details(,"portalr")` for more info
+
+</details>
+
+## Newly broken
+
+*   checking tests ...
+    ```
+     ERROR
+    Running the tests in ‘tests/testthat.R’ failed.
+    Last 13 lines of output:
+      Actual value: ""
+      
+      ── 4. Failure: default data path functions work if unset (@test-01-data-retrieva
+      `m` does not match "Make sure '.Renviron' ends with a newline!".
+      Actual value: ""
+      
+      ══ testthat results  ═══════════════════════════════════════════════════════════
+      [ OK: 174 | SKIPPED: 10 | WARNINGS: 0 | FAILED: 4 ]
+      1. Failure: default data path functions work if unset (@test-01-data-retrieval.R#107) 
+      2. Failure: default data path functions work if unset (@test-01-data-retrieval.R#108) 
+      3. Failure: default data path functions work if unset (@test-01-data-retrieval.R#109) 
+      4. Failure: default data path functions work if unset (@test-01-data-retrieval.R#110) 
+      
+      Error: testthat unit tests failed
+      Execution halted
+    ```
+

--- a/tests/testthat/test-roxygen.R
+++ b/tests/testthat/test-roxygen.R
@@ -4,7 +4,7 @@ test_that("use_package_doc() compatible with roxygen_ns_append()", {
   scoped_temporary_package()
   withr::local_options(list(usethis.quiet = FALSE))
 
-  expect_output(use_package_doc())
-  expect_output(roxygen_ns_append("test"), "Adding 'test'")
+  expect_message(use_package_doc())
+  expect_message(roxygen_ns_append("test"), "Adding 'test'")
   expect_silent(roxygen_ns_append("test"))
 })

--- a/tests/testthat/test-use-badge.R
+++ b/tests/testthat/test-use-badge.R
@@ -31,7 +31,7 @@ test_that("default readme has placeholders / can add to empty badge block", {
   scoped_temporary_package()
   withr::local_options(list(usethis.quiet = FALSE))
 
-  expect_output(use_readme_md())
-  expect_output(use_cran_badge(), "Adding CRAN status badge")
+  expect_message(use_readme_md())
+  expect_message(use_cran_badge(), "Adding CRAN status badge")
   expect_silent(use_cran_badge())
 })

--- a/tests/testthat/test-use-course.R
+++ b/tests/testthat/test-use-course.R
@@ -2,6 +2,8 @@
 
 test_that("tidy_download() errors early if destdir is not a directory", {
   tmp <- fs::path_temp("I_am_just_a_file")
+  on.exit(fs::file_delete(tmp))
+
   expect_error(
     tidy_download("URL", destdir = tmp), "does not exist",
     class = "usethis_error"

--- a/tests/testthat/test-use-dependency.R
+++ b/tests/testthat/test-use-dependency.R
@@ -4,7 +4,7 @@ test_that("we message for new type and are silent for same type", {
   scoped_temporary_package()
   withr::local_options(list(usethis.quiet = FALSE))
 
-  expect_output(
+  expect_message(
     use_dependency("crayon", "Imports"),
     "Adding 'crayon' to Imports field"
   )
@@ -15,16 +15,16 @@ test_that("we message for version change and are silent for same version", {
   scoped_temporary_package()
   withr::local_options(list(usethis.quiet = FALSE))
 
-  expect_output(
+  expect_message(
     use_dependency("crayon", "Imports"),
     "Adding 'crayon"
   )
-  expect_output(
+  expect_message(
     use_dependency("crayon", "Imports", min_version = "1.0.0"),
     "Increasing 'crayon'"
   )
   expect_silent(use_dependency("crayon", "Imports", min_version = "1.0.0"))
-  expect_output(
+  expect_message(
     use_dependency("crayon", "Imports", min_version = "2.0.0"),
     "Increasing 'crayon'"
   )
@@ -36,10 +36,10 @@ test_that("use_dependency() upgrades a dependency", {
   scoped_temporary_package()
   withr::local_options(list(usethis.quiet = FALSE))
 
-  expect_output(use_dependency("usethis", "Suggests"))
+  expect_message(use_dependency("usethis", "Suggests"))
   expect_match(desc::desc_get("Suggests", proj_get()), "usethis")
 
-  expect_output(use_dependency("usethis", "Imports"), "Moving 'usethis'")
+  expect_message(use_dependency("usethis", "Imports"), "Moving 'usethis'")
   expect_match(desc::desc_get("Imports", proj_get()), "usethis")
   expect_false(grepl("usethis", desc::desc_get("Suggests", proj_get())))
 })
@@ -49,7 +49,7 @@ test_that("use_dependency() declines to downgrade a dependency", {
   scoped_temporary_package()
   withr::local_options(list(usethis.quiet = FALSE))
 
-  expect_output(use_dependency("usethis", "Imports"))
+  expect_message(use_dependency("usethis", "Imports"))
   expect_match(desc::desc_get("Imports", proj_get()), "usethis")
 
   expect_warning(use_dependency("usethis", "Suggests"), "no change")
@@ -61,14 +61,14 @@ test_that("can add LinkingTo dependency if other dependency already exists", {
   scoped_temporary_package()
   withr::local_options(list(usethis.quiet = FALSE))
 
-  expect_output(use_dependency("Rcpp", "Imports"))
-  expect_output(use_dependency("Rcpp", "LinkingTo"), "Adding 'Rcpp'")
+  expect_message(use_dependency("Rcpp", "Imports"))
+  expect_message(use_dependency("Rcpp", "LinkingTo"), "Adding 'Rcpp'")
 })
 
 test_that("can add any dependency if LinkingTo dependency already exists", {
   scoped_temporary_package()
 
   withr::local_options(list(usethis.quiet = FALSE))
-  expect_output(use_dependency("Rcpp", "LinkingTo"))
-  expect_output(use_dependency("Rcpp", "Import"), "Adding 'Rcpp'")
+  expect_message(use_dependency("Rcpp", "LinkingTo"))
+  expect_message(use_dependency("Rcpp", "Import"), "Adding 'Rcpp'")
 })

--- a/tests/testthat/test-use-pipe.R
+++ b/tests/testthat/test-use-pipe.R
@@ -34,7 +34,7 @@ test_that("use_pipe(export = FALSE) gives advice if no package doc", {
     `usethis:::uses_roxygen` = function(base_path) TRUE, {
       scoped_temporary_package()
       withr::local_options(list(usethis.quiet = FALSE))
-      expect_output(
+      expect_message(
         use_pipe(export = FALSE),
         "Copy and paste this line"
       )

--- a/tests/testthat/test-use-tibble.R
+++ b/tests/testthat/test-use-tibble.R
@@ -10,7 +10,7 @@ test_that("use_tibble() Imports tibble", {
     `usethis:::uses_roxygen` = function(base_path) TRUE, {
       scoped_temporary_package()
       withr::local_options(list(usethis.quiet = FALSE))
-      expect_output(use_tibble(), "#' @importFrom tibble tibble")
+      expect_message(use_tibble(), "#' @importFrom tibble tibble")
       expect_match(desc::desc_get("Imports", proj_get()), "tibble")
     }
   )


### PR DESCRIPTION
But output the messages on stdout instead of stderr, to avoid red text
in RStudio and the Windows GUI.

This works around the issues with `message()` in RStudio by outputting the results on standard output rather than stderr, but still lets us emit message conditions objects, so they can be easily muffled by users with `suppressMessages()` and friends.

I recently used a similar approach in vroom, I think it handles the largest downside of using `message()` while giving the benefits of muffling without having to resort to `capture.output()`.

I did not try to edit the relevant sections of principles.md in regards to this.