### PR TITLE
`use_travis()` and friends now point to travis-ci.com by default.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -52,4 +52,4 @@ Encoding: UTF-8
 Language: en-US
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.0.2
+RoxygenNote: 7.1.0

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # usethis (development version)
 
+* In `use_travis()`, `use_travis_badge()` and `browse_travis()`, argument `ext`
+now defaults to `"com"` instead of `"ext"`, given travis-ci.com is now
+recommended over travis-ci.org (#1038, @riccardoporreca).
+
 * `pr_push()` works with gh v1.1.0 (and earlier versions), for a repository with no open pull requests (#990, @maurolepore).
 
 * New `use_github_actions()`, `use_github_action_check_release()`, `use_github_action_check_full()`,

--- a/R/browse.R
+++ b/R/browse.R
@@ -13,7 +13,7 @@
 #' * `browse_github_pulls()`: Visits the GitHub Pull Request index or one
 #' specific pull request.
 #' * `browse_travis()`: Visits the package's page on [Travis
-#' CI](https://travis-ci.org).
+#' CI](https://travis-ci.com).
 #' * `browse_circleci()`: Visits the package's page on [Circle
 #' CI](https://circleci.com)
 #' * `browse_cran()`: Visits the package on CRAN, via the canonical URL.
@@ -54,7 +54,7 @@ browse_github_pulls <- function(package = NULL, number = NULL) {
 #' @export
 #' @rdname browse-this
 #' @param ext Version of travis to use.
-browse_travis <- function(package = NULL, ext = c("org", "com")) {
+browse_travis <- function(package = NULL, ext = c("com", "org")) {
   gh <- github_home(package)
   ext <- rlang::arg_match(ext)
   travis_url <- glue::glue("travis-ci.{ext}")

--- a/R/ci.R
+++ b/R/ci.R
@@ -13,15 +13,15 @@ NULL
 
 #' @section `use_travis()`:
 #' Adds a basic `.travis.yml` to the top-level directory of a package. This is a
-#' configuration file for the [Travis CI](https://travis-ci.org/) continuous
+#' configuration file for the [Travis CI](https://travis-ci.com/) continuous
 #' integration service.
 #' @param browse Open a browser window to enable automatic builds for the
 #'   package.
-#' @param ext which travis website to use. default to `"org"`for
-#'   https://travis-ci.org. Change to `"com"` for https://travis-ci.com.
+#' @param ext Which travis website to use. Defaults to `"com"` for
+#'   https://travis-ci.com. Change to `"org"` for https://travis-ci.org.
 #' @export
 #' @rdname ci
-use_travis <- function(browse = interactive(), ext = c("org", "com")) {
+use_travis <- function(browse = interactive(), ext = c("com", "org")) {
   check_uses_github()
   ext <- rlang::arg_match(ext)
   new <- use_template(
@@ -39,18 +39,20 @@ use_travis <- function(browse = interactive(), ext = c("org", "com")) {
 }
 
 #' @section `use_travis_badge()`:
-#' Only adds the [Travis CI](https://travis-ci.org/) badge. Use for a project
+#' Only adds the [Travis CI](https://travis-ci.com/) badge. Use for a project
 #'  where Travis is already configured.
 #' @export
 #' @rdname ci
-use_travis_badge <- function(ext = "org") {
+use_travis_badge <- function(ext = c("com", "org")) {
   check_uses_github()
+  ext <- rlang::arg_match(ext)
   url <- glue("https://travis-ci.{ext}/{github_repo_spec()}")
   img <- glue("{url}.svg?branch=master")
   use_badge("Travis build status", url, img)
 }
 
-travis_activate <- function(browse = interactive(), ext = "org") {
+travis_activate <- function(browse = interactive(), ext = c("com", "org")) {
+  ext <- rlang::arg_match(ext)
   url <- glue("https://travis-ci.{ext}/profile/{github_owner()}")
 
   ui_todo("Turn on travis for your repo at {url}")

--- a/R/tidyverse.R
+++ b/R/tidyverse.R
@@ -10,7 +10,7 @@
 #' of the tidyverse conventions as possible, issues a few reminders, and
 #' activates the new package.
 #'
-#' * `use_tidy_ci()`: sets up [Travis CI](https://travis-ci.org) and
+#' * `use_tidy_ci()`: sets up [Travis CI](https://travis-ci.com) and
 #' [Codecov](https://codecov.io), ensuring that the package is actively tested
 #' on the versions of R officially supported by the Tidyverse (current release,
 #' devel, and four previous versions). It also ignores `compat-` and `deprec-`

--- a/man/browse-this.Rd
+++ b/man/browse-this.Rd
@@ -16,7 +16,7 @@ browse_github_issues(package = NULL, number = NULL)
 
 browse_github_pulls(package = NULL, number = NULL)
 
-browse_travis(package = NULL, ext = c("org", "com"))
+browse_travis(package = NULL, ext = c("com", "org"))
 
 browse_circleci(package = NULL)
 
@@ -43,7 +43,7 @@ and there is no guarantee there will be content at the destination.
 issue.
 \item \code{browse_github_pulls()}: Visits the GitHub Pull Request index or one
 specific pull request.
-\item \code{browse_travis()}: Visits the package's page on \href{https://travis-ci.org}{Travis CI}.
+\item \code{browse_travis()}: Visits the package's page on \href{https://travis-ci.com}{Travis CI}.
 \item \code{browse_circleci()}: Visits the package's page on \href{https://circleci.com}{Circle CI}
 \item \code{browse_cran()}: Visits the package on CRAN, via the canonical URL.
 }

--- a/man/ci.Rd
+++ b/man/ci.Rd
@@ -10,9 +10,9 @@
 \alias{use_circleci_badge}
 \title{Continuous integration setup and badges}
 \usage{
-use_travis(browse = interactive(), ext = c("org", "com"))
+use_travis(browse = interactive(), ext = c("com", "org"))
 
-use_travis_badge(ext = "org")
+use_travis_badge(ext = c("com", "org"))
 
 use_appveyor(browse = interactive())
 
@@ -28,8 +28,8 @@ use_circleci_badge()
 \item{browse}{Open a browser window to enable automatic builds for the
 package.}
 
-\item{ext}{which travis website to use. default to \code{"org"}for
-https://travis-ci.org. Change to \code{"com"} for https://travis-ci.com.}
+\item{ext}{Which travis website to use. Defaults to \code{"com"} for
+https://travis-ci.com. Change to \code{"org"} for https://travis-ci.org.}
 
 \item{image}{The Docker image to use for build. Must be available on
 \href{https://hub.docker.com}{DockerHub}. The
@@ -52,13 +52,13 @@ various platforms, triggered by each push or pull request. These functions
 \section{\code{use_travis()}}{
 
 Adds a basic \code{.travis.yml} to the top-level directory of a package. This is a
-configuration file for the \href{https://travis-ci.org/}{Travis CI} continuous
+configuration file for the \href{https://travis-ci.com/}{Travis CI} continuous
 integration service.
 }
 
 \section{\code{use_travis_badge()}}{
 
-Only adds the \href{https://travis-ci.org/}{Travis CI} badge. Use for a project
+Only adds the \href{https://travis-ci.com/}{Travis CI} badge. Use for a project
 where Travis is already configured.
 }
 

--- a/man/proj_utils.Rd
+++ b/man/proj_utils.Rd
@@ -39,7 +39,8 @@ project-signalling infrastructure, such as initialising a Git repo or
 adding a \code{DESCRIPTION} file.}
 
 \item{...}{character vectors, if any values are NA, the result will also be
-NA.}
+NA. The paths follow the recycling rules used in the tibble package,
+namely that only length 1 arguments are recycled.}
 
 \item{ext}{An optional extension to append to the generated path.}
 

--- a/man/tidyverse.Rd
+++ b/man/tidyverse.Rd
@@ -76,7 +76,7 @@ versions of R.
 \item \code{create_tidy_package()}: creates a new package, immediately applies as many
 of the tidyverse conventions as possible, issues a few reminders, and
 activates the new package.
-\item \code{use_tidy_ci()}: sets up \href{https://travis-ci.org}{Travis CI} and
+\item \code{use_tidy_ci()}: sets up \href{https://travis-ci.com}{Travis CI} and
 \href{https://codecov.io}{Codecov}, ensuring that the package is actively tested
 on the versions of R officially supported by the Tidyverse (current release,
 devel, and four previous versions). It also ignores \verb{compat-} and \verb{deprec-}

--- a/tests/testthat/test-browse.R
+++ b/tests/testthat/test-browse.R
@@ -46,8 +46,8 @@ test_that("browse_XXX() goes to correct URL", {
   expect_match(browse_github_pulls("gh"), g("r-lib/gh/pulls"))
   expect_equal(browse_github_pulls("gh", 1), g("r-lib/gh/pull/1"))
 
-  expect_equal(browse_travis("usethis"), "https://travis-ci.org/r-lib/usethis")
-  expect_equal(browse_travis("usethis", ext = "com"), "https://travis-ci.com/r-lib/usethis")
+  expect_equal(browse_travis("usethis"), "https://travis-ci.com/r-lib/usethis")
+  expect_equal(browse_travis("usethis", ext = "org"), "https://travis-ci.org/r-lib/usethis")
 
   expect_equal(browse_cran("usethis"), "https://cran.r-project.org/package=usethis")
 })


### PR DESCRIPTION
Fixes #1038.

* travis-ci.com is now recommended over travis-ci.org.
* Documented with newly-released roxygen2.