### PR TITLE
Add generated shared libraries to .gitignore for macOS

### DIFF
--- a/R/rcpp.R
+++ b/R/rcpp.R
@@ -75,7 +75,7 @@ use_c <- function(name = NULL) {
 
 use_src <- function() {
   use_directory("src")
-  use_git_ignore(c("*.o", "*.so", "*.dll"), "src")
+  use_git_ignore(c("*.o", "*.so", "*.dll", "*.dylib"), "src")
   roxygen_ns_append(glue("@useDynLib {project_name()}, .registration = TRUE")) &&
     roxygen_update()
 

--- a/tests/testthat/test-use-rcpp.R
+++ b/tests/testthat/test-use-rcpp.R
@@ -15,7 +15,7 @@ test_that("use_rcpp() creates files/dirs, edits DESCRIPTION and .gitignore", {
   expect_proj_dir("src")
 
   ignores <- readLines(proj_path("src", ".gitignore"))
-  expect_true(all(c("*.o", "*.so", "*.dll") %in% ignores))
+  expect_true(all(c("*.o", "*.so", "*.dll", "*.dylib") %in% ignores))
 })
 
 test_that("use_rcpp_armadillo() creates Makevars files and edits DESCRIPTION", {


### PR DESCRIPTION
I saw that `usethis::use_rcpp()` adds shared library files matching `*.so` to the `src/.gitignore`. This is the file extension used on Linux. On macOS, these files are given a `*.dylib` extension.

For consistency with Linux, I thought these probably shouldn't enter source control. However, I'm very new to Rcpp, so would love to learn if I've misunderstood!