### PR TITLE
Manually install libgit2-dev

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -64,6 +64,7 @@ jobs:
           do
             eval sudo $cmd
           done < <(Rscript -e 'cat(remotes::system_requirements("ubuntu", "16.04"), sep = "\n")')
+          sudo apt-get install -y libgit2-dev
 
       - name: Install macOS system dependencies
         if: runner.os == 'macOS'


### PR DESCRIPTION
It is not included in the system requirements database because it
conflicts with libcurl4-openssl-dev. But the `setup-r` action include
the travis ppa which has a backport for libgit2-dev which does work
without conflicts