### PR TITLE
Ignore the whole .github folder

### DIFF
--- a/R/github-action.R
+++ b/R/github-action.R
@@ -39,14 +39,13 @@ use_github_action <- function(name,
 
   contents <- readLines(url)
 
+
+  use_dot_github(ignore = ignore)
+
   save_as <- path(".github", "workflows", save_as)
-
   create_directory(dirname(proj_path(save_as)))
-  new <- write_over(proj_path(save_as), contents)
 
-  if (ignore) {
-    use_build_ignore(path(".github"))
-  }
+  new <- write_over(proj_path(save_as), contents)
 
   if (open && new) {
     edit_file(proj_path(save_as))

--- a/R/github-action.R
+++ b/R/github-action.R
@@ -45,7 +45,7 @@ use_github_action <- function(name,
   new <- write_over(proj_path(save_as), contents)
 
   if (ignore) {
-    use_build_ignore(save_as)
+    use_build_ignore(path(".github"))
   }
 
   if (open && new) {

--- a/R/tidyverse.R
+++ b/R/tidyverse.R
@@ -193,8 +193,8 @@ use_tidy_github <- function() {
   use_tidy_coc()
 }
 
-use_dot_github <- function() {
-  use_directory(".github", ignore = TRUE)
+use_dot_github <- function(ignore = TRUE) {
+  use_directory(".github", ignore = ignore)
   use_git_ignore("*.html", directory = ".github")
 }
 

--- a/tests/testthat/test-github-actions.R
+++ b/tests/testthat/test-github-actions.R
@@ -60,7 +60,7 @@ test_that("use_github_actions() configures .Rbuildignore", {
   use_git_remote(name = "origin", url = "https://github.com/fake/fake")
   use_description_field("URL", "https://github.com/fake/fake")
   use_github_actions()
-  expect_true(is_build_ignored("^\\.github/workflows"))
+  expect_true(is_build_ignored("^\\.github$"))
 })
 
 test_that("use_github_action_check_full() configures full GitHub Actions", {


### PR DESCRIPTION
Rather than trying to ignore individual files. This way is simpler and
less fiddly if you later add other workflows.