### PR TITLE
Fix use_tutorial

### DIFF
--- a/R/tutorial.R
+++ b/R/tutorial.R
@@ -33,9 +33,6 @@ use_tutorial <- function(name, title, open = rlang::is_interactive()) {
   use_git_ignore("*.html", directory = dir_path)
   use_dependency("learnr", "Suggests")
 
-  html_path <- path(dir_path, asciify(name), ext = ".html")
-  use_build_ignore(html_path)
-
   path <- path(dir_path, asciify(name), ext = "Rmd")
 
   data <- project_data()

--- a/R/tutorial.R
+++ b/R/tutorial.R
@@ -33,6 +33,9 @@ use_tutorial <- function(name, title, open = rlang::is_interactive()) {
   use_git_ignore("*.html", directory = dir_path)
   use_dependency("learnr", "Suggests")
 
+  html_path <- path(dir_path, asciify(name), ext = ".html")
+  use_build_ignore(html_path)
+
   path <- path(dir_path, asciify(name), ext = "Rmd")
 
   data <- project_data()
@@ -42,7 +45,7 @@ use_tutorial <- function(name, title, open = rlang::is_interactive()) {
     "tutorial-template.Rmd",
     save_as = path,
     data = data,
-    ignore = TRUE,
+    ignore = FALSE,
     open = open
   )
 


### PR DESCRIPTION
Fixes #1178 

It changes the `use_tutorial` function so the tutorial `Rmd` is no longer added in `.Rbuildignore`, which now makes the tutorial discoverable to `learnr::run_tutorial`. 

On the other hand, it now build ignores  the `html` file generated from rendering the tutorial.