### PR TITLE
Only disable crayon for individual tests

### DIFF
--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -11,8 +11,5 @@ if (nzchar(Sys.getenv("CI"))) {
 }
 
 pre_test_options <- options(
-  usethis.quiet = TRUE,
-  ## make ui_*() output easier to test against
-  ## just say no to ANSI escape codes
-  "crayon.enabled" = FALSE
+  usethis.quiet = TRUE
 )

--- a/tests/testthat/test-github-actions.R
+++ b/tests/testthat/test-github-actions.R
@@ -14,6 +14,7 @@ test_that("uses_github_actions() reports usage of GitHub Actions", {
 
 test_that("check_uses_github_actions() can throw error", {
   create_local_package()
+  withr::local_options(list(crayon.enabled = FALSE))
   expect_error(
     check_uses_github_actions(),
     "Do you need to run `use_github_actions()`?",

--- a/tests/testthat/test-roxygen.R
+++ b/tests/testthat/test-roxygen.R
@@ -2,7 +2,7 @@ context("test-roxygen")
 
 test_that("use_package_doc() compatible with roxygen_ns_append()", {
   create_local_package()
-  withr::local_options(list(usethis.quiet = FALSE))
+  withr::local_options(list(usethis.quiet = FALSE, crayon.enabled = FALSE))
 
   expect_message(use_package_doc())
   expect_message(roxygen_ns_append("test"), "Adding 'test'")

--- a/tests/testthat/test-ui.R
+++ b/tests/testthat/test-ui.R
@@ -23,6 +23,7 @@ test_that("ui_silence() suppresses output", {
 })
 
 test_that("trailing slash behaviour of ui_path()", {
+  withr::local_options(list(crayon.enabled = FALSE))
   # target doesn't exist so no empirical evidence that it's a directory
   expect_match(ui_path("abc"), "abc'$")
 
@@ -32,7 +33,7 @@ test_that("trailing slash behaviour of ui_path()", {
 
   # path is known to be a directory
   tmpdir <- fs::file_temp(pattern = "ui_path")
-  on.exit(fs::dir_delete(tmpdir))
+  on.exit(fs::dir_delete(tmpdir), add = TRUE)
   fs::dir_create(tmpdir)
 
   expect_match(ui_path(tmpdir), "/'$")

--- a/tests/testthat/test-use-badge.R
+++ b/tests/testthat/test-use-badge.R
@@ -29,7 +29,7 @@ test_that("use_badge() does nothing if badge seems to pre-exist", {
 
 test_that("default readme has placeholders / can add to empty badge block", {
   create_local_package()
-  withr::local_options(list(usethis.quiet = FALSE))
+  withr::local_options(list(usethis.quiet = FALSE, crayon.enabled = FALSE))
 
   expect_message(use_readme_md())
   expect_message(use_cran_badge(), "Adding CRAN status badge")


### PR DESCRIPTION
Turned out to be simpler than I expected, and I think the payoff (nicely coloured tests) is worth it. The only minor head scratcher was finding the `on.exit()` with missing `add = TRUE`.