### PR TITLE
apply host_hint/code_hint to create_github_token()

### DIFF
--- a/R/github_token.R
+++ b/R/github_token.R
@@ -63,8 +63,11 @@ create_github_token <- function(scopes = c("repo", "user", "gist", "workflow"),
   )
   withr::defer(view_url(url))
 
+  host_hint <- if (is_github_dot_com(host)) "" else glue("\"{host}\"")
+  code_hint <- glue("gitcreds::gitcreds_set({host_hint})")
+
   ui_todo("
-    Call {ui_code('gitcreds::gitcreds_set()')} to register this token in the \\
+    Call {ui_code(code_hint)} to register this token in the \\
     local Git credential store
     It is also a great idea to store this token in any password-management \\
     software that you use")

--- a/R/github_token.R
+++ b/R/github_token.R
@@ -65,7 +65,6 @@ create_github_token <- function(scopes = c("repo", "user", "gist", "workflow"),
 
   host_hint <- if (is_github_dot_com(host)) "" else glue("\"{host}\"")
   code_hint <- glue("gitcreds::gitcreds_set({host_hint})")
-
   ui_todo("
     Call {ui_code(code_hint)} to register this token in the \\
     local Git credential store


### PR DESCRIPTION
Brings host-specific feedback to `create_github_token()`.

This is very similar to #1291 - I waffled on attaching this change to that PR. 