### PR TITLE
require styler 1.2.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -46,7 +46,7 @@ Suggests:
     rmarkdown,
     roxygen2,
     spelling (>= 1.2),
-    styler (>= 1.0.2),
+    styler (>= 1.2.0),
     testthat (>= 2.1.0)
 Encoding: UTF-8
 Language: en-US


### PR DESCRIPTION
in particular because {{ is now recognized as rlang *curly curly*. Before, the line was broken between the two curly braces. For details see https://github.com/r-lib/styler/releases/tag/v1.2.0