### PR TITLE
Ensure we can write_utf8() even when outside a project

### DIFF
--- a/R/write.R
+++ b/R/write.R
@@ -92,13 +92,21 @@ read_utf8 <- function(path, n = -1L) {
   base::readLines(path, n = n, encoding = "UTF-8", warn = FALSE)
 }
 
-write_utf8 <- function(path, lines, append = FALSE, line_ending = proj_line_ending()) {
+write_utf8 <- function(path, lines, append = FALSE, line_ending = NULL) {
   stopifnot(is.character(path))
   stopifnot(is.character(lines))
 
   file_mode <- if (append) "ab" else "wb"
   con <- file(path, open = file_mode, encoding = "utf-8")
   on.exit(close(con), add = TRUE)
+
+  if (is.null(line_ending)) {
+    if (possibly_in_proj(path)) {
+      line_ending <- proj_line_ending()
+    } else {
+      line_ending <- platform_line_ending()
+    }
+  }
 
   # convert embedded newlines
   lines <- gsub("\r?\n", line_ending, lines)

--- a/tests/testthat/test-write.R
+++ b/tests/testthat/test-write.R
@@ -70,13 +70,13 @@ test_that("write_over() leaves file 'as is'", {
 })
 
 # https://github.com/r-lib/usethis/issues/514
-test_that("write_ut8 always produces a trailing newline", {
+test_that("write_utf8() always produces a trailing newline", {
   path <- file_temp()
   write_utf8(path, "x", line_ending = "\n")
   expect_equal(readChar(path, 2), "x\n")
 })
 
-test_that("write_ut8 can append text when requested", {
+test_that("write_utf8() can append text when requested", {
   path <- file_temp()
   write_utf8(path, "x", line_ending = "\n")
   write_utf8(path, "x", line_ending = "\n", append = TRUE)
@@ -84,7 +84,7 @@ test_that("write_ut8 can append text when requested", {
   expect_equal(readChar(path, 4), "x\nx\n")
 })
 
-test_that("write_utf8 respects line ending", {
+test_that("write_utf8() respects line ending", {
   path <- file_temp()
 
   write_utf8(path, "x", line_ending = "\n")
@@ -92,4 +92,16 @@ test_that("write_utf8 respects line ending", {
 
   write_utf8(path, "x", line_ending = "\r\n")
   expect_equal(detect_line_ending(path), "\r\n")
+})
+
+test_that("write_utf8() can operate outside of a project", {
+  tmpdir <- file_temp()
+  on.exit(dir_delete(tmpdir))
+  dir_create(tmpdir)
+
+  withr::local_dir(tmpdir)
+  local_project(NULL)
+
+  expect_false(proj_active())
+  expect_error_free(write_utf8(path = "foo", letters[1:3]))
 })


### PR DESCRIPTION
This is the root cause of what we were talking about in https://github.com/r-lib/usethis/pull/1072#pullrequestreview-380448740 (my initial comment was off-base, but this was worth sorting out).