### PR TITLE
Update `version.c` in `use_dev_version()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -147,6 +147,9 @@ The legacy `"devtools.desc"` option is no longer consulted when populating a new
 `use_testthat()` gains an edition argument to support testthat v3.0.0 
   (#1185)
 
+`use_version()` now updates `src/version.c` if it exists and if it
+contains a line matching `pkg_version = "x.x.x";`.
+
 usethis has been re-licensed as MIT (#1252, #1253).  
   
 ## Dependency changes

--- a/NEWS.md
+++ b/NEWS.md
@@ -147,8 +147,7 @@ The legacy `"devtools.desc"` option is no longer consulted when populating a new
 `use_testthat()` gains an edition argument to support testthat v3.0.0 
   (#1185)
 
-`use_version()` now updates `src/version.c` if it exists and if it
-contains a line matching `pkg_version = "x.x.x";`.
+`use_version()` now updates `src/version.c` if it exists and contains a line matching `PKG_version = "x.y.z";`.
 
 usethis has been re-licensed as MIT (#1252, #1253).  
   

--- a/R/version.R
+++ b/R/version.R
@@ -2,7 +2,8 @@
 #'
 #' @description `use_version()` increments the "Version" field in `DESCRIPTION`,
 #'   adds a new heading to `NEWS.md` (if it exists), and commits those changes
-#'   (if package uses Git).
+#'   (if package uses Git). It makes the same update to a line like `PKG_version
+#'   = "x.y.z";` in `src/version.c` (if it exists).
 #'
 #' @description `use_dev_version()` increments to a development version, e.g.
 #'   from 1.0.0 to 1.0.0.9000. If the existing version is already a development
@@ -114,6 +115,10 @@ use_c_version <- function(ver) {
   if (!file_exists(version_path)) {
     return()
   }
+
+  hint <- glue("{project_name()}_version")
+  ui_done("
+    Setting {ui_field(hint)} to {ui_value(ver)} in {ui_path(version_path)}")
 
   lines <- read_utf8(version_path)
 

--- a/R/version.R
+++ b/R/version.R
@@ -111,7 +111,7 @@ bump_ <- function(x, ver) {
 use_c_version <- function(ver) {
   version_path <- proj_path("src", "version.c")
 
-  if (!file.exists(version_path)) {
+  if (!file_exists(version_path)) {
     return()
   }
 

--- a/R/version.R
+++ b/R/version.R
@@ -53,10 +53,12 @@ use_version <- function(which = NULL) {
     use_news_heading(new_ver)
   }
 
+  use_c_version(new_ver)
+
   git_ask_commit(
     "Increment version number",
     untracked = TRUE,
-    paths = c("DESCRIPTION", "NEWS.md")
+    paths = c("DESCRIPTION", "NEWS.md", path("src", "version.c"))
   )
   invisible(TRUE)
 }
@@ -104,4 +106,19 @@ bump_version <- function(ver) {
 bump_ <- function(x, ver) {
   d <- desc::desc(text = paste0("Version: ", ver))
   suppressMessages(d$bump_version(x)$get("Version")[[1]])
+}
+
+use_c_version <- function(ver) {
+  version_path <- proj_path("src", "version.c")
+
+  if (!file.exists(version_path)) {
+    return()
+  }
+
+  lines <- read_utf8(version_path)
+
+  re <- glue("(^.*{project_name()}_version = \")([0-9.]+)(\";$)")
+  lines <- gsub(re, glue("\\1{ver}\\3"), lines)
+
+  write_utf8(version_path, lines)
 }

--- a/man/use_version.Rd
+++ b/man/use_version.Rd
@@ -16,7 +16,7 @@ use_dev_version()
 \description{
 \code{use_version()} increments the "Version" field in \code{DESCRIPTION},
 adds a new heading to \code{NEWS.md} (if it exists), and commits those changes
-(if package uses Git).
+(if package uses Git). It makes the same update to a line like \code{PKG_version = "x.y.z";} in \code{src/version.c} (if it exists).
 
 \code{use_dev_version()} increments to a development version, e.g.
 from 1.0.0 to 1.0.0.9000. If the existing version is already a development

--- a/tests/testthat/test-version.R
+++ b/tests/testthat/test-version.R
@@ -72,3 +72,26 @@ test_that("use_version() updates (development version) directly", {
     "0[.]0[.]1"
   )
 })
+
+test_that("use_version() updates version.c", {
+  create_local_package()
+  use_description_field(name = "Version", value = "1.0.0", overwrite = TRUE)
+
+  name <- project_name()
+  src_path <- path(proj_path(), "src")
+  ver_path <- path(src_path, "version.c")
+
+  dir_create(src_path)
+  file_create(ver_path)
+
+  write_utf8(ver_path, glue("
+foo;
+const char {name}_version = \"1.0.0\";
+bar;
+"))
+
+  use_dev_version()
+
+  lines <- read_utf8(ver_path)
+  expect_true(grepl("1.0.0.9000", lines, fixed = TRUE)[[2]])
+})

--- a/tests/testthat/test-version.R
+++ b/tests/testthat/test-version.R
@@ -78,17 +78,14 @@ test_that("use_version() updates version.c", {
   use_description_field(name = "Version", value = "1.0.0", overwrite = TRUE)
 
   name <- project_name()
-  src_path <- path(proj_path(), "src")
+  src_path <- proj_path("src")
   ver_path <- path(src_path, "version.c")
-
   dir_create(src_path)
-  file_create(ver_path)
 
-  write_utf8(ver_path, glue("
-foo;
-const char {name}_version = \"1.0.0\";
-bar;
-"))
+  write_utf8(ver_path, glue('
+    foo;
+    const char {name}_version = "1.0.0";
+    bar;'))
 
   use_dev_version()
 


### PR DESCRIPTION
With this change, we check for existence of a src/version.c file with a line that matches `package_version = "VERSION"`. If there is a match, it is updated to the new version.

This is useful for projects like rlang or vctrs which check at load time that the version stored in the dynlib corresponds to the installed version. https://github.com/r-lib/rlang/blob/v0.4.9/src/version.c