### PR TITLE
Add missing `ui_value()` when referring to protocol

### DIFF
--- a/R/git.R
+++ b/R/git.R
@@ -159,7 +159,7 @@ use_git_config <- function(scope = c("user", "project"), ...) {
 git_protocol <- function() {
   protocol <- tolower(getOption("usethis.protocol", "unset"))
   if (identical(protocol, "unset")) {
-    ui_info("Defaulting to {'https'} Git protocol")
+    ui_info("Defaulting to {ui_value('https')} Git protocol")
     protocol <- "https"
   } else {
     check_protocol(protocol)

--- a/vignettes/articles/pr-functions.Rmd
+++ b/vignettes/articles/pr-functions.Rmd
@@ -79,7 +79,7 @@ create_from_github("rladies/praise")
 ```
 <div class = "output">
 ```{r eval=FALSE}
-#> ℹ Defaulting to https Git protocol
+#> ℹ Defaulting to 'https' Git protocol
 #> ✓ Setting `fork = TRUE`
 #> ✓ Creating '/Users/mine/Desktop/praise/'
 #> ✓ Forking 'rladies/praise'


### PR DESCRIPTION
This little baby PR just adds a missing `ui_value()` when referring to the default protocol and updates the corresponding output in the PR vignette