### PR TITLE
Don't import lifecycle package in `use_lifecycle()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -359,6 +359,10 @@ Patch release to align some path handling internals with an update coming in the
   put a new folder created by `use_course()` or `create_from_github()`
   (@malcolmbarrett, #1015).
 
+* `use_lifecycle()` no longer adds the lifecycle package to the DESCRIPTION
+  file. With the new roxygen markdown syntax for including badges, lifecycle has
+  become a build-time dependency.
+
 ## Dependency changes
 
 New Imports: cli, rematch2, rlang.

--- a/R/lifecycle.R
+++ b/R/lifecycle.R
@@ -2,9 +2,9 @@
 #'
 #' @description
 #'
-#' Call this to copy the lifecycle badges into your package (`man/figures`) and
-#' remind you of the syntax to use them in the documentation of individual
-#' functions or arguments.
+#' This helper imports the lifecycle badges in the `man/figures`
+#' folder of your package. It also reminds you of the syntax to use
+#' them in the documentation of individual functions or arguments.
 #'
 #' See the [getting started
 #' vignette](https://lifecycle.r-lib.org/articles/lifecycle.html) of the
@@ -21,10 +21,6 @@ use_lifecycle <- function() {
     ui_stop("
       Turn on roxygen2 markdown support {ui_code('use_roxygen_md()')}")
   }
-
-  use_dependency("lifecycle", "imports")
-  # silence R CMD check NOTE
-  roxygen_ns_append("@importFrom lifecycle deprecate_soft")
 
   dest_dir <- proj_path("man", "figures")
   create_directory(dest_dir)
@@ -46,6 +42,11 @@ use_lifecycle <- function() {
     "- `r lifecycle::badge('deprecated')`",
     "- `r lifecycle::badge('defunct')`",
     "- `r lifecycle::badge('archived')`"
+  ))
+
+  ui_todo(c(
+    "If you want to use functions like `lifecycle::deprecate_soft()` in your package:",
+    "- `usethis::use_depency(\"lifecycle\", \"import\")`"
   ))
 
   invisible(TRUE)

--- a/R/lifecycle.R
+++ b/R/lifecycle.R
@@ -38,7 +38,6 @@ use_lifecycle <- function() {
     "- `r lifecycle::badge('stable')`",
     "- `r lifecycle::badge('superseded')`",
     "- `r lifecycle::badge('questioning')`",
-    "- `r lifecycle::badge('soft-deprecated')`",
     "- `r lifecycle::badge('deprecated')`",
     "- `r lifecycle::badge('defunct')`",
     "- `r lifecycle::badge('archived')`"

--- a/R/lifecycle.R
+++ b/R/lifecycle.R
@@ -2,7 +2,7 @@
 #'
 #' @description
 #'
-#' This helper imports the lifecycle badges in the `man/figures`
+#' This helper copies the lifecycle badges in to the `man/figures`
 #' folder of your package. It also reminds you of the syntax to use
 #' them in the documentation of individual functions or arguments.
 #'
@@ -46,7 +46,7 @@ use_lifecycle <- function() {
 
   ui_todo(c(
     "If you want to use functions like `lifecycle::deprecate_soft()` in your package:",
-    "- `usethis::use_depency(\"lifecycle\", \"import\")`"
+    "- `usethis::use_package(\"lifecycle\")`"
   ))
 
   invisible(TRUE)

--- a/man/use_lifecycle.Rd
+++ b/man/use_lifecycle.Rd
@@ -7,7 +7,7 @@
 use_lifecycle()
 }
 \description{
-This helper imports the lifecycle badges in the \code{man/figures}
+This helper copies the lifecycle badges in to the \code{man/figures}
 folder of your package. It also reminds you of the syntax to use
 them in the documentation of individual functions or arguments.
 

--- a/man/use_lifecycle.Rd
+++ b/man/use_lifecycle.Rd
@@ -7,9 +7,9 @@
 use_lifecycle()
 }
 \description{
-Call this to copy the lifecycle badges into your package (\code{man/figures}) and
-remind you of the syntax to use them in the documentation of individual
-functions or arguments.
+This helper imports the lifecycle badges in the \code{man/figures}
+folder of your package. It also reminds you of the syntax to use
+them in the documentation of individual functions or arguments.
 
 See the \href{https://lifecycle.r-lib.org/articles/lifecycle.html}{getting started vignette} of the
 lifecycle package.


### PR DESCRIPTION
The main purpose of this function is to import badges in `man/figures` and using lifecycle badges only requires a build time dependency.

Instead, we suggest using `usethis::use_dependency()` in case lifecycle functions are needed.