### PR TITLE
Transfer cfg object in check_ours_or_fork()

### DIFF
--- a/R/utils-github.R
+++ b/R/utils-github.R
@@ -630,8 +630,8 @@ check_ours_or_fork <- function(cfg = NULL) {
   if (cfg$type %in% c("ours", "fork")) {
     return(invisible(cfg))
   }
-  check_for_bad_config()
-  check_for_maybe_config()
+  check_for_bad_config(cfg)
+  check_for_maybe_config(cfg)
   ui_stop("
     Internal error: Unexpected GitHub remote configuration: {ui_value(cfg$type)}")
 }


### PR DESCRIPTION
cfg is a required argument in both check_for_bad_config()and check_for_maybe_config(). Not transferring into these creates a bug that keeps emitting error.