### PR TITLE
Correct menu title for blog post v2.0

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -29,7 +29,7 @@ navbar:
   - text: News
     menu:
     - text: "Blog posts"
-    - text: "usethis 1.6.0"
+    - text: "usethis 2.0.0"
       href: https://www.tidyverse.org/blog/2020/12/usethis-2-0-0/
     - text: "usethis 1.6.0"
       href: https://www.tidyverse.org/blog/2020/04/usethis-1-6-0/


### PR DESCRIPTION
Fix a small typo in the menu about News. 