### PR TITLE
Update fs linter

### DIFF
--- a/.github/workflows/lint-undesirable-functions.yaml
+++ b/.github/workflows/lint-undesirable-functions.yaml
@@ -74,7 +74,7 @@ jobs:
             "list.dirs",
             "normalizePath",
             "path.expand",
-            "tempdir",
+            "system.file",
             "tempfile",
             "unlink",
             "basename",

--- a/.github/workflows/lint-undesirable-functions.yaml
+++ b/.github/workflows/lint-undesirable-functions.yaml
@@ -75,6 +75,7 @@ jobs:
             "normalizePath",
             "path.expand",
             "system.file",
+            "tempdir",
             "tempfile",
             "unlink",
             "basename",

--- a/tests/testthat/test-addin.R
+++ b/tests/testthat/test-addin.R
@@ -3,7 +3,7 @@ test_that("use_addin() creates the first addins.dcf as promised", {
   use_addin("addin.test")
 
   addin_dcf <- read_utf8(proj_path("inst", "rstudio", "addins.dcf"))
-  expected_file <- system.file("templates", "addins.dcf", package = "usethis")
+  expected_file <- path_package("usethis", "templates", "addins.dcf")
   addin_dcf_expected <- read_utf8(expected_file)
   addin_dcf_expected[3] <- "Binding: addin.test"
   addin_dcf_expected[5] <- ""


### PR DESCRIPTION
In working on https://github.com/r-lib/devtools/pull/2331, I noticed that this linter (which I was using locally) was missing `system.file()`. It also doesn't seem like there is an fs equivalent of `tempdir()` (and fs itself seems to use `tempdir()`). I also updated a test using `system.file()`