### PR TITLE
Avoid message after use_test() in uninitialized package

### DIFF
--- a/R/r.R
+++ b/R/r.R
@@ -38,7 +38,7 @@ use_r <- function(name = NULL, open = rlang::is_interactive()) {
 #' @export
 use_test <- function(name = NULL, open = rlang::is_interactive()) {
   if (!uses_testthat()) {
-    use_testthat()
+    use_testthat_impl()
   }
 
   name <- name %||% get_active_r_file(path = "R")

--- a/R/test.R
+++ b/R/test.R
@@ -14,6 +14,15 @@
 #' use_test("something-management")
 #' }
 use_testthat <- function() {
+  use_testthat_impl()
+
+  ui_todo(
+    "Call {ui_code('use_test()')} to initialize a basic test file and open it \\
+    for editing."
+  )
+}
+
+use_testthat_impl <- function() {
   check_installed("testthat")
   if (utils::packageVersion("testthat") < "2.1.0") {
     ui_stop("testthat 2.1.0 or greater needed. Please install before re-trying")
@@ -28,11 +37,6 @@ use_testthat <- function() {
     "testthat.R",
     save_as = path("tests", "testthat.R"),
     data = list(name = project_name())
-  )
-
-  ui_todo(
-    "Call {ui_code('use_test()')} to initialize a basic test file and open it \\
-    for editing."
   )
 }
 


### PR DESCRIPTION
Hides the first TODO item shown currently:

``` r
pkg <- rlang::with_options(
  usethis.quiet = TRUE,
  usethis::create_package(tempfile("pkg"))
)
usethis::proj_set(pkg)
#> ✓ Setting active project to '/tmp/Rtmp7WyA5K/pkg4c967aa89a98'
usethis::use_test("super")
#> ✓ Adding 'testthat' to Suggests field in DESCRIPTION
#> ✓ Creating 'tests/testthat/'
#> ✓ Writing 'tests/testthat.R'
#> ● Call `use_test()` to initialize a basic test file and open it for editing.
#> ✓ Writing 'tests/testthat/test-super.R'
#> ● Edit 'tests/testthat/test-super.R'
```

<sup>Created on 2020-05-10 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>