### PR TITLE
`pr_finish()`: Check if remote tracking branch still exists

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -21,6 +21,8 @@
 
 * `pr_finish()` checks that you don't have any local changes (#805).
 
+* `pr_finish()` does not error if the remote branch was already deleted (#950)
+
 * `use_lifecycle()` now adds `@importFrom lifecycle deprecate_soft` to 
   silent an R CMD check note (#896).
 

--- a/R/pr.R
+++ b/R/pr.R
@@ -301,10 +301,14 @@ pr_pause <- function() {
 pr_finish <- function() {
   check_branch_not_master()
   check_uncommitted_changes()
-  check_branch_pushed(use = "pr_push()")
+
+  # check whether the remote still exists
+  tracking_branch <- git_branch_tracking()
+  if (!is.null(tracking_branch)) {
+    check_branch_pushed(use = "pr_push()")
+  }
 
   pr <- git_branch_name()
-  tracking_branch <- git_branch_tracking()
 
   ui_done("Switching back to {ui_value('master')} branch")
   git_branch_switch("master")


### PR DESCRIPTION
fixes #950 

Tested it on a case where the remote branch was already deleted but the local branch was still present -> worked.

