### PR TITLE
make git_cfg_get() case insensitive

### DIFF
--- a/R/utils-git.R
+++ b/R/utils-git.R
@@ -60,7 +60,7 @@ git_cfg_get <- function(name, where = c("de_facto", "local", "global")) {
   if (where == "local") {
     dat <- dat[dat$level == "local", ]
   }
-  out <- dat$value[dat$name == name]
+  out <- dat$value[tolower(dat$name) == tolower(name)]
   if (length(out) > 0) out else NULL
 }
 

--- a/tests/testthat/test-git.R
+++ b/tests/testthat/test-git.R
@@ -27,11 +27,14 @@ test_that("use_git_config() can set local config", {
   use_git_config(
     scope = "project",
     user.name = "Jane",
-    user.email = "jane@example.org"
+    user.email = "jane@example.org",
+    init.defaultBranch = "main"
   )
   r <- git_repo()
   expect_identical(git_cfg_get("user.name", "local"), "Jane")
   expect_identical(git_cfg_get("user.email", "local"), "jane@example.org")
+  expect_identical(git_cfg_get("init.defaultBranch", "local"), "main")
+  expect_identical(git_cfg_get("init.defaultbranch", "local"), "main")
 })
 
 test_that("use_git_config() can set a non-existing config field", {


### PR DESCRIPTION
- wrap both keys in `tolower()`
- add expectations to existing test

Fixes #1401