### PR TITLE
Link GitHub Actions badge to repo URL

### DIFF
--- a/R/github-actions.R
+++ b/R/github-actions.R
@@ -46,10 +46,9 @@ use_github_actions_badge <- function(name = "R-CMD-check") {
   check_uses_github()
 
   name <- utils::URLencode(name)
-  url <- glue("{github_home()}/actions?workflow={name}")
   img <- glue("{github_home()}/workflows/{name}/badge.svg")
 
-  use_badge("R build status", url, img)
+  use_badge("R build status", github_home(), img)
 }
 
 #' @section `use_github_action()`:


### PR DESCRIPTION
Closes #944 

Linking directly to the GitHub Actions page on the repo will 404 if you are not signed into GitHub, which makes CRAN check unhappy.

i.e. try going here in an incognito window:
https://github.com/r-lib/vctrs/actions?workflow=R-CMD-check

The suggestion in #944 is just to link to the repo URL, so that is what I've done here.