### PR TITLE
Fixes choose_branch() when one branch is not shown

### DIFF
--- a/R/pr.R
+++ b/R/pr.R
@@ -808,7 +808,7 @@ choose_branch <- function() {
     branches_not_shown <- utils::tail(dat$name, -9)
     n <- length(branches_not_shown)
     dat <- dat[1:9, ]
-    pre <- glue("{n} branch{if (n > 1) 'es'} not listed: ")
+    pre <- glue("{n} branch{if (n > 1) 'es' else ''} not listed: ")
     listing <- glue_collapse(
       branches_not_shown, sep = ", ", width = getOption("width") - nchar(pre)
     )


### PR DESCRIPTION
Fixes a small issue in a `glue()` string caused by a `NULL` value when 1 branch is not listed that creates a length-0 character, which eventually causes an error.

``` r
library(glue)

# Current
n <- 1
pre <- glue("{n} branch{if (n > 1) 'es'} not listed: ")
nchar(pre)
#> integer(0)
# later in glue()...
if (nchar(pre) < Inf) "go ahead and glue..."
#> Error in if (nchar(pre) < Inf) "go ahead and glue...": argument is of length zero

# New
n <- 1
pre <- glue("{n} branch{if (n > 1) 'es' else ''} not listed: ")
nchar(pre)
#> [1] 21
if (nchar(pre) < Inf) "go ahead and glue..."
#> [1] "go ahead and glue..."
```
