### PR TITLE
fix typo in documentation

### DIFF
--- a/R/course.R
+++ b/R/course.R
@@ -12,7 +12,7 @@
 #'   of typos in live settings, these shorter forms are accepted:
 #'
 #'     * GitHub repo spec: "OWNER/REPO". Equivalent to
-#'       `https://github.com/r-lib/OWNER/REPO/DEFAULT_BRANCH.zip`.
+#'       `https://github.com/OWNER/REPO/DEFAULT_BRANCH.zip`.
 #'     * bit.ly or rstd.io shortlinks: "bit.ly/xxx-yyy-zzz" or "rstd.io/foofy".
 #'       The instructor must then arrange for the shortlink to point to a valid
 #'       download URL for the target ZIP file. The helper

--- a/man/zip-utils.Rd
+++ b/man/zip-utils.Rd
@@ -17,7 +17,7 @@ use_zip(
 \arguments{
 \item{url}{Link to a ZIP file containing the materials. To reduce the chance
 of typos in live settings, these shorter forms are accepted:\preformatted{* GitHub repo spec: "OWNER/REPO". Equivalent to
-  `https://github.com/r-lib/OWNER/REPO/DEFAULT_BRANCH.zip`.
+  `https://github.com/OWNER/REPO/DEFAULT_BRANCH.zip`.
 * bit.ly or rstd.io shortlinks: "bit.ly/xxx-yyy-zzz" or "rstd.io/foofy".
   The instructor must then arrange for the shortlink to point to a valid
   download URL for the target ZIP file. The helper


### PR DESCRIPTION
/document

(I don't know if I have the authority to run the "document" action, we'll see)

Narrator: He did not have the authority.