### PR TITLE
Improve `use_release_issue()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 `use_readme_rmd()`, `use_readme_md()`, `use_tidy_contributing()`, and `use_tidy_support()` use updated logic for determining the `OWNER/REPO` spec of the target repo (#1312).
 
+`use_release_issue()` now allows you to specify the current release and, if so, does not instruct you to `use_version()` in the resulting checklist (@malcolmbarrett, #1324)
+
 # usethis 2.0.0
 
 ## Adoption of gert and changes to Git/GitHub credential handling

--- a/R/release.R
+++ b/R/release.R
@@ -25,7 +25,7 @@ use_release_issue <- function(version = NULL) {
     }
   }
 
-  version <- version %||% choose_version()
+  version <- version %||% choose_version(use_current = TRUE)
   if (is.null(version)) {
     return(invisible(FALSE))
   }

--- a/R/release.R
+++ b/R/release.R
@@ -25,7 +25,7 @@ use_release_issue <- function(version = NULL) {
     }
   }
 
-  version <- version %||% choose_version(use_current = TRUE)
+  version <- version %||% choose_version(allow_current = TRUE)
   if (is.null(version)) {
     return(invisible(FALSE))
   }

--- a/R/release.R
+++ b/R/release.R
@@ -43,8 +43,13 @@ use_release_issue <- function(version = NULL) {
   view_url(issue$html_url)
 }
 
-release_checklist <- function(version, on_cran) {
-  type <- release_type(version)
+release_checklist <- function(release_version, on_cran) {
+  type <- release_type(release_version)
+  current_version <- desc::desc_get_version(proj_get())
+  is_same_version <- identical(
+    unname(release_version),
+    as.character(current_version)
+  )
   cran_results <- cran_results_url()
   has_src <- dir_exists(proj_path("src"))
   has_news <- file_exists(proj_path("NEWS.md"))
@@ -81,7 +86,7 @@ release_checklist <- function(version, on_cran) {
     "",
     "Submit to CRAN:",
     "",
-    todo("`usethis::use_version('{type}')`"),
+    todo("`usethis::use_version('{type}')`", !is_same_version),
     todo("`devtools::submit_cran()`"),
     todo("Approve email"),
     "",

--- a/R/version.R
+++ b/R/version.R
@@ -75,11 +75,11 @@ use_dev_version <- function() {
   use_version(which = "dev")
 }
 
-choose_version <- function(which = NULL) {
+choose_version <- function(which = NULL, use_current = FALSE) {
   ver <- desc::desc_get_version(proj_get())
   versions <- c(
     bump_version(ver),
-    "current" = as.character(ver)
+    "current" = if (use_current) as.character(ver)
   )
 
   if (is.null(which)) {
@@ -99,7 +99,10 @@ choose_version <- function(which = NULL) {
     }
   }
 
-  which <- match.arg(which, c("major", "minor", "patch", "dev", "current"))
+  which <- match.arg(
+    which,
+    c("major", "minor", "patch", "dev", if (use_current) "current")
+  )
   versions[which]
 }
 

--- a/R/version.R
+++ b/R/version.R
@@ -78,8 +78,8 @@ use_dev_version <- function() {
 choose_version <- function(which = NULL, use_current = FALSE) {
   ver <- desc::desc_get_version(proj_get())
   versions <- c(
-    bump_version(ver),
-    "current" = if (use_current) as.character(ver)
+    "current" = if (use_current) as.character(ver),
+    bump_version(ver)
   )
 
   if (is.null(which)) {

--- a/R/version.R
+++ b/R/version.R
@@ -75,10 +75,10 @@ use_dev_version <- function() {
   use_version(which = "dev")
 }
 
-choose_version <- function(which = NULL, use_current = FALSE) {
+choose_version <- function(which = NULL, allow_current = FALSE) {
   ver <- desc::desc_get_version(proj_get())
   versions <- c(
-    "current" = if (use_current) as.character(ver),
+    "current" = if (allow_current) as.character(ver),
     bump_version(ver)
   )
 
@@ -101,7 +101,7 @@ choose_version <- function(which = NULL, use_current = FALSE) {
 
   which <- match.arg(
     which,
-    c("major", "minor", "patch", "dev", if (use_current) "current")
+    c("major", "minor", "patch", "dev", if (allow_current) "current")
   )
   versions[which]
 }

--- a/R/version.R
+++ b/R/version.R
@@ -77,7 +77,10 @@ use_dev_version <- function() {
 
 choose_version <- function(which = NULL) {
   ver <- desc::desc_get_version(proj_get())
-  versions <- bump_version(ver)
+  versions <- c(
+    bump_version(ver),
+    "current" = as.character(ver)
+  )
 
   if (is.null(which)) {
     choice <- utils::menu(
@@ -85,7 +88,8 @@ choose_version <- function(which = NULL) {
         "{format(names(versions), justify = 'right')} --> {versions}"
       ),
       title = glue(
-        "Current version is {ver}.\n", "Which part to increment? (0 to exit)"
+        "Current version is {ver}.\n",
+        "What should the release version be? (0 to exit)"
       )
     )
     if (choice == 0) {
@@ -95,7 +99,7 @@ choose_version <- function(which = NULL) {
     }
   }
 
-  which <- match.arg(which, c("major", "minor", "patch", "dev"))
+  which <- match.arg(which, c("major", "minor", "patch", "dev", "current"))
   versions[which]
 }
 

--- a/tests/testthat/_snaps/release.md
+++ b/tests/testthat/_snaps/release.md
@@ -94,3 +94,35 @@
       * [ ] Tweet
       * [ ] Add link to blog post in pkgdown news menu
 
+---
+
+    Code
+      cat(release_checklist("0.1.0", on_cran = TRUE), sep = "\n")
+    Output
+      Prepare for release:
+      
+      * [ ] Check [current CRAN check results](https://cran.rstudio.org/web/checks/check_results_releasebullets.html)
+      * [ ] `devtools::check(remote = TRUE, manual = TRUE)`
+      * [ ] `devtools::check_win_devel()`
+      * [ ] `rhub::check_for_cran()`
+      * [ ] `revdepcheck::revdep_check(num_workers = 4)`
+      * [ ] `urlchecker::url_check()`
+      * [ ] Update `cran-comments.md`
+      * [ ] [Polish NEWS](https://style.tidyverse.org/news.html#news-release)
+      * [ ] Draft blog post
+      
+      Submit to CRAN:
+      
+      * [ ] `devtools::submit_cran()`
+      * [ ] Approve email
+      
+      Wait for CRAN...
+      
+      * [ ] Accepted :tada:
+      * [ ] `usethis::use_news_md()`
+      * [ ] `usethis::use_github_release()`
+      * [ ] `usethis::use_dev_version()`
+      * [ ] Finish blog post
+      * [ ] Tweet
+      * [ ] Add link to blog post in pkgdown news menu
+

--- a/tests/testthat/test-release.R
+++ b/tests/testthat/test-release.R
@@ -24,6 +24,11 @@ test_that("release bullets don't change accidentally", {
   expect_snapshot(
     cat(release_checklist("1.0.0", on_cran = TRUE), sep = "\n")
   )
+
+  # Release same as current version
+  expect_snapshot(
+    cat(release_checklist(as.character(desc::desc_get_version()), on_cran = TRUE), sep = "\n")
+  )
 })
 
 test_that("get extra news bullets if available", {

--- a/tests/testthat/test-release.R
+++ b/tests/testthat/test-release.R
@@ -9,6 +9,7 @@ test_that("release bullets don't change accidentally", {
   withr::defer(dir_delete(tmpproj))
   file_create(path(tmpproj, ".here"))
   local_project(tmpproj, setwd = FALSE)
+  use_description()
 
   # First release
   expect_snapshot(
@@ -26,8 +27,9 @@ test_that("release bullets don't change accidentally", {
   )
 
   # Release same as current version
+  use_description_field("Version", "0.1.0", overwrite = TRUE)
   expect_snapshot(
-    cat(release_checklist(as.character(desc::desc_get_version()), on_cran = TRUE), sep = "\n")
+    cat(release_checklist("0.1.0", on_cran = TRUE), sep = "\n")
   )
 })
 


### PR DESCRIPTION
I recently had a confusing encounter with `use_release_issue()`. Firstly, I had already used `use_version()` to increment, and the menu option did not provide me a way to say "use the current version". Secondly, the menu prompt made it sounds like `use_release_issue()` was going to increment my version (which it didn't, of course; it just told me to use `use_version()` in the checklist), resulting in me changing my version then changing it back when I realized nothing happened. 

This PR makes a few improvements to the menu encounter and resulting actions:

1. It adds an option to use the current version. This is only a menu option for `use_release_issue()` and not `use_version()`, since the latter doesn't make sense.
2. It clarifies the menu message a bit to ask for what the release version *will* be. 
3. In cases where you already have the release version set, it does not tell you to use `use_version()` in the resulting checklist.
4. Some bookkeeping with the related tests + adding a test for when you are using the same version as the current version.

If you think this PR merits a merge, I'd also be happy to address #1322, if you like, since it's related to this function.