### PR TITLE
allow create_package(.) to work; improve valid_package regex

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -69,6 +69,8 @@
 
 * Export `use_circleci_badge()` (#920, @pat-s)
 
+* `create_package('.')` now works if the current directory is a valid package (@michaelchirico)
+
 # usethis 1.5.1
 
 This is a patch release with various small features and bug fixes.

--- a/R/create.R
+++ b/R/create.R
@@ -36,6 +36,8 @@ create_package <- function(path,
   check_path_is_directory(path_dir(path))
 
   name <- path_file(path)
+  # e.g. create_package('.') will expand . to the current dirname
+  name = basename(normalizePath(name))
   if (check_name) {
     check_package_name(name)
   }

--- a/R/create.R
+++ b/R/create.R
@@ -37,7 +37,7 @@ create_package <- function(path,
 
   name <- path_file(path)
   # e.g. create_package('.') will expand . to the current dirname
-  name = basename(normalizePath(name))
+  name <- basename(normalizePath(name))
   if (check_name) {
     check_package_name(name)
   }

--- a/R/description.R
+++ b/R/description.R
@@ -114,8 +114,9 @@ check_package_name <- function(name) {
   }
 }
 
+# at least two characters in [a-z0-9.], starting with letter, not ending with .
 valid_package_name <- function(x) {
-  grepl("^[a-zA-Z][a-zA-Z0-9.]+$", x) && !grepl("\\.$", x)
+  grepl("^[a-z][a-z0-9.]*[a-z0-9]$", x, ignore.case = TRUE)
 }
 
 tidy_desc <- function(desc) {

--- a/tests/testthat/test-create.R
+++ b/tests/testthat/test-create.R
@@ -55,6 +55,16 @@ test_that("create_* works w/ non-existing rel path and absolutizes it", {
   expect_true(dir_exists(path_temp(path_project)))
 })
 
+test_that("create_package(.) works within valid project directory", {
+  temp_pkg = file.path(tempdir(), 'pkg')
+  dir.create(temp_pkg, recursive = TRUE, showWarnings = FALSE)
+  withr::with_dir(temp_pkg, {
+    create_package('.')
+    expect_true(possibly_in_proj('.'))
+    expect_true(is_package('.'))
+  })
+})
+
 test_that("rationalize_fork() honors fork = FALSE", {
   expect_false(
     rationalize_fork(fork = FALSE, repo_info = list(), auth_token = "PAT")

--- a/tests/testthat/test-create.R
+++ b/tests/testthat/test-create.R
@@ -56,7 +56,7 @@ test_that("create_* works w/ non-existing rel path and absolutizes it", {
 })
 
 test_that("create_package(.) works within valid project directory", {
-  temp_pkg = file.path(tempdir(), 'pkg')
+  temp_pkg <- file.path(tempdir(), 'pkg')
   dir.create(temp_pkg, recursive = TRUE, showWarnings = FALSE)
   withr::with_dir(temp_pkg, {
     create_package('.')


### PR DESCRIPTION
Please let me know if you'd like me to file an issue with this.

My workflow was:

 1. Navigate to my github directory `cd ~/github`
 2. Create my pkg dir: `mkdir pkg`
 3. RStudio : File > New Project... > Existing Directory > [select `pkg`]
 4. In new RStudio session within `pkg.Rproj`, try to run `usethis::create_package('.')`, but it failed.

This issue would allow this workflow which doesn't seem to crazy to me.

I kind of slapped `basename(normalizePath(.))` in there, not sure if you'd prefer that to be part of `user_path_prep` or `path_file`; please advise.