### PR TITLE
Look in remotes for github_home()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,6 +30,7 @@ Imports:
     git2r (>= 0.23),
     glue (>= 1.3.0),
     purrr,
+    rematch2,
     rlang (>= 0.4.2),
     rprojroot (>= 1.2),
     rstudioapi,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # usethis (development version)
 
+* `browse_github()` now always goes to the canoncial Github site: 
+  `https://github.com/user/repo`. This is slightly worse than the current 
+  behaviour but makes the function more consistent across packages, and 
+  considerably simplifies the implementation.
+
 * usethis should do a better job of not messing up UTF-8 files on windows 
   (#969).
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # usethis (development version)
 
-* `browse_github()` now always goes to the canoncial Github site: 
+* `browse_github()` now always goes to the canonical Github site: 
   `https://github.com/user/repo`. This is slightly worse than the current 
   behaviour but makes the function more consistent across packages, and 
   considerably simplifies the implementation.

--- a/R/browse.R
+++ b/R/browse.R
@@ -35,7 +35,7 @@ NULL
 #' @export
 #' @rdname browse-this
 browse_github <- function(package = NULL) {
-  view_url(github_link(package))
+  view_url(github_home(package))
 }
 
 #' @export
@@ -75,39 +75,37 @@ browse_cran <- function(package = NULL) {
   view_url(cran_home(package))
 }
 
-## gets at most one GitHub link from the URL field of DESCRIPTION
-## strips any trailing slash
-## respects the URL given by maintainer, e.g.
-## "https://github.com/simsem/semTools/wiki" <-- note the "wiki" part
-## "https://github.com/r-lib/gh#readme" <-- note trailing "#readme"
-github_link <- function(package = NULL) {
+# gets at most one GitHub link from BugReports/URL fields;
+# always creates canonical GitHub url, even if the maintainer specified
+# something else
+github_home <- function(package = NULL) {
   if (is.null(package)) {
+    remote <- github_upstream() %||% github_origin()
+    if (!is.null(remote)) {
+      return(glue("https://github.com/{remote$owner}/{remote$repo}"))
+    }
+
     desc <- desc::desc(proj_get())
+    package <- project_name()
   } else {
     desc <- desc::desc(package = package)
   }
 
-  urls <- desc$get_urls()
+  urls <- c(
+    desc$get_field("BugReports", default = character()),
+    desc$get_urls()
+  )
   gh_links <- grep("^https?://github.com/", urls, value = TRUE)
 
   if (length(gh_links) == 0) {
-    ui_warn("
-      Package does not provide a GitHub URL.
-      Falling back to GitHub CRAN mirror")
+    ui_warn(c(
+      "Package does not provide a GitHub URL.",
+      "Falling back to GitHub CRAN mirror"
+    ))
     return(glue("https://github.com/cran/{package}"))
   }
 
-  gsub("/$", "", gh_links[[1]])
-}
-
-cran_home <- function(package = NULL) {
-  package <- package %||% project_name()
-
-  glue("https://cran.r-project.org/package={package}")
-}
-
-github_url_rx <- function() {
-  paste0(
+  re <- paste0(
     "^",
     "(?:https?://github.com/)",
     "(?<owner>[^/]+)/",
@@ -116,48 +114,12 @@ github_url_rx <- function() {
     "(?<fragment>.*)",
     "$"
   )
+  remote <- rematch2::re_match(gh_links[[1]], re)
+  glue("https://github.com/{remote$owner}/{remote$repo}")
 }
 
-## takes URL return by github_link() and strips it down to support
-## appending path parts for issues or pull requests
-##  input: "https://github.com/simsem/semTools/wiki"
-## output: "https://github.com/simsem/semTools"
-##  input: "https://github.com/r-lib/gh#readme"
-## output: "https://github.com/r-lib/gh"
-github_home <- function(package = NULL) {
-  gh_link <- github_link(package)
-  df <- re_match_inline(gh_link, github_url_rx())
-  glue("https://github.com/{df$owner}/{df$repo}")
-}
+cran_home <- function(package = NULL) {
+  package <- package %||% project_name()
 
-## inline a simplified version of rematch2::re_match()
-re_match_inline <- function(text, pattern) {
-  match <- regexpr(pattern, text, perl = TRUE)
-  start <- as.vector(match)
-  length <- attr(match, "match.length")
-  end <- start + length - 1L
-
-  matchstr <- substring(text, start, end)
-  matchstr[ start == -1 ] <- NA_character_
-
-  res <- data.frame(
-    stringsAsFactors = FALSE,
-    .text = text,
-    .match = matchstr
-  )
-
-  if (!is.null(attr(match, "capture.start"))) {
-    gstart <- attr(match, "capture.start")
-    glength <- attr(match, "capture.length")
-    gend <- gstart + glength - 1L
-
-    groupstr <- substring(text, gstart, gend)
-    groupstr[ gstart == -1 ] <- NA_character_
-    dim(groupstr) <- dim(gstart)
-
-    res <- cbind(groupstr, res, stringsAsFactors = FALSE)
-  }
-
-  names(res) <- c(attr(match, "capture.names"), ".text", ".match")
-  res
+  glue("https://cran.r-project.org/package={package}")
 }

--- a/tests/testthat/test-browse.R
+++ b/tests/testthat/test-browse.R
@@ -1,31 +1,13 @@
 context("browse")
 
-test_that("github_link() has fall back", {
-  scoped_temporary_package()
-  expect_warning(out <- github_link("utils"), "CRAN mirror")
-  expect_equal(out, "https://github.com/cran/utils")
-})
-
-test_that("github_link() reports GitHub URL 'as is'", {
-  expect_identical(
-    github_link("usethis"),
-    "https://github.com/r-lib/usethis"
-  )
-  expect_identical(
-    github_link("gh"),
-    "https://github.com/r-lib/gh#readme"
-  )
-})
-
 test_that("github_home() strips everything after USER/REPO", {
-  expect_identical(
-    github_home("usethis"),
-    glue::as_glue("https://github.com/r-lib/usethis")
-  )
-  expect_identical(
-    github_home("gh"),
-    glue::as_glue("https://github.com/r-lib/gh")
-  )
+  expect_equal(github_home("usethis"), "https://github.com/r-lib/usethis")
+  expect_equal(github_home("gh"), "https://github.com/r-lib/gh")
+})
+
+test_that("github_home() has fall back", {
+  expect_warning(out <- github_home("utils"), "CRAN mirror")
+  expect_equal(out, "https://github.com/cran/utils")
 })
 
 test_that("cran_home() produces canonical URL", {
@@ -35,9 +17,10 @@ test_that("cran_home() produces canonical URL", {
 })
 
 test_that("browse_XXX() goes to correct URL", {
+  skip_if(interactive())
   g <- function(x) paste0("https://github.com/", x)
 
-  expect_equal(browse_github("gh"), g("r-lib/gh#readme"))
+  expect_equal(browse_github("gh"), g("r-lib/gh"))
 
   expect_match(browse_github_issues("gh"), g("r-lib/gh/issues"))
   expect_equal(browse_github_issues("gh", 1), g("r-lib/gh/issues/1"))


### PR DESCRIPTION
If `package` is NULL, `gitub_home()` starts by looking in the upstream remote, followed by the origin. If package isn't NULL, it looks in BugReports, then URL.

I've eliminated github_link() because it's too hard to make it work across a wide range of packages.

Fixes #1023

This is important for GitHub actions because they use `github_home()` to construct the badge.