### PR TITLE
Suggest adding mention of draft PR in PR helpers' docs

### DIFF
--- a/R/pr.R
+++ b/R/pr.R
@@ -19,8 +19,8 @@
 #' the `master` branch). You'll then work locally, making changes to files and
 #' checking them into git. Once you're ready to submit, run `pr_push()` to push
 #' your local branch to GitHub, and open a webpage that lets you initiate the
-#' PR. To learn more about the process of making a pull request, read the [Pull
-#' Request
+#' PR (or draft PR). To learn more about the process of making a pull request,
+#' read the [Pull Request
 #' Helpers](https://usethis.r-lib.org/articles/articles/pr-functions.html)
 #' vignette.
 #'

--- a/man/pr_init.Rd
+++ b/man/pr_init.Rd
@@ -63,7 +63,8 @@ use \code{pr_init()} to create a branch for your PR (\strong{never} submit a PR 
 the \code{master} branch). You'll then work locally, making changes to files and
 checking them into git. Once you're ready to submit, run \code{pr_push()} to push
 your local branch to GitHub, and open a webpage that lets you initiate the
-PR. To learn more about the process of making a pull request, read the \href{https://usethis.r-lib.org/articles/articles/pr-functions.html}{Pull Request Helpers}
+PR (or draft PR). To learn more about the process of making a pull request,
+read the \href{https://usethis.r-lib.org/articles/articles/pr-functions.html}{Pull Request Helpers}
 vignette.
 
 If you are lucky, your PR will be perfect, and the maintainer will accept

--- a/vignettes/articles/pr-functions.Rmd
+++ b/vignettes/articles/pr-functions.Rmd
@@ -167,7 +167,7 @@ looks like the following.
 knitr::include_graphics("img/pr-functions-pull-request.png", dpi = 300)
 ```
 
-Click "Create pull request" to make the PR. GitHub will ping the package maintainer and they will review our pull request. We can view this pull request in the browser with `pr_view()`. And anyone can follow along with this PR [rladies/praise#84](https://github.com/rladies/praise/pull/84).
+Click "Create pull request" to make the PR. In the next step you will be able to choose between [draft PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) and actual PR (If opening a draft PR, [mark it as ready for review](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/changing-the-stage-of-a-pull-request) once you're done e.g. after a few more commits). GitHub will ping the package maintainer and they will review our pull request. We can view this pull request in the browser with `pr_view()`. And anyone can follow along with this PR [rladies/praise#84](https://github.com/rladies/praise/pull/84).
 
 ```{r pr_view, eval=FALSE}
 pr_view()

--- a/vignettes/articles/pr-functions.Rmd
+++ b/vignettes/articles/pr-functions.Rmd
@@ -167,7 +167,9 @@ looks like the following.
 knitr::include_graphics("img/pr-functions-pull-request.png", dpi = 300)
 ```
 
-Click "Create pull request" to make the PR. In the next step you will be able to choose between [draft PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) and actual PR (If opening a draft PR, [mark it as ready for review](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/changing-the-stage-of-a-pull-request) once you're done e.g. after a few more commits). GitHub will ping the package maintainer and they will review our pull request. We can view this pull request in the browser with `pr_view()`. And anyone can follow along with this PR [rladies/praise#84](https://github.com/rladies/praise/pull/84).
+Click "Create pull request" to make the PR. After clicking you will be able to choose between [draft PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) and actual PR (If opening a draft PR, [mark it as ready for review](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/changing-the-stage-of-a-pull-request) once you're done e.g. after a few more commits and one new call to `pr_push()`). 
+
+GitHub will ping the package maintainer and they will review our pull request. We can view this pull request in the browser with `pr_view()`. And anyone can follow along with this PR [rladies/praise#84](https://github.com/rladies/praise/pull/84).
 
 ```{r pr_view, eval=FALSE}
 pr_view()


### PR DESCRIPTION
Context: in rOpenSci blog guidance we recommend opening a draft PR first, and mention `usethis`' excellent PR helpers. I started wondering whether the docs of `usethis`' PR helpers should mention draft PRs. :slightly_smiling_face: 