### PR TITLE
Clarify `choose_version()` prompt for `use_release_issue()`

### DIFF
--- a/R/release.R
+++ b/R/release.R
@@ -25,7 +25,7 @@ use_release_issue <- function(version = NULL) {
     }
   }
 
-  version <- version %||% choose_version()
+  version <- version %||% choose_version(release = TRUE)
   if (is.null(version)) {
     return(invisible(FALSE))
   }

--- a/R/release.R
+++ b/R/release.R
@@ -25,7 +25,7 @@ use_release_issue <- function(version = NULL) {
     }
   }
 
-  version <- version %||% choose_version(release = TRUE)
+  version <- version %||% choose_version("What should the release version be?")
   if (is.null(version)) {
     return(invisible(FALSE))
   }

--- a/R/version.R
+++ b/R/version.R
@@ -75,17 +75,24 @@ use_dev_version <- function() {
   use_version(which = "dev")
 }
 
-choose_version <- function(which = NULL) {
+choose_version <- function(which = NULL, release = FALSE) {
   ver <- desc::desc_get_version(proj_get())
   versions <- bump_version(ver)
 
   if (is.null(which)) {
+    msg <- if (release) {
+      "What should the release version be?"
+    } else {
+      "Which part to increment?"
+    }
+
     choice <- utils::menu(
       choices = glue(
         "{format(names(versions), justify = 'right')} --> {versions}"
       ),
       title = glue(
-        "Current version is {ver}.\n", "Which part to increment? (0 to exit)"
+        "Current version is {ver}.\n",
+        "{msg} (0 to exit)"
       )
     )
     if (choice == 0) {

--- a/R/version.R
+++ b/R/version.R
@@ -42,7 +42,7 @@ use_version <- function(which = NULL) {
     msg = "There are uncommitted changes and you're about to bump version"
   )
 
-  new_ver <- choose_version(which)
+  new_ver <- choose_version("What should the new version be?", which)
   if (is.null(new_ver)) {
     return(invisible(FALSE))
   }
@@ -75,24 +75,18 @@ use_dev_version <- function() {
   use_version(which = "dev")
 }
 
-choose_version <- function(which = NULL, release = FALSE) {
+choose_version <- function(message, which = NULL) {
   ver <- desc::desc_get_version(proj_get())
   versions <- bump_version(ver)
 
   if (is.null(which)) {
-    msg <- if (release) {
-      "What should the release version be?"
-    } else {
-      "Which part to increment?"
-    }
-
     choice <- utils::menu(
       choices = glue(
         "{format(names(versions), justify = 'right')} --> {versions}"
       ),
       title = glue(
         "Current version is {ver}.\n",
-        "{msg} (0 to exit)"
+        "{message} (0 to exit)"
       )
     )
     if (choice == 0) {


### PR DESCRIPTION
This is a drastically simplified version of #1324. As mentioned there, I was confused by the prompt in `use_release_issue()`, identical to the prompt in `use_version()`, which made it sound like it was going to increment for me then and there.

This PR simply clarifies the message and doesn't touch any of the other issues mentioned in 1324. Unfortunately, I couldn't think of wording that worked for both cases that didn't make it sound like `use_release_issue()` was going to increment then and there, so I had to introduce a few more lines of code than I would have liked for such a simple PR.