### PR TITLE
Check for roxygen in `use_data_table()`

### DIFF
--- a/R/data-table.R
+++ b/R/data-table.R
@@ -13,6 +13,8 @@
 #' @export
 use_data_table <- function() {
   check_is_package("use_data_table()")
+  check_uses_roxygen("use_data_table()")
+
   deps <- desc::desc_get_deps(".")
   if (any(deps$type == 'Depends' & deps$package == "data.table")) {
     ui_warn("data.table should be in Imports or Suggests, not Depends")


### PR DESCRIPTION
`use_data_table()` doesn't currently check for roxygen, but as this implementation uses `@import`, it seems essential, as in the case of `use_tibble()`. This PR adds a check.