### PR TITLE
Renv compatibility

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,6 +29,7 @@ Imports:
     gh,
     git2r (>= 0.23),
     glue (>= 1.3.0),
+    jsonlite (>= 1.6),
     purrr,
     rlang (>= 0.4.2),
     rprojroot (>= 1.2),

--- a/R/package.R
+++ b/R/package.R
@@ -27,6 +27,10 @@ use_package <- function(package, type = "Imports", min_version = NULL) {
     refuse_package(package, verboten = "tidyverse")
   }
 
+  if (min_version == "renv") {
+    min_version <- get_renv_version(package)
+  }
+
   use_dependency(package, type, min_version = min_version)
   how_to_use(package, type)
 
@@ -121,4 +125,11 @@ show_includes <- function(package) {
 
   ui_todo("Possible includes are:")
   ui_code_block("#include <{path_file(h)}>", copy = FALSE)
+}
+
+get_renv_version <- function(package){
+
+  renv_lock <- jsonlite::read_json("renv.lock")
+  min_version <- renv[["Packages"]][[package]][["Version"]]
+  return(min_version)
 }

--- a/R/package.R
+++ b/R/package.R
@@ -27,7 +27,7 @@ use_package <- function(package, type = "Imports", min_version = NULL) {
     refuse_package(package, verboten = "tidyverse")
   }
 
-  if (min_version == "renv") {
+  if (isTRUE(min_version == "renv")) {
     min_version <- get_renv_version(package)
   }
 
@@ -130,6 +130,6 @@ show_includes <- function(package) {
 get_renv_version <- function(package){
 
   renv_lock <- jsonlite::read_json("renv.lock")
-  min_version <- renv[["Packages"]][[package]][["Version"]]
+  min_version <- renv_lock[["Packages"]][[package]][["Version"]]
   return(min_version)
 }


### PR DESCRIPTION
It implements an optional functionality on `use_package` function allowing it to import the package version contained on `renv.lock` file created by `renv` package. This ensures package development associated with package version management.