### PR TITLE
Use `path_ext_set()` to modify extension

### DIFF
--- a/R/github-actions.R
+++ b/R/github-actions.R
@@ -136,9 +136,7 @@ use_github_action <- function(name,
     stopifnot(is_string(name))
 
     # Append a `.yaml` extension if needed
-    if (!grepl("[.]yaml$", name)) {
-      name <- paste0(name, ".yaml")
-    }
+    name <- path_ext_set(name, "yaml")
 
     url <- glue(
       "https://raw.githubusercontent.com/r-lib/actions/master/examples/{name}"


### PR DESCRIPTION
I noticed a slight inconsistency in `use_github_action()` that used its own solution to managing extensions rather than fs. This PR updates that bit of code to use `path_ext_set()`. I don't think it needs to use the more surgical `slug()` since it's referring to an r-lib file that follows a predictable pattern