### PR TITLE
Configure a dummy git user

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -71,8 +71,8 @@ jobs:
 
       - name: Configure Git user
         run: |
-          git config --local user.email "ghau@example.com"
-          git config --local user.name "Dummy User"
+          git config --global user.email "ghau@example.com"
+          git config --global user.name "GitHub Actions User"
 
       - name: Check
         run: rcmdcheck::rcmdcheck(args = "--no-manual", error_on = "warning", check_dir = "check")

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -69,6 +69,11 @@ jobs:
           remotes::install_cran("rcmdcheck")
         shell: Rscript {0}
 
+      - name: Configure Git user
+        run: |
+          git config --local user.email "ghau@example.com"
+          git config --local user.name "GitHub Actions User"
+
       - name: Check
         run: rcmdcheck::rcmdcheck(args = "--no-manual", error_on = "warning", check_dir = "check")
         shell: Rscript {0}

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -72,7 +72,7 @@ jobs:
       - name: Configure Git user
         run: |
           git config --local user.email "ghau@example.com"
-          git config --local user.name "GitHub Actions User"
+          git config --local user.name "Dummy User"
 
       - name: Check
         run: rcmdcheck::rcmdcheck(args = "--no-manual", error_on = "warning", check_dir = "check")


### PR DESCRIPTION
Fixes #1070

Lesson learned along the way: the git config has to be global, not local, if it needs to be in force inside the scoped temporary projects we used widely in the tests.