### PR TITLE
Use better link for the GitHub Actions badge

### DIFF
--- a/R/github-actions.R
+++ b/R/github-actions.R
@@ -51,8 +51,9 @@ use_github_actions_badge <- function(name = "R-CMD-check") {
 
   name <- utils::URLencode(name)
   img <- glue("{github_home()}/workflows/{name}/badge.svg")
+  url <- glue("{github_home()}/actions")
 
-  use_badge("R build status", github_home(), img)
+  use_badge("R build status", url, img)
 }
 
 uses_github_actions <- function(base_path = proj_get()) {


### PR DESCRIPTION
GitHub now provides a /actions URL which is accessible even when users
are not logged in, so we can now link to that