### PR TITLE
Use separate test-coverage action to run test coverage

### DIFF
--- a/R/github-actions.R
+++ b/R/github-actions.R
@@ -40,6 +40,7 @@ use_tidy_github_actions <- function() {
   full_status    <- use_github_action_check_full()
   pr_status      <- use_github_action_pr_commands()
   pkgdown_status <- use_github_action("pkgdown")
+  test_coverage_status <- use_github_action("test-coverage")
 
   old_configs <- proj_path(c(".travis.yml", "appveyor.yml"))
   has_appveyor_travis <- file_exists(old_configs)
@@ -53,7 +54,7 @@ use_tidy_github_actions <- function() {
     }
   }
 
-  invisible(full_status && pr_status && pkgdown_status)
+  invisible(full_status && pr_status && pkgdown_status && test_coverage_status)
 }
 
 #' @section `use_github_actions_badge()`:


### PR DESCRIPTION
Rather than running test coverage after the check finishes, this action
runs it as a separate workflow

This can be useful when a package takes a while to compile and check, as
covr needs to recompile it anyway and measuring the coverage does not
really depend on a successful check