### PR TITLE
add tests for `use_data_table()`

### DIFF
--- a/tests/testthat/test-use-data-table.R
+++ b/tests/testthat/test-use-data-table.R
@@ -1,0 +1,20 @@
+context("use_data_table")
+
+test_that("use_data_table() requires a package", {
+  scoped_temporary_project()
+  expect_usethis_error(use_data_table(), "not an R package")
+})
+
+test_that("use_data_table() Imports data.table", {
+  with_mock(
+    `usethis:::uses_roxygen` = function(base_path) TRUE, {
+      scoped_temporary_package()
+      use_data_table()
+      expect_match(desc::desc_get("Imports", proj_get()), "data.table")
+      datatable_doc <- readLines(proj_path("R", "utils-data-table.R"))
+      expect_match(datatable_doc, "#' @import data.table", all = FALSE)
+    }
+  )
+})
+
+

--- a/tests/testthat/test-use-data-table.R
+++ b/tests/testthat/test-use-data-table.R
@@ -1,5 +1,3 @@
-context("use_data_table")
-
 test_that("use_data_table() requires a package", {
   scoped_temporary_project()
   expect_usethis_error(use_data_table(), "not an R package")
@@ -7,7 +5,8 @@ test_that("use_data_table() requires a package", {
 
 test_that("use_data_table() Imports data.table", {
   with_mock(
-    `usethis:::uses_roxygen` = function(base_path) TRUE, {
+    `usethis:::uses_roxygen` = function(base_path) TRUE,
+    `usethis:::is_installed` = function(pkg) TRUE, {
       scoped_temporary_package()
       use_data_table()
       expect_match(desc::desc_get("Imports", proj_get()), "data.table")


### PR DESCRIPTION
Closes #984 

(I am using a mock roxygen check here, but `use_data_table()` doesn't currently check for roxygen despite using `@import`. Will add a separate issue for that.)