### PR TITLE
Check for github before modifying anything

### DIFF
--- a/R/coverage.R
+++ b/R/coverage.R
@@ -6,6 +6,7 @@
 #'   [Codecov](https://codecov.io) and [Coveralls](https://coveralls.io).
 #' @export
 use_coverage <- function(type = c("codecov", "coveralls")) {
+  check_uses_github()
   use_dependency("covr", "Suggests")
 
   type <- match.arg(type)
@@ -45,7 +46,6 @@ use_covr_ignore <- function(files) {
 }
 
 use_codecov_badge <- function() {
-  check_uses_github()
   url <- glue("https://codecov.io/gh/{github_repo_spec()}?branch=master")
   img <- glue(
     "https://codecov.io/gh/{github_repo_spec()}/branch/master/graph/badge.svg"
@@ -54,7 +54,6 @@ use_codecov_badge <- function() {
 }
 
 use_coveralls_badge <- function() {
-  check_uses_github()
   url <- glue("https://coveralls.io/r/{github_repo_spec()}?branch=master")
   img <- glue(
     "https://coveralls.io/repos/github/{github_repo_spec()}/badge.svg"


### PR DESCRIPTION
As currently is `use_codecov` first modify the package and then checks if there is a github repository. This might end up not adding the badge on the README but having some files on the package directory. 

There workaround is to follow the suggestion and run again codecov (after manually deleting the codecov.yml, otherwise it won't work).

```
use_codecov()
✓ Adding 'covr' to Suggests field in DESCRIPTION
✓ Writing 'codecov.yml'
✓ Adding '^codecov\\.yml$' to '.Rbuildignore'
Error: This project does not have a GitHub remote configured as 'origin'.
Do you need to run `use_github()`?
use_github()
use_codecov()
# Manually deleting codecov.yml
use_codecov()
✓ Writing 'codecov.yml'
✓ Adding Codecov test coverage badge to 'README.Rmd'
```

This PR changes that, so that first it checks if github repository is available if so it proceeds to set up the code coverage.

----

Note that the functions `use_coveralls_badge` and `use_codecov_badge` aren't exported. If the user hasn't created the README before running `use_codecov` the badges won't be added and will not be possible to add them later without deleting codecov.yml and rerunning `use_codecov`. 