### PR TITLE
Fix hint of pr_sync() to include pr_push()

### DIFF
--- a/R/usethis-defunct.R
+++ b/R/usethis-defunct.R
@@ -33,7 +33,7 @@ pr_sync <- function() {
     Sync a PR with:
       * {ui_code('pr_pull()')}
       * {ui_code('pr_merge_main()')}
-      * {ui_code('pr_pull()')}")
+      * {ui_code('pr_push()')}")
   lifecycle::deprecate_stop(
     when = "2.0.0",
     what = "pr_sync()",


### PR DESCRIPTION
Closes #1297 

``` r
usethis::pr_sync()
#> Error: `pr_sync()` was deprecated in usethis 2.0.0 and is now defunct.
#> Sync a PR with:
#>   * `pr_pull()`
#>   * `pr_merge_main()`
#>   * `pr_push()`
```

<sup>Created on 2020-12-02 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>