### PR TITLE
add option `usethis.destdir`

### DIFF
--- a/R/course.R
+++ b/R/course.R
@@ -15,7 +15,10 @@
 #'   Function works well with DropBox folders and GitHub repos, but should work
 #'   for ZIP files generally. See examples and [use_course_details] for more.
 #' @param destdir The new folder is stored here. If `NULL`, defaults to user's
-#'   Desktop or some other conspicuous place.
+#'   Desktop or some other conspicuous place. You can also set a default
+#'   location using the option `usethis.destdir`, e.g. `options(usethis.destdir
+#'   = "a/good/dir")`, perhaps saved to your `.Rprofile` with
+#'   [`edit_r_profile()`]
 #' @param cleanup Whether to delete the original ZIP file after unpacking its
 #'   contents. In an interactive setting, `NA` leads to a menu where user can
 #'   approve the deletion (or decline).
@@ -50,14 +53,15 @@ NULL
 #' @export
 use_course <- function(url, destdir = NULL) {
   url <- normalize_url(url)
-  destdir_not_specified <- is.null(destdir)
+  destdir_not_specified <- is.null(destdir) && is.null(getOption("usethis.destdir"))
   destdir <- user_path_prep(destdir %||% conspicuous_place())
   check_path_is_directory(destdir)
 
   if (destdir_not_specified && interactive()) {
     ui_line(c(
       "Downloading into {ui_path(destdir)}.",
-      "Prefer a different location? Cancel, try again, and specify {ui_code('destdir')}"
+      "Prefer a different location? Cancel, try again, and specify {ui_code('destdir')}//
+      or set with option {ui_code('usethis.destdir')} in your R profile"
     ))
     if (ui_nope("OK to proceed?")) {
       ui_stop("Aborting.")
@@ -105,7 +109,8 @@ use_zip <- function(url,
 #' ## as called inside use_course()
 #' tidy_download(
 #'   url, ## after post-processing with normalize_url()
-#'   # conspicuous_place() = Desktop or home directory or working directory
+#'   # conspicuous_place() = `getOption('usethis.destdir')` or desktop or home
+#'   # directory or working directory
 #'   destdir = destdir %||% conspicuous_place()
 #' )
 #' ```
@@ -303,6 +308,9 @@ expand_github <- function(url) {
 }
 
 conspicuous_place <- function() {
+  destdir_opt <- getOption("usethis.destdir")
+  if (!is.null(destdir_opt)) return(path_tidy(destdir_opt))
+
   Filter(dir_exists, c(
     path_home("Desktop"),
     path_home(),

--- a/R/course.R
+++ b/R/course.R
@@ -60,7 +60,7 @@ use_course <- function(url, destdir = getOption("usethis.destdir")) {
   if (destdir_not_specified && interactive()) {
     ui_line(c(
       "Downloading into {ui_path(destdir)}.",
-      "Prefer a different location? Cancel, try again, and specify {ui_code('destdir')}
+      "Prefer a different location? Cancel, try again, and specify {ui_code('destdir')}"
     ))
     if (ui_nope("OK to proceed?")) {
       ui_stop("Aborting.")

--- a/R/course.R
+++ b/R/course.R
@@ -16,9 +16,9 @@
 #'   for ZIP files generally. See examples and [use_course_details] for more.
 #' @param destdir The new folder is stored here. If `NULL`, defaults to user's
 #'   Desktop or some other conspicuous place. You can also set a default
-#'   location using the option `usethis.destdir`, e.g. `options(usethis.destdir
-#'   = "a/good/dir")`, perhaps saved to your `.Rprofile` with
-#'   [`edit_r_profile()`]
+#'   location using the option `usethis.destdir`, e.g.
+#'   `options(usethis.destdir = "a/good/dir")`, perhaps saved to your
+#'   `.Rprofile` with [`edit_r_profile()`]
 #' @param cleanup Whether to delete the original ZIP file after unpacking its
 #'   contents. In an interactive setting, `NA` leads to a menu where user can
 #'   approve the deletion (or decline).
@@ -51,17 +51,16 @@ NULL
 #'   launched. Otherwise, the folder is opened in the file manager, e.g. Finder
 #'   or File Explorer.
 #' @export
-use_course <- function(url, destdir = NULL) {
+use_course <- function(url, destdir = getOption("usethis.destdir")) {
   url <- normalize_url(url)
-  destdir_not_specified <- is.null(destdir) && is.null(getOption("usethis.destdir"))
+  destdir_not_specified <- is.null(destdir)
   destdir <- user_path_prep(destdir %||% conspicuous_place())
   check_path_is_directory(destdir)
 
   if (destdir_not_specified && interactive()) {
     ui_line(c(
       "Downloading into {ui_path(destdir)}.",
-      "Prefer a different location? Cancel, try again, and specify {ui_code('destdir')}//
-      or set with option {ui_code('usethis.destdir')} in your R profile"
+      "Prefer a different location? Cancel, try again, and specify {ui_code('destdir')}
     ))
     if (ui_nope("OK to proceed?")) {
       ui_stop("Aborting.")

--- a/man/create_from_github.Rd
+++ b/man/create_from_github.Rd
@@ -22,8 +22,9 @@ create_from_github(
 
 \item{destdir}{The new folder is stored here. If \code{NULL}, defaults to user's
 Desktop or some other conspicuous place. You can also set a default
-location using the option \code{usethis.destdir}, e.g. \code{options(usethis.destdir = "a/good/dir")}, perhaps saved to your \code{.Rprofile} with
-\code{\link[=edit_r_profile]{edit_r_profile()}}}
+location using the option \code{usethis.destdir}, e.g.
+\code{options(usethis.destdir = "a/good/dir")}, perhaps saved to your
+\code{.Rprofile} with \code{\link[=edit_r_profile]{edit_r_profile()}}}
 
 \item{fork}{If \code{TRUE}, we create and clone a fork. If \code{FALSE}, we clone
 \code{repo_spec} itself. Will be set to \code{FALSE} if no \code{auth_token} (a.k.a. PAT)

--- a/man/create_from_github.Rd
+++ b/man/create_from_github.Rd
@@ -21,7 +21,9 @@ create_from_github(
 \code{repo} part will be the name of the new local repo.}
 
 \item{destdir}{The new folder is stored here. If \code{NULL}, defaults to user's
-Desktop or some other conspicuous place.}
+Desktop or some other conspicuous place. You can also set a default
+location using the option \code{usethis.destdir}, e.g. \code{options(usethis.destdir = "a/good/dir")}, perhaps saved to your \code{.Rprofile} with
+\code{\link[=edit_r_profile]{edit_r_profile()}}}
 
 \item{fork}{If \code{TRUE}, we create and clone a fork. If \code{FALSE}, we clone
 \code{repo_spec} itself. Will be set to \code{FALSE} if no \code{auth_token} (a.k.a. PAT)

--- a/man/use_course_details.Rd
+++ b/man/use_course_details.Rd
@@ -25,7 +25,8 @@ tidy_download(url, destdir = getwd())
 ## as called inside use_course()
 tidy_download(
   url, ## after post-processing with normalize_url()
-  # conspicuous_place() = Desktop or home directory or working directory
+  # conspicuous_place() = `getOption('usethis.destdir')` or desktop or home
+  # directory or working directory
   destdir = destdir \%||\% conspicuous_place()
 )
 }

--- a/man/zip-utils.Rd
+++ b/man/zip-utils.Rd
@@ -6,7 +6,7 @@
 \alias{use_zip}
 \title{Download and unpack a ZIP file}
 \usage{
-use_course(url, destdir = NULL)
+use_course(url, destdir = getOption("usethis.destdir"))
 
 use_zip(url, destdir = getwd(), cleanup = if (interactive()) NA else FALSE)
 }
@@ -21,8 +21,9 @@ for ZIP files generally. See examples and \link{use_course_details} for more.}
 
 \item{destdir}{The new folder is stored here. If \code{NULL}, defaults to user's
 Desktop or some other conspicuous place. You can also set a default
-location using the option \code{usethis.destdir}, e.g. \code{options(usethis.destdir = "a/good/dir")}, perhaps saved to your \code{.Rprofile} with
-\code{\link[=edit_r_profile]{edit_r_profile()}}}
+location using the option \code{usethis.destdir}, e.g.
+\code{options(usethis.destdir = "a/good/dir")}, perhaps saved to your
+\code{.Rprofile} with \code{\link[=edit_r_profile]{edit_r_profile()}}}
 
 \item{cleanup}{Whether to delete the original ZIP file after unpacking its
 contents. In an interactive setting, \code{NA} leads to a menu where user can

--- a/man/zip-utils.Rd
+++ b/man/zip-utils.Rd
@@ -20,7 +20,9 @@ Function works well with DropBox folders and GitHub repos, but should work
 for ZIP files generally. See examples and \link{use_course_details} for more.}
 
 \item{destdir}{The new folder is stored here. If \code{NULL}, defaults to user's
-Desktop or some other conspicuous place.}
+Desktop or some other conspicuous place. You can also set a default
+location using the option \code{usethis.destdir}, e.g. \code{options(usethis.destdir = "a/good/dir")}, perhaps saved to your \code{.Rprofile} with
+\code{\link[=edit_r_profile]{edit_r_profile()}}}
 
 \item{cleanup}{Whether to delete the original ZIP file after unpacking its
 contents. In an interactive setting, \code{NA} leads to a menu where user can

--- a/tests/testthat/test-use-course.R
+++ b/tests/testthat/test-use-course.R
@@ -102,6 +102,14 @@ test_that("conspicuous_place() returns a writeable directory", {
   expect_true(file_access(x, mode = "write"))
 })
 
+test_that("conspicuous_place() uses `usethis.destdir` when set", {
+  tdestdir_temp <- path(tempdir(), "destdir_temp")
+  dir_create(tdestdir_temp)
+  withr::local_options(list(usethis.destdir = tdestdir_temp))
+  expect_error_free(x <- conspicuous_place())
+  expect_equal(path(tdestdir_temp), x)
+})
+
 test_that("check_is_zip() errors if MIME type is not 'application/zip'", {
   skip("work this into a use_course test")
   skip_on_cran()

--- a/vignettes/articles/usethis-setup.Rmd
+++ b/vignettes/articles/usethis-setup.Rmd
@@ -65,6 +65,8 @@ Certain options are consulted by usethis and allow you to set personal defaults:
     Git. Either "ssh" or "https". See the help for `git_protocol()` for more.
   * `usethis.description`: named list of default DESCRIPTION fields for new
     packages made with `usethis::create_package()`.
+  * `usethis.quiet`: if `TRUE`, prevent usethis from printing messages to the console.
+  * `usethis.destdir`: a default directory to use in `create_from_github()` and `use_course()`
 
 Define any of these options in your `.Rprofile`, which can be opened for editing via `usethis::edit_r_profile()`. Here is example code:
 


### PR DESCRIPTION
Closes #1015.

This PR adds an option `usethis.destdir` to set a default directory for use in `create_from_github()` and `use_course()`, describes it in the relevant docs and setup vignette, and adds a test.

Note that I also added a brief description about `usethis.quiet` to the setup vignette, since it was missing. If this PR is not accepted, I'd be happy to submit a smaller one that has that, since it should probably be there.

I'll admit that, while I think this would be a very useful feature, there's a little bit of an inconsistency. `use_zip()` and `use_pkgdown()` both also have `destdir` options that have defaults. `use_pkgdown()` is perhaps less of an issue but `use_zip()` is closely related to `use_course()` and even shares a help page with it. 