### PR TITLE
Patch release for upcoming withr

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -21,3 +21,4 @@
 ^inst/templates/.*\\.html$
 ^man/figures/usethis-full-logo\.png$
 ^man/figures/usethis-og-1280x640\.png$
+^internal$

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .RData
 inst/doc
 docs
+internal

--- a/CRAN-RELEASE
+++ b/CRAN-RELEASE
@@ -1,2 +1,2 @@
 This package was submitted to CRAN on 2020-09-17.
-Once it is accepted, delete this file and tag the release (commit c8ab540cb).
+Once it is accepted, delete this file and tag the release (commit 23a2cecef).

--- a/CRAN-RELEASE
+++ b/CRAN-RELEASE
@@ -1,0 +1,2 @@
+This package was submitted to CRAN on 2020-09-16.
+Once it is accepted, delete this file and tag the release (commit 9130334d4).

--- a/CRAN-RELEASE
+++ b/CRAN-RELEASE
@@ -1,2 +1,2 @@
-This package was submitted to CRAN on 2020-09-16.
-Once it is accepted, delete this file and tag the release (commit 9130334d4).
+This package was submitted to CRAN on 2020-09-17.
+Once it is accepted, delete this file and tag the release (commit c8ab540cb).

--- a/CRAN-RELEASE
+++ b/CRAN-RELEASE
@@ -1,2 +1,0 @@
-This package was submitted to CRAN on 2020-09-17.
-Once it is accepted, delete this file and tag the release (commit 23a2cecef).

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: usethis
 Title: Automate Package and Project Setup
-Version: 1.6.2
+Version: 1.6.3
 Authors@R: 
     c(person(given = "Hadley",
              family = "Wickham",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -57,4 +57,4 @@ Encoding: UTF-8
 Language: en-US
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.1.0
+RoxygenNote: 7.1.1

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: usethis
 Title: Automate Package and Project Setup
-Version: 1.6.1
+Version: 1.6.2
 Authors@R: 
     c(person(given = "Hadley",
              family = "Wickham",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# usethis 1.6.2
+
 # usethis 1.6.1
 
 Patch release to align some path handling internals with an update coming in the fs package.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # usethis 1.6.2
 
+Patch release to refactor usage of withr in the tests for forward compatibility with an upcoming withr release. All changes are within the usethis tests.
+
 # usethis 1.6.1
 
 Patch release to align some path handling internals with an update coming in the fs package.

--- a/NEWS.md
+++ b/NEWS.md
@@ -678,7 +678,7 @@ templating functions using this framework (@ijlyttle #120).
   project lifecycle (#48).
 
 * `use_pkgdown()` creates the basics needed for a 
-  [pkgdown](https://github.com/hadley/pkgdown) website (#88).
+  [pkgdown](https://github.com/r-lib/pkgdown) website (#88).
 
 * `use_r("foo")` creates and edit `R/foo.R` file. If you have a test file open,
   `use_r()` will open the corresponding `.R` file (#105).

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# usethis 1.6.2
+# usethis 1.6.3
 
 Patch release to refactor usage of withr in the tests for forward compatibility with an upcoming withr release. All changes are within the usethis tests.
 

--- a/R/ci.R
+++ b/R/ci.R
@@ -198,7 +198,7 @@ use_circleci <- function(browse = rlang::is_interactive(), image = "rocker/verse
 }
 
 #' @section `use_circleci_badge()`:
-#' Only adds the [Circle CI](https://www.circleci.com) badge. Use for a project
+#' Only adds the [Circle CI](https://circleci.com/) badge. Use for a project
 #'  where Circle CI is already configured.
 #' @export
 #' @rdname ci

--- a/R/code-of-conduct.R
+++ b/R/code-of-conduct.R
@@ -4,15 +4,15 @@
 #' `.Rbuildignore`, in the case of a package. The goal of a code of conduct is
 #' to foster an environment of inclusiveness, and to explicitly discourage
 #' inappropriate behaviour. The template comes from
-#' <https://contributor-covenant.org>, version 2:
-#' <https://contributor-covenant.org/version/2/0>.
+#' <https://www.contributor-covenant.org>, version 2:
+#' <https://www.contributor-covenant.org/version/2/0/code_of_conduct/>.
 #'
 #' If your package is going to CRAN, the link to the CoC in your README must
 #' be an absolute link to a rendered website as `CODE_OF_CONDUCT.md` is not
 #' included in the package sent to CRAN. `use_code_of_conduct()` will
 #' automatically generate this link if you use pkgdown and have set the
 #' `url` field in `pkgdown.yml`; otherwise it'll link to
-#' <https://contributor-covenant.org/version/2/0>.
+#' <https://www.contributor-covenant.org/version/2/0/code_of_conduct/>.
 #'
 #' @param path Path of the directory to put `CODE_OF_CONDUCT.md` in, relative to
 #'   the active project. Passed along to [use_directory()]. Default is to locate

--- a/R/course.R
+++ b/R/course.R
@@ -137,7 +137,7 @@ use_zip <- function(url,
 #' ## DropBox
 #'
 #' To make a folder available for ZIP download, create a shared link for it:
-#' * <https://www.dropbox.com/help/files-folders/view-only-access>
+#' * <https://help.dropbox.com/files-folders/share/view-only-access>
 #'
 #' A shared link will have this form:
 #' ```
@@ -152,8 +152,8 @@ use_zip <- function(url,
 #' This download link (or a shortlink that points to it) is suitable as input
 #' for `tidy_download()`. After one or more redirections, this link will
 #' eventually lead to a download URL. For more details, see
-#' <https://www.dropbox.com/help/desktop-web/force-download> and
-#' <https://www.dropbox.com/en/help/desktop-web/download-entire-folders>.
+#' <https://help.dropbox.com/files-folders/share/force-download> and
+#' <https://help.dropbox.com/installs-integrations/sync-uploads/download-entire-folders>.
 #'
 #' ## GitHub
 #'

--- a/R/description.R
+++ b/R/description.R
@@ -5,7 +5,7 @@
 #' `use_description()` creates a `DESCRIPTION` file. Although mostly associated
 #' with R packages, a `DESCRIPTION` file can also be used to declare
 #' dependencies for a non-package projects. Within such a project,
-#' [`devtools::install_deps()`] can then be used to install all the required
+#' `devtools::install_deps()` can then be used to install all the required
 #' packages. Note that, by default, `use_decription()` checks for a
 #' CRAN-compliant package name. You can turn this off with `check_name = FALSE`.
 #'

--- a/R/jenkins.R
+++ b/R/jenkins.R
@@ -6,7 +6,7 @@
 #' already exist at the project root.
 #'
 #' @seealso The [documentation on Jenkins
-#'   Pipelines](https://jenkins.io/doc/book/pipeline/jenkinsfile).
+#'   Pipelines](https://www.jenkins.io/doc/book/pipeline/jenkinsfile/).
 #' @seealso [use_make()]
 #' @export
 use_jenkins <- function() {

--- a/R/make.R
+++ b/R/make.R
@@ -3,7 +3,7 @@
 #' `use_make()` adds a basic Makefile to the project root directory.
 #'
 #' @seealso The [documentation for GNU
-#'   Make](https://www.gnu.org/software/make/manual/html_node).
+#'   Make](https://www.gnu.org/software/make/manual/html_node/).
 #' @export
 use_make <- function() {
   use_template(

--- a/R/rstudio.R
+++ b/R/rstudio.R
@@ -37,7 +37,7 @@ use_rstudio <- function(line_ending = c("posix", "windows")) {
 #' Starting with a blank slate provides timely feedback that encourages the
 #' development of scripts that are complete and self-contained. More detail can
 #' be found in the blog post [Project-oriented
-#' workflow](https://www.tidyverse.org/articles/2017/12/workflow-vs-script/).
+#' workflow](https://www.tidyverse.org/blog/2017/12/workflow-vs-script/).
 #'
 #' Only `use_blank_slate("project")` is automated so far, since RStudio
 #' currently only supports modification of user-level or global options via the

--- a/R/tidyverse.R
+++ b/R/tidyverse.R
@@ -226,7 +226,7 @@ tidy_release_test_env <- function() {
 #'
 #' Derives a list of GitHub usernames, based on who has opened issues or pull
 #' requests. Used to populate the acknowledgment section of package release blog
-#' posts at <https://www.tidyverse.org/articles/>. All arguments can potentially
+#' posts at <https://www.tidyverse.org/blog/>. All arguments can potentially
 #' be determined from the active project, if the project follows standard
 #' practices around the GitHub remote and GitHub releases. Unexported helper
 #' functions, `releases()` and `ref_df()` can be useful interactively to get a

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,27 +1,5 @@
-This is a small patch release to create forward compatibility with a soon-to-submitted update to the fs package, which we Import.
-
-## Test environments
-
-* GitHub actions (ubuntu-16.04): 3.3, 3.4, 3.5, oldrel, release
-* GitHub actions (windows): release, devel
-* Github actions (macOS): release, devel
-* win-builder: devel (actuall, no, that's currently unavailable)
+This is a small patch release to create forward compatibility with a soon-to-submitted update to the withr package. This only affects tests.
 
 ## R CMD check results
 
 0 errors | 0 warnings | 0 notes
-
-## revdepcheck results
-
-We checked 64 reverse dependencies, comparing R CMD check results across CRAN
-and dev versions of this package.
-
- * We saw 0 new problems
- * We failed to check 2 packages
- 
-Issues with CRAN packages are summarised below.
-
-### Failed to check
-
-* butcher (NA)
-* finbif  (NA)

--- a/inst/templates/CODE_OF_CONDUCT.md
+++ b/inst/templates/CODE_OF_CONDUCT.md
@@ -115,8 +115,7 @@ community.
 
 This Code of Conduct is adapted from the [Contributor Covenant][homepage],
 version 2.0,
-available at https://www.contributor-covenant.org/version/2/0/
-code_of_conduct.html.
+available at https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
 
 Community Impact Guidelines were inspired by [Mozilla's code of conduct
 enforcement ladder](https://github.com/mozilla/diversity).

--- a/man/ci.Rd
+++ b/man/ci.Rd
@@ -91,7 +91,7 @@ integration service.
 
 \section{\code{use_circleci_badge()}}{
 
-Only adds the \href{https://www.circleci.com}{Circle CI} badge. Use for a project
+Only adds the \href{https://circleci.com/}{Circle CI} badge. Use for a project
 where Circle CI is already configured.
 }
 

--- a/man/edit.Rd
+++ b/man/edit.Rd
@@ -53,7 +53,7 @@ of user's home directory. The \verb{edit_git_*()} functions -- and \pkg{usethis}
 in general -- inherit home directory behaviour from the \pkg{fs} package,
 which differs from R itself on Windows. The \pkg{fs} default is more
 conventional in terms of the location of user-level Git config files. See
-\code{\link[fs:path_home]{fs::path_home()}} for more details.
+\code{\link[fs:path_expand]{fs::path_home()}} for more details.
 
 Files created by \code{edit_rstudio_snippets()} will \emph{mask}, not supplement,
 the built-in default snippets. If you like the built-in snippets, copy them

--- a/man/use_blank_slate.Rd
+++ b/man/use_blank_slate.Rd
@@ -16,7 +16,7 @@ file in the current directory. However, long-term reproducibility is enhanced
 when you turn this feature off and clear R's memory at every restart.
 Starting with a blank slate provides timely feedback that encourages the
 development of scripts that are complete and self-contained. More detail can
-be found in the blog post \href{https://www.tidyverse.org/articles/2017/12/workflow-vs-script/}{Project-oriented workflow}.
+be found in the blog post \href{https://www.tidyverse.org/blog/2017/12/workflow-vs-script/}{Project-oriented workflow}.
 }
 \details{
 Only \code{use_blank_slate("project")} is automated so far, since RStudio

--- a/man/use_code_of_conduct.Rd
+++ b/man/use_code_of_conduct.Rd
@@ -16,8 +16,8 @@ Adds a \code{CODE_OF_CONDUCT.md} file to the active project and lists in
 \code{.Rbuildignore}, in the case of a package. The goal of a code of conduct is
 to foster an environment of inclusiveness, and to explicitly discourage
 inappropriate behaviour. The template comes from
-\url{https://contributor-covenant.org}, version 2:
-\url{https://contributor-covenant.org/version/2/0}.
+\url{https://www.contributor-covenant.org}, version 2:
+\url{https://www.contributor-covenant.org/version/2/0/code_of_conduct/}.
 }
 \details{
 If your package is going to CRAN, the link to the CoC in your README must
@@ -25,5 +25,5 @@ be an absolute link to a rendered website as \code{CODE_OF_CONDUCT.md} is not
 included in the package sent to CRAN. \code{use_code_of_conduct()} will
 automatically generate this link if you use pkgdown and have set the
 \code{url} field in \code{pkgdown.yml}; otherwise it'll link to
-\url{https://contributor-covenant.org/version/2/0}.
+\url{https://www.contributor-covenant.org/version/2/0/code_of_conduct/}.
 }

--- a/man/use_course_details.Rd
+++ b/man/use_course_details.Rd
@@ -50,7 +50,7 @@ connect timeout.
 
 To make a folder available for ZIP download, create a shared link for it:
 \itemize{
-\item \url{https://www.dropbox.com/help/files-folders/view-only-access}
+\item \url{https://help.dropbox.com/files-folders/share/view-only-access}
 }
 
 A shared link will have this form:\preformatted{https://www.dropbox.com/sh/12345abcde/6789wxyz?dl=0
@@ -64,8 +64,8 @@ You can use \code{create_download_url()} to do this conversion.
 This download link (or a shortlink that points to it) is suitable as input
 for \code{tidy_download()}. After one or more redirections, this link will
 eventually lead to a download URL. For more details, see
-\url{https://www.dropbox.com/help/desktop-web/force-download} and
-\url{https://www.dropbox.com/en/help/desktop-web/download-entire-folders}.
+\url{https://help.dropbox.com/files-folders/share/force-download} and
+\url{https://help.dropbox.com/installs-integrations/sync-uploads/download-entire-folders}.
 }
 
 \subsection{GitHub}{

--- a/man/use_description.Rd
+++ b/man/use_description.Rd
@@ -25,7 +25,7 @@ error if not}
 \code{use_description()} creates a \code{DESCRIPTION} file. Although mostly associated
 with R packages, a \code{DESCRIPTION} file can also be used to declare
 dependencies for a non-package projects. Within such a project,
-\code{\link[devtools:install_deps]{devtools::install_deps()}} can then be used to install all the required
+\code{devtools::install_deps()} can then be used to install all the required
 packages. Note that, by default, \code{use_decription()} checks for a
 CRAN-compliant package name. You can turn this off with \code{check_name = FALSE}.
 

--- a/man/use_jenkins.Rd
+++ b/man/use_jenkins.Rd
@@ -13,7 +13,7 @@ calling this function will also run \code{use_make()} if a Makefile does not
 already exist at the project root.
 }
 \seealso{
-The \href{https://jenkins.io/doc/book/pipeline/jenkinsfile}{documentation on Jenkins Pipelines}.
+The \href{https://www.jenkins.io/doc/book/pipeline/jenkinsfile/}{documentation on Jenkins Pipelines}.
 
 \code{\link[=use_make]{use_make()}}
 }

--- a/man/use_make.Rd
+++ b/man/use_make.Rd
@@ -10,5 +10,5 @@ use_make()
 \code{use_make()} adds a basic Makefile to the project root directory.
 }
 \seealso{
-The \href{https://www.gnu.org/software/make/manual/html_node}{documentation for GNU Make}.
+The \href{https://www.gnu.org/software/make/manual/html_node/}{documentation for GNU Make}.
 }

--- a/man/use_tidy_thanks.Rd
+++ b/man/use_tidy_thanks.Rd
@@ -25,7 +25,7 @@ A character vector of GitHub usernames, invisibly.
 \description{
 Derives a list of GitHub usernames, based on who has opened issues or pull
 requests. Used to populate the acknowledgment section of package release blog
-posts at \url{https://www.tidyverse.org/articles/}. All arguments can potentially
+posts at \url{https://www.tidyverse.org/blog/}. All arguments can potentially
 be determined from the active project, if the project follows standard
 practices around the GitHub remote and GitHub releases. Unexported helper
 functions, \code{releases()} and \code{ref_df()} can be useful interactively to get a

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -17,34 +17,37 @@ if (!is.null(session_temp_proj)) {
 }
 
 create_local_package <- function(dir = file_temp(pattern = "testpkg"),
-                                     env = parent.frame(),
-                                     rstudio = FALSE) {
+                                 env = parent.frame(),
+                                 rstudio = FALSE) {
   create_local_thing(dir, env, rstudio, "package")
 }
 
 create_local_project <- function(dir = file_temp(pattern = "testproj"),
-                                     env = parent.frame(),
-                                     rstudio = FALSE) {
+                                 env = parent.frame(),
+                                 rstudio = FALSE) {
   create_local_thing(dir, env, rstudio, "project")
 }
 
 create_local_thing <- function(dir = file_temp(pattern = pattern),
-                                   env = parent.frame(),
-                                   rstudio = FALSE,
-                                   thing = c("package", "project")) {
+                               env = parent.frame(),
+                               rstudio = FALSE,
+                               thing = c("package", "project")) {
   thing <- match.arg(thing)
   if (fs::dir_exists(dir)) {
     ui_stop("Target {ui_code('dir')} {ui_path(dir)} already exists.")
   }
 
   old_project <- proj_get_()
-  withr::defer({
-    ui_silence({
-      proj_set(old_project, force = TRUE)
-    })
-    setwd(old_project)
-    fs::dir_delete(dir)
-  }, envir = env)
+  withr::defer(
+    {
+      ui_silence({
+        proj_set(old_project, force = TRUE)
+      })
+      setwd(old_project)
+      fs::dir_delete(dir)
+    },
+    envir = env
+  )
 
   ui_silence({
     switch(thing,

--- a/tests/testthat/test-create.R
+++ b/tests/testthat/test-create.R
@@ -11,16 +11,17 @@ test_that("create_project() creates a non-package project", {
 })
 
 test_that("create functions return path to new proj, but restore active proj", {
-  path <- file_temp()
-  cur_proj <- proj_get()
+  cur_proj <- proj_get_()
 
+  path <- file_temp()
   new_path <- create_package(path)
-  expect_equal(proj_get(), cur_proj)
+  expect_equal(proj_get_(), cur_proj)
   expect_equal(proj_path_prep(path), new_path)
   dir_delete(path)
 
+  path <- file_temp()
   new_path <- create_project(path)
-  expect_equal(proj_get(), cur_proj)
+  expect_equal(proj_get_(), cur_proj)
   expect_equal(proj_path_prep(path), new_path)
   dir_delete(path)
 })

--- a/tests/testthat/test-release.R
+++ b/tests/testthat/test-release.R
@@ -19,6 +19,8 @@ test_that("release bullets don't change accidentally", {
 })
 
 test_that("get extra news bullets if available", {
+  create_local_package()
+
   standard <- release_checklist("1.0.0", TRUE)
 
   attach(

--- a/tests/testthat/test-use-logo.R
+++ b/tests/testthat/test-use-logo.R
@@ -4,9 +4,7 @@ test_that("use_logo() doesn't error", {
   skip_if_not_installed("magick")
   skip_on_os("solaris")
 
-  pkg <- create_local_package()
+  create_local_package()
   img <- magick::image_write(magick::image_read("logo:"), "logo.png")
-  on.exit(file_delete("logo.png"))
-
   expect_error_free(use_logo("logo.png"))
 })

--- a/vignettes/articles/usethis-setup.Rmd
+++ b/vignettes/articles/usethis-setup.Rmd
@@ -26,7 +26,7 @@ Key steps that accelerate your R development workflow (details on *how* to do al
   
 ## Use usethis or devtools in interactive work
 
-The usethis package was carved out of the [devtools package](https://devtools.r-lib.org) as part of its "conscious uncoupling" in [the v2.0.0 release](https://www.tidyverse.org/articles/2018/10/devtools-2-0-0/). But note that devtools makes all of usethis's functions available and they should feel like they are part of devtools itself. In addition, devtools offers some functions of its own and exposes selected functionality from a few other packages. You might enjoy making devtools (and therefore usethis) available in all your interactive R work.
+The usethis package was carved out of the [devtools package](https://devtools.r-lib.org) as part of its "conscious uncoupling" in [the v2.0.0 release](https://www.tidyverse.org/blog/2018/10/devtools-2-0-0/). But note that devtools makes all of usethis's functions available and they should feel like they are part of devtools itself. In addition, devtools offers some functions of its own and exposes selected functionality from a few other packages. You might enjoy making devtools (and therefore usethis) available in all your interactive R work.
 
 Call `usethis::use_devtools()` for prompts to do this:
 


### PR DESCRIPTION
The only thing that *had* to change was this aspect of `create_local_thing()`:

* We should capture and restore original working directory explicitly and not assume original working directory == original project. Sometimes there is no active usethis project to start with (so, project is `NULL`), but obviously there is still a working directory. If you conflate the two, you might try to restore the working directory to `NULL`. This used to "work" because withr was swallowing the error, but going forward it will not work. This change improves usethis, in any case.

I used this chance to do a complete audit of active project before and after each test, which I believe should always be the same. I discovered 2 tests that violated this and fixed them. I also refactored `create_local_thing()` to reflect the structure recommended in [testthat's vignette about test fixtures](https://testthat.r-lib.org/articles/test-fixtures.html). The changes described in this paragraph were optional for the patch release, but made sense to do at the same time.

I backported a 3rd test fix that we made since v1.6.1 (https://github.com/r-lib/usethis/commit/e0064aa87321830312ae79f2816a5c76fe0b9ca3#diff-ad31bf57b6e9b29bcce272bc388ca1aa).

Lesson learned about checking: we discovered this via CRAN reverse dependency checks, which clearly run somewhere that does not fulfill any of rprojroot's criteria for a project. So, it hits the "no active project" scenario described above. We were able to replicate using `rcmdcheck::rcmdcheck()`. But we did not see these failures with `devtools::test()` or `devtools::check()` or our cloud revdepchecks, presumably because all of those run in such a way that there is some sort of active project at check time. Possible insight for the future: the safest thing to do is to check from a temp directory, completely decoupled from any project, package, or git repo.