### PR TITLE
Add tidymodels to refuse_package()

### DIFF
--- a/R/package.R
+++ b/R/package.R
@@ -30,7 +30,7 @@
 #' }
 use_package <- function(package, type = "Imports", min_version = NULL) {
   if (type == "Imports") {
-    refuse_package(package, verboten = "tidyverse")
+    refuse_package(package, verboten = c("tidyverse", "tidymodels"))
   }
 
   use_dependency(package, type, min_version = min_version)
@@ -42,7 +42,7 @@ use_package <- function(package, type = "Imports", min_version = NULL) {
 #' @export
 #' @rdname use_package
 use_dev_package <- function(package, type = "Imports", remote = NULL) {
-  refuse_package(package, verboten = "tidyverse")
+  refuse_package(package, verboten = c("tidyverse", "tidymodels"))
 
   use_dependency(package, type = type, min_version = TRUE)
   use_remote(package, remote)
@@ -100,7 +100,7 @@ package_remote <- function(package) {
 }
 
 refuse_package <- function(package, verboten) {
-  if (identical(package, verboten)) {
+  if (package %in% verboten) {
     code <- glue("use_package(\"{package}\", type = \"depends\")")
     ui_stop(
       "{ui_value(package)} is a meta-package and it is rarely a good idea to \\

--- a/tests/testthat/test-package.R
+++ b/tests/testthat/test-package.R
@@ -1,6 +1,7 @@
-test_that("use_package() won't facilitate dependency on tidyverse", {
+test_that("use_package() won't facilitate dependency on tidyverse/tidymodels", {
   create_local_package()
   expect_usethis_error(use_package("tidyverse"), "rarely a good idea")
+  expect_usethis_error(use_package("tidymodels"), "rarely a good idea")
 })
 
 


### PR DESCRIPTION
This PR adds tidymodels to `verboten`, to be handled in the same way that tidyverse is within `add_package()` and `refuse_package()`. This addresses tidymodels/tidymodels#3.