### PR TITLE
Fix use_logo url converting https://* to https:/*

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
   `use_github_action_pr_commands()`, `use_github_actions_tidy()` to set up a GitHub Actions
   for a package (@jimhester).
 
+* Fix `use_logo()` README href if pkgdown `url` is set. (#986, @mitchelloharawild).
+
 * usethis now outputs with message conditions. (@jimhester)
 
 * New `use_data_table()` to set up a package for Import-ing `data.table` (#897, @michaelchirico).

--- a/R/logo.R
+++ b/R/logo.R
@@ -54,7 +54,7 @@ use_logo <- function(img, geometry = "240x278", retina = TRUE) {
   if (is.null(pd_link)) {
     ui_code_block("# {pkg} <img src={ui_path(logo_path)} align=\"right\" height=\"{height}\" />")
   } else {
-    ui_code_block("# {pkg} <a href={ui_path(pd_link, NA)}><img src={ui_path(logo_path)} align=\"right\" height=\"{height}\" /></a>")
+    ui_code_block("# {pkg} <a href={ui_value(pd_link)}><img src={ui_path(logo_path)} align=\"right\" height=\"{height}\" /></a>")
   }
 }
 


### PR DESCRIPTION
```
> usethis::use_logo("hex/icon.svg")
✔ Copied 'hex/icon.svg' to 'man/figures/logo.svg'
● Add logo to your README with the following html:
  # icon <a href='https:/pkg.mitchelloharawild.com/icon'><img src='man/figures/logo.svg' align="right" height="139" /></a>
  [Copied to clipboard]
```

This PR fixes the URL `https:/*` to be `https://*`. I don't think treating the URL as a path here is necessary, as it is from pkgdown config.