### PR TITLE
Fix `proj_activate()` to work with relative paths outside of RStudio

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -73,6 +73,8 @@
 
 * Export `use_circleci_badge()` (#920, @pat-s)
 
+* `proj_activate()` now works with relative paths outside of RStudio (#1024, @malcolmbarrett. Thanks to Thomas Levine and @lettucehead filing and investigating)
+
 # usethis 1.5.1
 
 This is a patch release with various small features and bug fixes.

--- a/R/proj.R
+++ b/R/proj.R
@@ -287,7 +287,7 @@ project_pkgdown_url <- function(base_path = proj_get()) {
 #' @export
 proj_activate <- function(path) {
   check_path_is_directory(path)
-  path <- user_path_prep(path)
+  path <- proj_path_prep(path)
 
   if (rstudioapi::isAvailable()) {
     ui_done("Opening {ui_path(path, base = NA)} in new RStudio session")

--- a/tests/testthat/test-proj.R
+++ b/tests/testthat/test-proj.R
@@ -202,3 +202,22 @@ test_that("local_project() activates proj til scope ends", {
   )
   expect_null(proj_get_())
 })
+
+test_that("proj_activate() works with relative paths when RStudio is not detected", {
+  parent_dir <- tempfile()
+  dir.create(parent_dir)
+  old_wd <- setwd(parent_dir)
+  old_proj <- proj_get()
+  on.exit({
+    setwd(old_wd)
+    proj_set(old_proj)
+    unlink(parent_dir, recursive = TRUE)
+  }, add = TRUE)
+
+  # create a new project
+  dir.create("child_dir")
+  file.create("child_dir/.here")
+
+  with_mock("rstudioapi::isAvailable" = function(x) FALSE, proj_activate("child_dir"))
+  expect_equal(getwd(), normalizePath(file.path(parent_dir, "child_dir")))
+})

--- a/tests/testthat/test-proj.R
+++ b/tests/testthat/test-proj.R
@@ -219,5 +219,5 @@ test_that("proj_activate() works with relative paths when RStudio is not detecte
   file.create("child_dir/.here")
 
   with_mock("rstudioapi::isAvailable" = function(x) FALSE, proj_activate("child_dir"))
-  expect_equal(getwd(), normalizePath(file.path(parent_dir, "child_dir")))
+  expect_equal(normalizePath(getwd()), normalizePath(file.path(parent_dir, "child_dir")))
 })


### PR DESCRIPTION
…and add the corresponding test. Closes #954 

This PR changes `proj_activate()` a little to expand `path` using `proj_path_prop()` instead of `user_path_prep()`. As discussed in #954, relative paths don't work in this function outside of RStudio because the working directory gets changed, but `path` does not. As opposed to #955, this PR does not change the ordering of setting the directory and project, and the test mocks the lack of RStudio and creates a proper project. It also avoids a minor issue where `setwd()` will get run even if `path` is actually the working directory if `path` is relative (since `getwd()` is absolute)

This is based on the investigating that @lettucehead and Thomas did, and I have cited them in the news item, as well.