### PR TITLE
Fix background color for reviewer and output chunks in vignette

### DIFF
--- a/vignettes/articles/pr-functions.Rmd
+++ b/vignettes/articles/pr-functions.Rmd
@@ -8,8 +8,8 @@ vignette: >
 ---
 
 <style>
-div.reviewer pre.r { background-color:#e3dece; }
-div.output pre.r { background-color:#FFFFFF; }
+div.reviewer pre { background-color:#e3dece; }
+div.output pre { background-color:#FFFFFF; }
 </style>
 
 ## Contributing to someone else's package


### PR DESCRIPTION
This PR fixes the background coloring for reviewer and output chunks in the [pull request helpers](https://usethis.r-lib.org/articles/articles/pr-functions.html) vignette. It seems like the class for these chunks have changed over time. I haven't dug into why the change happened but this minor fix should display the colors correctly.

Closes #1186.