### PR TITLE
Use 2.0 code of conduct

### DIFF
--- a/R/code-of-conduct.R
+++ b/R/code-of-conduct.R
@@ -31,7 +31,7 @@ use_code_of_conduct <- function(path = NULL) {
     ignore = is_package() && is.null(path)
   )
 
-  href <- project_pkgdown_url() %||% "https://contributor-covenant.org/version/1/0/0"
+  href <- project_pkgdown_url() %||% "https://contributor-covenant.org/version/2/0"
   href <- paste0(href, "/CODE_OF_CONDUCT.html")
 
   ui_todo("Don't forget to describe the code of conduct in your README:")

--- a/R/code-of-conduct.R
+++ b/R/code-of-conduct.R
@@ -4,15 +4,15 @@
 #' `.Rbuildignore`, in the case of a package. The goal of a code of conduct is
 #' to foster an environment of inclusiveness, and to explicitly discourage
 #' inappropriate behaviour. The template comes from
-#' <https://contributor-covenant.org>, version 1:
-#' <https://contributor-covenant.org/version/1/0/0>.
+#' <https://contributor-covenant.org>, version 2:
+#' <https://contributor-covenant.org/version/2/0>.
 #'
 #' If your package is going to CRAN, the link to the CoC in your README must
 #' be an absolute link to a rendered website as `CODE_OF_CONDUCT.md` is not
 #' included in the package sent to CRAN. `use_code_of_conduct()` will
 #' automatically generate this link if you use pkgdown and have set the
 #' `url` field in `pkgdown.yml`; otherwise it'll link to
-#' <https://contributor-covenant.org/version/1/0/0>.
+#' <https://contributor-covenant.org/version/2/0>.
 #'
 #' @param path Path of the directory to put `CODE_OF_CONDUCT.md` in, relative to
 #'   the active project. Passed along to [use_directory()]. Default is to locate

--- a/inst/templates/CODE_OF_CONDUCT.md
+++ b/inst/templates/CODE_OF_CONDUCT.md
@@ -1,25 +1,129 @@
-# Contributor Code of Conduct
+# Contributor Covenant Code of Conduct
 
-As contributors and maintainers of this project, we pledge to respect all people who 
-contribute through reporting issues, posting feature requests, updating documentation,
-submitting pull requests or patches, and other activities.
+## Our Pledge
 
-We are committed to making participation in this project a harassment-free experience for
-everyone, regardless of level of experience, gender, gender identity and expression,
-sexual orientation, disability, personal appearance, body size, race, ethnicity, age, or religion.
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
 
-Examples of unacceptable behavior by participants include the use of sexual language or
-imagery, derogatory comments or personal attacks, trolling, public or private harassment,
-insults, or other unprofessional conduct.
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
 
-Project maintainers have the right and responsibility to remove, edit, or reject comments,
-commits, code, wiki edits, issues, and other contributions that are not aligned to this 
-Code of Conduct. Project maintainers who do not follow the Code of Conduct may be removed 
-from the project team.
+## Our Standards
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by 
-opening an issue or contacting one or more of the project maintainers.
+Examples of behavior that contributes to a positive environment for our
+community include:
 
-This Code of Conduct is adapted from the Contributor Covenant 
-(https://www.contributor-covenant.org), version 1.0.0, available at 
-https://contributor-covenant.org/version/1/0/0/.
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or
+advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email
+address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards
+of acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies
+when an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at [INSERT CONTACT
+METHOD]. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.0,
+available at https://www.contributor-covenant.org/version/2/0/
+code_of_conduct.html.
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct
+enforcement ladder](https://github.com/mozilla/diversity).
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are available at https://
+www.contributor-covenant.org/translations.
+

--- a/man/use_code_of_conduct.Rd
+++ b/man/use_code_of_conduct.Rd
@@ -16,8 +16,8 @@ Adds a \code{CODE_OF_CONDUCT.md} file to the active project and lists in
 \code{.Rbuildignore}, in the case of a package. The goal of a code of conduct is
 to foster an environment of inclusiveness, and to explicitly discourage
 inappropriate behaviour. The template comes from
-\url{https://contributor-covenant.org}, version 1:
-\url{https://contributor-covenant.org/version/1/0/0}.
+\url{https://contributor-covenant.org}, version 2:
+\url{https://contributor-covenant.org/version/2/0}.
 }
 \details{
 If your package is going to CRAN, the link to the CoC in your README must
@@ -25,5 +25,5 @@ be an absolute link to a rendered website as \code{CODE_OF_CONDUCT.md} is not
 included in the package sent to CRAN. \code{use_code_of_conduct()} will
 automatically generate this link if you use pkgdown and have set the
 \code{url} field in \code{pkgdown.yml}; otherwise it'll link to
-\url{https://contributor-covenant.org/version/1/0/0}.
+\url{https://contributor-covenant.org/version/2/0}.
 }


### PR DESCRIPTION
When submitting a package of mine to CRAN this morning, I receive a reply noting that the link in my README (to the [contributor-covenant.org](https://contributor-covenant.org)) website was "invalid".

Turns out that 1.0.0 version has moved; you can still find that version if you use hyphens in the URL. However, you can also access latest 2.0 version using underscores. Kind of odd.

Using either approach would solve the problem, I don't know if you want to update to the newer version.

I just read the 2.0 markdown directly and wrapped it to 80 characters width. Then I replaced all the instances of the old version with the new version.

``` r
# current url
old_code <- readr::read_lines("R/code-of-conduct.R")
cat(old_code[34:35], sep = "\n")
#>   href <- project_pkgdown_url() %||% "https://contributor-covenant.org/version/2/0"
#>   href <- paste0(href, "/CODE_OF_CONDUCT.html")

# test old and new url
base <- "https://www.contributor-covenant.org/version/"
httr::status_code(httr::HEAD(paste(base, "1/0/0/CODE_OF_CONDUCT.html", sep = "/")))
#> [1] 404
httr::status_code(httr::HEAD(paste(base, "1/0/0/CODE-OF-CONDUCT.html", sep = "/")))
#> [1] 200
httr::status_code(httr::HEAD(paste(base, "2/0/CODE_OF_CONDUCT.html", sep = "/")))
#> [1] 200

# wrap raw md to 80 width
md <- readr::read_lines(paste(base, "2/0/CODE_OF_CONDUCT.md", sep = "/"))
md <- stringr::str_wrap(md, width = 80)
readr::write_lines(md, "inst/templates/CODE_OF_CONDUCT.md")

# update use_code_of_conduct()
# three urls
new_code <- stringr::str_replace(old_code, "version/1/0/0", "version/2/0")
# version description
new_code <- stringr::str_replace(new_code, "version 1", "version 2")
readr::write_lines(new_code, "R/code-of-conduct.R")
```

<sup>Created on 2020-01-27 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>