### PR TITLE
fix use_dependency when already LinkingTo

### DIFF
--- a/R/helpers.R
+++ b/R/helpers.R
@@ -60,6 +60,7 @@ use_dependency <- function(package, type, min_version = NULL) {
 
   existing_type <- setdiff(existing_type, "LinkingTo")
   delta <- sign(match(existing_type, types) - match(type, types))
+  delta <- ifelse(length(delta) == 0, 0, delta)
   if (delta < 0) {
     # don't downgrade
     ui_warn(


### PR DESCRIPTION
This PR is one way to resolve an error that arises when following @jimhester's advice on ["Getting started with cpp11"](https://cpp11.r-lib.org/articles/cpp11.html#using-cpp11-in-a-package), which simply says to add a "LinkingTo" statement. `cpp11` has a few other idiosyncracies in current form, so I sensibly tried `usethis::use_cpp11()` in case I'd missed a file or something. This is the result:

``` r
d <- file.path (tempdir (), "junk")
dir.create (d)
usethis::create_package (path = d, check_name = FALSE)
#> ✔ Writing 'NAMESPACE'
#> ✔ Setting active project to '<no active project>'
desc <- c (readLines (file.path (d, "DESCRIPTION")),
           "LinkingTo: cpp11")
writeLines (desc, file.path (d, "DESCRIPTION"))
setwd (d)
usethis::use_cpp11 ()
#> ✔ Setting active project to '/tmp/RtmpQGi7ct/junk'
#> ✔ Creating 'src/'
#> ✔ Adding '*.o', '*.so', '*.dll' to 'src/.gitignore'
#> ● Copy and paste the following lines into 'R/junk-package.R':
#>   ## usethis namespace: start
#>   #' @useDynLib junk, .registration = TRUE
#>   ## usethis namespace: end
#>   NULL
#> Error in if (delta < 0) {: argument is of length zero
```

<sup>Created on 2021-01-14 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>

Clearly happens because `use_dependency` did not envision a situation where [`setdiff(existing_type, "LinkingTo")`](https://github.com/r-lib/usethis/blob/master/R/helpers.R#L61) returned empty.  `min_version` remains `NULL`, so this change simply ensures that `use_dependency` does nothing in this case, instead of erroring.