### PR TITLE
Add leading newline before news header

### DIFF
--- a/R/news.R
+++ b/R/news.R
@@ -39,5 +39,5 @@ use_news_heading <- function(version) {
   }
 
   ui_done("Adding new heading to NEWS.md")
-  write_utf8(news_path, c(title, "", news))
+  write_utf8(news_path, c("", title, "", news))
 }

--- a/tests/testthat/test-version.R
+++ b/tests/testthat/test-version.R
@@ -30,10 +30,10 @@ test_that("use_version() increments version in DESCRIPTION, edits NEWS", {
     as.character(desc::desc_get_version(proj_get())),
     "2.0.0"
   )
-  expect_match(
-    read_utf8(proj_path("NEWS.md"), n = 1),
-    "2.0.0"
-  )
+
+  news <- read_utf8(proj_path("NEWS.md"), n = 2)
+  expect_equal(news[[1]], "")
+  expect_match(news[[2]], "2.0.0")
 })
 
 test_that("use_dev_version() appends .9000 to Version, exactly once", {
@@ -62,13 +62,8 @@ test_that("use_version() updates (development version) directly", {
   # directly overwrite development header
   use_version("patch")
 
-  expect_match(
-    read_utf8(proj_path("NEWS.md"), n = 1),
-    "0[.]0[.]2"
-  )
-
-  expect_match(
-    read_utf8(proj_path("NEWS.md"), n = 3)[3],
-    "0[.]0[.]1"
-  )
+  news <- read_utf8(proj_path("NEWS.md"), n = 10)
+  news <- Filter(nzchar, news)
+  expect_match(news[[1]], "0[.]0[.]2")
+  expect_match(news[[3]], "0[.]0[.]1")
 })


### PR DESCRIPTION
Having the news header in the first line feels a bit wrong to me. It seems at least some style guides recommend spacing around headers, e.g. https://google.github.io/styleguide/docguide/style.html