### PR TITLE
Use a try block to catch any errors in withr::defer

### DIFF
--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -44,9 +44,11 @@ create_local_thing <- function(dir = file_temp(pattern = pattern),
       ui_silence({
         proj_set(old_project, force = TRUE)
       })
-      setwd(old_project)
-      ui_done("Deleting temporary project: {ui_path(dir)}")
-      fs::dir_delete(dir)
+      try(silent = TRUE, {
+        setwd(old_project)
+        ui_done("Deleting temporary project: {ui_path(dir)}")
+        fs::dir_delete(dir)
+      })
     },
     envir = env
   )


### PR DESCRIPTION
withr 2.3.0 now throws errors if they occur in `withr::defer()` expressions.

In previous versions of withr these errors were silently ignored.

There are cases in the usethis tests where `setwd()` and `fs::dir_delete()` throw errors. For example if `old_project` is `NULL` then `setwd()` will fail.

This PR restores the previous behavior, but you may want to revisit this function, as it stands if `old_project` is `NULL` then `dir` is not deleted, I am not sure if that is the intent or not.