### PR TITLE
Consult CRAN-RELEASE for release sha

### DIFF
--- a/R/release.R
+++ b/R/release.R
@@ -126,10 +126,15 @@ release_type <- function(version) {
 
 #' Draft a GitHub release
 #'
+#' @description
 #' Creates a __draft__ GitHub release for the current package using the current
 #' version and `NEWS.md`. If you are comfortable that it is correct, you will
-#' need to publish the release from GitHub. It also deletes `CRAN-RELEASE` and
-#' checks that you've pushed all commits to GitHub.
+#' need to publish the release from GitHub.
+#'
+#' When `CRAN-RELEASE` is present (as produced by `devtools::release()` or
+#' `devtools::submit_cran`), the target commit is extracted from there and,
+#' after the draft release is successfully created, `CRAN-RELEASE` is deleted.
+#' Otherwise, the release tag is set to current `HEAD`.
 #'
 #' @param host,auth_token `r lifecycle::badge("deprecated")`: No longer consulted
 #'   now that usethis allows the gh package to lookup a token based on a URL
@@ -150,15 +155,31 @@ use_github_release <- function(host = deprecated(),
       You don't seem to have push access for {ui_value(tr$repo_spec)}, which \\
       is required to draft a release.")
   }
+  gh <- gh_tr(tr)
 
-  challenge_non_default_branch(
-    "Are you sure you want to create a release on a non-default branch?"
-  )
-  check_branch_pushed()
+  package <- package_data()
+  release_name <- glue("{package$Package} {package$Version}")
+  tag_name <- glue("v{package$Version}")
+  kv_line("Release name", release_name)
+  kv_line("Tag name", tag_name)
 
   cran_release <- proj_path("CRAN-RELEASE")
   if (file_exists(cran_release)) {
-    file_delete(cran_release)
+    lines <- read_utf8(cran_release)
+    str_extract <- function(marker, pattern) {
+      re_match(grep(marker, lines, value = TRUE), pattern)$.match
+    }
+    date <- str_extract("submitted.*on", "[0-9]{4}-[0-9]{2}-[0-9]{2}")
+    ui_done("{ui_path('CRAN-RELEASE')} file found, from a submission on {date}")
+    sha7 <- str_extract("commit", "[[:xdigit:]]{7}")
+    kv_line("SHA", sha7)
+    # the release endpoint requires the full sha
+    sha <- gh("/repos/{owner}/{repo}/commits/{commit_sha}", commit_sha = sha7)$sha
+  } else {
+    ui_done("Tagging current HEAD commit for the release")
+    challenge_non_default_branch()
+    check_branch_pushed()
+    sha <- gert::git_info(repo = git_repo())$commit
   }
 
   path <- proj_path("NEWS.md")
@@ -168,16 +189,16 @@ use_github_release <- function(host = deprecated(),
     news <- "Initial release"
   }
 
-  package <- package_data()
-
-  gh <- gh_tr(tr)
   release <- gh(
     "POST /repos/{owner}/{repo}/releases",
-    tag_name = paste0("v", package$Version),
-    target_commitish = gert::git_info(repo = git_repo())$commit,
-    name = paste0(package$Package, " ", package$Version),
-    body = news, draft = TRUE
+    name = release_name, tag_name = tag_name,
+    target_commitish = sha, body = news, draft = TRUE
   )
+
+  if (file_exists(cran_release)) {
+    ui_done("{ui_path('CRAN-RELEASE')} deleted")
+    file_delete(cran_release)
+  }
 
   view_url(release$html_url)
 }

--- a/man/use_github_release.Rd
+++ b/man/use_github_release.Rd
@@ -14,6 +14,10 @@ determined from the current project's GitHub remotes.}
 \description{
 Creates a \strong{draft} GitHub release for the current package using the current
 version and \code{NEWS.md}. If you are comfortable that it is correct, you will
-need to publish the release from GitHub. It also deletes \code{CRAN-RELEASE} and
-checks that you've pushed all commits to GitHub.
+need to publish the release from GitHub.
+
+When \code{CRAN-RELEASE} is present (as produced by \code{devtools::release()} or
+\code{devtools::submit_cran}), the target commit is extracted from there and,
+after the draft release is successfully created, \code{CRAN-RELEASE} is deleted.
+Otherwise, the release tag is set to current \code{HEAD}.
 }


### PR DESCRIPTION
Closes #1380

Here's an example of what this looks like now:

``` r
> proj_set("~/rrr/googlesheets4")
> use_github_release()
● Release name: 'googlesheets4 0.3.0'
● Tag name: 'v0.3.0'
✓ 'CRAN-RELEASE' file found, from a submission on 2021-03-04
● SHA: '4c7589a'
✓ 'CRAN-RELEASE' deleted
✓ Opening URL 'https://github.com/tidyverse/googlesheets4/releases/tag/untagged-e3b94baf12203c4b7024'
```

Happy to refine the messaging / aesthetics. I'm probably TMI at this point but was useful while getting it to work.