### PR TITLE
Overwrite VignetteBuilder if already set

### DIFF
--- a/R/vignette.R
+++ b/R/vignette.R
@@ -25,7 +25,7 @@ use_vignette <- function(name, title = name) {
   check_vignette_name(name)
 
   use_dependency("knitr", "Suggests")
-  use_description_field("VignetteBuilder", "knitr")
+  use_description_field("VignetteBuilder", "knitr", overwrite = TRUE)
   use_git_ignore("inst/doc")
 
   use_vignette_template("vignette.Rmd", name, title)


### PR DESCRIPTION
This is technically wrong, but it's such a rare case that I doubt it will cause any problems in practice.

Fixes #773