### PR TITLE
Update template to correct links to rlang docs

### DIFF
--- a/inst/templates/tidy-eval.R
+++ b/inst/templates/tidy-eval.R
@@ -2,17 +2,17 @@
 #'
 #' @description
 #'
-#' * \code{\link[rlang:quotation]{sym}()} creates a symbol from a string and
-#'   \code{\link[rlang:quotation]{syms}()} creates a list of symbols from a
+#' * \code{\link[rlang]{sym}()} creates a symbol from a string and
+#'   \code{\link[rlang:sym]{syms}()} creates a list of symbols from a
 #'   character vector.
 #'
-#' * \code{\link[rlang:quotation]{enquo}()} and
-#'   \code{\link[rlang:quotation]{enquos}()} delay the execution of one or
+#' * \code{\link[rlang:nse-defuse]{enquo}()} and
+#'   \code{\link[rlang:nse-defuse]{enquos}()} delay the execution of one or
 #'   several function arguments. \code{enquo()} returns a single quoted
 #'   expression, which is like a blueprint for the delayed computation.
 #'   \code{enquos()} returns a list of such quoted expressions.
 #'
-#' * \code{\link[rlang:quotation]{expr}()} quotes a new expression _locally_. It
+#' * \code{\link[rlang:nse-defuse]{expr}()} quotes a new expression _locally_. It
 #'   is mostly useful to build new expressions around arguments
 #'   captured with [enquo()] or [enquos()]:
 #'   \code{expr(mean(!!enquo(arg), na.rm = TRUE))}.


### PR DESCRIPTION
The quotation page was broken into several subpages, so the links needed to be updated to prevent warnings.