### PR TITLE
Make it possible to proceed if no remote branch can be found

### DIFF
--- a/R/git-utils.R
+++ b/R/git-utils.R
@@ -292,6 +292,15 @@ check_branch_pulled <- function(branch = git_branch_name(), use = "git pull") {
 check_branch_pushed <- function(branch = git_branch_name(), use = "git push") {
   local <- paste0("local/", branch)
   remote <- git_branch_tracking_FIXME(branch)
+  if (is.null(remote)) {
+    if (ui_yeah(
+      "Checking that branch has been pushed, but can't find a remote tracking \\
+       branch. Proceed anyway?")) {
+      return(invisible())
+    } else {
+      ui_stop("Aborting.")
+    }
+  }
   ui_done(
     "Checking that remote branch {ui_value(remote)} has the changes \\
      in {ui_value(local)}"


### PR DESCRIPTION
Fixes #950

WIP / under consideration. Another approach is in #968.

My concerns include:

  * I think another reason you could get to this place is that the remote branch never existed? I.e. the PR never got made and no push has happened yet. So logic and messaging needs to account for that.
  * `check_branch_pushed()` is also called from `use_github_release()`. So logic and messaging needs to account for that.

Overall conclusion reinforces that many of the git helpers need some rationalization.