### PR TITLE
Empty `gh()` responses are now correctly returned as classed empty lists

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,7 +30,7 @@ Imports:
     curl (>= 2.7),
     desc,
     fs (>= 1.3.0),
-    gh,
+    gh (>= 1.1.0),
     git2r (>= 0.23),
     glue (>= 1.3.0),
     purrr,

--- a/R/github-labels.R
+++ b/R/github-labels.R
@@ -70,7 +70,7 @@ use_github_labels <- function(repo_spec = github_repo_spec(),
   check_github_token(auth_token)
 
   gh <- function(endpoint, ...) {
-    out <- gh::gh(
+    gh::gh(
       endpoint,
       ...,
       owner = spec_owner(repo_spec),
@@ -81,11 +81,6 @@ use_github_labels <- function(repo_spec = github_repo_spec(),
         "Accept" = "application/vnd.github.symmetra-preview+json"
       )
     )
-    if (identical(out[[1]], "")) {
-      list()
-    } else {
-      out
-    }
   }
 
   cur_labels <- gh("GET /repos/:owner/:repo/labels")


### PR DESCRIPTION
Closes #1087 