### PR TITLE
Use `name` instead of "R build status" in GHA badge

### DIFF
--- a/R/github-actions.R
+++ b/R/github-actions.R
@@ -42,11 +42,11 @@ use_github_actions <- function() {
 #' @rdname github_actions
 use_github_actions_badge <- function(name = "R-CMD-check", repo_spec = NULL) {
   repo_spec <- repo_spec %||% repo_spec()
-  name <- utils::URLencode(name)
-  img <- glue("https://github.com/{repo_spec}/workflows/{name}/badge.svg")
+  enc_name <- utils::URLencode(name)
+  img <- glue("https://github.com/{repo_spec}/workflows/{enc_name}/badge.svg")
   url <- glue("https://github.com/{repo_spec}/actions")
 
-  use_badge("R build status", url, img)
+  use_badge(name, url, img)
 }
 
 uses_github_actions <- function(base_path = proj_get()) {


### PR DESCRIPTION
This PR updates `use_github_actions_badge()` to more generally support GHA badges, using `name` instead of "R build status". This essentially maintains the default behavior (the Rmd link and `ui_done()` message now say "R-CMD-check" instead of "R build Status", but the appearance of the badge itself does not change) while giving more informative messages when you're adding a badge for a different type of workflow besides "R-CMD-check".