### PR TITLE
Default to `main` as default branch in GitHub actions

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -1,10 +1,10 @@
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     branches:
-      - master
+      - main
 
 name: R-CMD-check
 

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -1,14 +1,14 @@
 on:
   push:
     branches:
-      - master
+      - main
     paths:
       - 'R/*'
       - 'tests/**'
       - codecov.yml
   pull_request:
     branches:
-      - master
+      - main
 
 name: test-coverage
 


### PR DESCRIPTION
this would fix #1245 . I open this as a suggestion but of course i understand the tradeoffs (see last paragraph). 

From the issue description:

This issue is inspired by my own experience using usethis' github actions in [newsanchor](https://github.com/CorrelAid/newsanchor) and [pocketapi](https://github.com/CorrelAid/pocketapi) and [this tweet](https://twitter.com/coolbutuseless/status/1314465384276389888?s=20) by @coolbutuseless. 

New GitHub repos are now using `main` as default branch by default, see [here](https://github.com/github/renaming) unless a different default branch is set in user / organization settings. Hence, more and more repositories will have main as default branch. For those repos, the github actions provided via `usethis` do not work out of the box and have to be adapted (for example, see [this commit](https://github.com/CorrelAid/newsanchor/commit/cab71fea43d769071714b8edf924a95705df954a)). 

I understand that there is a trade-off between supporting existing repositories still running on `master` with default branch. However, given that the R community is not afraid to adapt / move forward and that in the future, a lot more `main` repos will be there because of GitHub's new defaults, I think there is definitely a case to change the defaults in `usethis` GitHub actions as well. :) 