### PR TITLE
Eliminate project_data()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # usethis (development version)
 
+`use_readme_rmd()`, `use_readme_md()`, `use_tidy_contributing()`, and `use_tidy_support()` use updated logic for determining the `OWNER/REPO` spec of the target repo (#1312).
+
 # usethis 2.0.0
 
 ## Adoption of gert and changes to Git/GitHub credential handling

--- a/R/browse.R
+++ b/R/browse.R
@@ -60,7 +60,7 @@ NULL
 browse_package <- function(package = NULL) {
   stopifnot(is.null(package) || is_string(package))
   if (is.null(package)) {
-    check_for_project()
+    check_is_project()
   }
 
   urls <- character()
@@ -170,7 +170,7 @@ github_url <- function(package = NULL) {
   stopifnot(is.null(package) || is_string(package))
 
   if (is.null(package)) {
-    check_for_project()
+    check_is_project()
     url <- github_url_from_git_remotes()
     if (!is.null(url)) {
       return(url)
@@ -263,12 +263,4 @@ desc_urls <- function(package = NULL, include_cran = FALSE, desc = NULL) {
   # TODO: could have a more sophisticated understanding of GitHub deployments
   dat$is_github <- !is.na(dat$.match) & grepl("github", dat$host)
   dat[c("url", "desc_field", "is_github")]
-}
-
-check_for_project <- function() {
-  if (!possibly_in_proj()) {
-    ui_stop("
-      We do not appear to be inside a valid project or package
-      No way to discover URLs")
-  }
 }

--- a/R/github.R
+++ b/R/github.R
@@ -90,7 +90,7 @@ use_github <- function(organisation = NULL,
   repo_name <- project_name()
   check_no_github_repo(owner, repo_name, host)
 
-  repo_desc <- project_data()$Title %||% ""
+  repo_desc <- if (is_package()) package_data()$Title %||% "" else ""
   repo_desc <- gsub("\n", " ", repo_desc)
   repo_spec <- glue("{owner}/{repo_name}")
 

--- a/R/proj.R
+++ b/R/proj.R
@@ -210,6 +210,14 @@ check_is_package <- function(whos_asking = NULL) {
   ui_stop(message)
 }
 
+check_is_project <- function() {
+  if (!possibly_in_proj()) {
+    ui_stop("
+      We do not appear to be inside a valid project or package
+      Read more in the help for {ui_code(\"proj_get()\")}")
+  }
+}
+
 proj_active <- function() !is.null(proj_get_())
 
 is_in_proj <- function(path) {

--- a/R/proj.R
+++ b/R/proj.R
@@ -231,27 +231,6 @@ is_in_proj <- function(path) {
   )
 }
 
-project_data <- function(base_path = proj_get()) {
-  if (!possibly_in_proj(base_path)) {
-    ui_stop(c(
-      "{ui_path(base_path)} doesn't meet the usethis criteria for a project.",
-      "Read more in the help for {ui_code(\"proj_get()\")}."
-    ))
-  }
-  if (is_package(base_path)) {
-    data <- package_data(base_path)
-  } else {
-    data <- list(Project = path_file(base_path))
-  }
-  if (proj_active() && origin_is_on_github()) {
-    origin <- github_remote_list("origin")
-    data$github_owner <- origin$repo_owner
-    data$github_repo  <- origin$repo_name
-    data$github_spec  <- glue("{origin$repo_owner}/{origin$repo_name}")
-  }
-  data
-}
-
 package_data <- function(base_path = proj_get()) {
   desc <- desc::description$new(base_path)
   as.list(desc$get(desc$fields()))

--- a/R/proj.R
+++ b/R/proj.R
@@ -259,9 +259,9 @@ project_name <- function(base_path = proj_get()) {
   }
 
   if (is_package(base_path)) {
-    project_data(base_path)$Package
+    package_data(base_path)$Package
   } else {
-    project_data(base_path)$Project
+    path_file(base_path)
   }
 }
 

--- a/R/readme.R
+++ b/R/readme.R
@@ -76,8 +76,8 @@ use_readme_md <- function(open = rlang::is_interactive()) {
   )
   use_template(
     if (is_pkg) "package-README" else "project-README",
-      "README.md",
-      data = data,
-      open = open
+    "README.md",
+    data = data,
+    open = open
   )
 }

--- a/R/readme.R
+++ b/R/readme.R
@@ -28,17 +28,24 @@
 #' use_readme_md()
 #' }
 use_readme_rmd <- function(open = rlang::is_interactive()) {
+  check_is_project()
   check_installed("rmarkdown")
 
-  data <- project_data()
-  data$Rmd <- TRUE
-  data$on_github <- origin_is_on_github()
+  is_pkg <- is_package()
+  repo_spec <- tryCatch(target_repo_spec(ask = FALSE), error = function(e) NULL)
+  nm <- if (is_pkg) "Package" else "Project"
+  data <- list2(
+    !!nm := project_name(),
+    Rmd = TRUE,
+    on_github = !is.null(repo_spec),
+    github_spec = repo_spec
+  )
 
   new <- use_template(
-    if (is_package()) "package-README" else "project-README",
+    if (is_pkg) "package-README" else "project-README",
     "README.Rmd",
     data = data,
-    ignore = is_package(),
+    ignore = is_pkg,
     open = open
   )
   if (!new) {
@@ -58,10 +65,19 @@ use_readme_rmd <- function(open = rlang::is_interactive()) {
 #' @export
 #' @rdname use_readme_rmd
 use_readme_md <- function(open = rlang::is_interactive()) {
+  check_is_project()
+  is_pkg <- is_package()
+  nm <- if (is_pkg) "Package" else "Project"
+  data <- list2(
+    !!nm := project_name(),
+    Rmd = FALSE,
+    on_github = NULL,
+    github_spec = NULL
+  )
   use_template(
-    if (is_package()) "package-README" else "project-README",
-    "README.md",
-    data = project_data(),
-    open = open
+    if (is_pkg) "package-README" else "project-README",
+      "README.md",
+      data = data,
+      open = open
   )
 }

--- a/R/tidyverse.R
+++ b/R/tidyverse.R
@@ -117,10 +117,14 @@ use_tidy_eval <- function() {
 #' @rdname tidyverse
 use_tidy_contributing <- function() {
   use_dot_github()
+  data <- list(
+    Package = project_name(),
+    github_spec = target_repo_spec(ask = FALSE)
+  )
   use_template(
     "tidy-contributing.md",
     path(".github", "CONTRIBUTING.md"),
-    data = project_data()
+    data = data
   )
 }
 
@@ -128,10 +132,14 @@ use_tidy_contributing <- function() {
 #' @rdname tidyverse
 use_tidy_support <- function() {
   use_dot_github()
+  data <- list(
+    Package = project_name(),
+    github_spec = target_repo_spec(ask = FALSE)
+  )
   use_template(
     "tidy-support.md",
     path(".github", "SUPPORT.md"),
-    data = project_data()
+    data = data
   )
 }
 

--- a/R/tutorial.R
+++ b/R/tutorial.R
@@ -34,14 +34,10 @@ use_tutorial <- function(name, title, open = rlang::is_interactive()) {
   use_dependency("learnr", "Suggests")
 
   path <- path(dir_path, asciify(name), ext = "Rmd")
-
-  data <- project_data()
-  data$tutorial_title <- title
-
   new <- use_template(
     "tutorial-template.Rmd",
     save_as = path,
-    data = data,
+    data = list(tutorial_title = title),
     ignore = FALSE,
     open = open
   )

--- a/R/utils-github.R
+++ b/R/utils-github.R
@@ -134,13 +134,6 @@ github_remote_list <- function(these = c("origin", "upstream"), x = NULL) {
   )]
 }
 
-origin_is_on_github <- function() {
-  if (!uses_git()) {
-    return(FALSE)
-  }
-  nrow(github_remote_list("origin")) > 0
-}
-
 #' Gather LOCAL and (maybe) REMOTE data on GitHub-associated remotes
 #'
 #' Creates a data frame where each row represents a GitHub-associated remote,

--- a/R/vignette.R
+++ b/R/vignette.R
@@ -54,9 +54,11 @@ use_vignette_template <- function(template, name, title) {
 
   path <- path("vignettes", asciify(name), ext = "Rmd")
 
-  data <- project_data()
-  data$vignette_title <- title
-  data$braced_vignette_title <- glue("{{{title}}}")
+  data <- list(
+    Package = project_name(),
+    vignette_title = title,
+    braced_vignette_title = glue("{{{title}}}")
+  )
 
   use_template(template,
     save_as = path,

--- a/tests/testthat/test-tidyverse.R
+++ b/tests/testthat/test-tidyverse.R
@@ -20,10 +20,17 @@ test_that("use_tidy_eval() inserts the template file and Imports rlang", {
 })
 
 test_that("use_tidy_GITHUB-STUFF() adds and Rbuildignores files", {
+  local_interactive(FALSE)
   create_local_package()
-  use_tidy_contributing()
+  use_git()
+
+  with_mock(
+    target_repo_spec = function(...) "OWNER/REPO", {
+      use_tidy_contributing()
+      use_tidy_support()
+    }
+  )
   use_tidy_issue_template()
-  use_tidy_support()
   use_tidy_coc()
   expect_proj_file(".github/CONTRIBUTING.md")
   expect_proj_file(".github/ISSUE_TEMPLATE/issue_template.md")
@@ -33,8 +40,14 @@ test_that("use_tidy_GITHUB-STUFF() adds and Rbuildignores files", {
 })
 
 test_that("use_tidy_github() adds and Rbuildignores files", {
+  local_interactive(FALSE)
   create_local_package()
-  use_tidy_github()
+  use_git()
+
+  with_mock(
+    target_repo_spec = function(...) "OWNER/REPO",
+    use_tidy_github()
+  )
   expect_proj_file(".github/CONTRIBUTING.md")
   expect_proj_file(".github/ISSUE_TEMPLATE/issue_template.md")
   expect_proj_file(".github/SUPPORT.md")


### PR DESCRIPTION
`project_data()` and related functions contain some outdated logic that `origin` is always the target remote. This function can actually be eliminated.

Closes #1312