### PR TITLE
Change badge URL to ease CRAN submissions

### DIFF
--- a/R/badge.R
+++ b/R/badge.R
@@ -98,7 +98,7 @@ use_lifecycle_badge <- function(stage) {
   colour <- stages[[stage]]
 
   src <- glue("https://img.shields.io/badge/lifecycle-{stage}-{colour}.svg")
-  href <- glue("https://lifecycle.r-lib.org/articles/stages.html#{stage}")
+  href <- "https://lifecycle.r-lib.org/articles/stages.html"
   use_badge(paste0("Lifecycle: ", stage), href, src)
 
   invisible(TRUE)


### PR DESCRIPTION
Hello! For a recent package submission, CRAN requested I change the url "https://www.tidyverse.org/lifecycle/#stable" to "https://lifecycle.r-lib.org/articles/stages.html". If this is common to others, maybe it should be the default?