### PR TITLE
Expose `readme` argument in `use_github_action()`

### DIFF
--- a/R/github-actions.R
+++ b/R/github-actions.R
@@ -120,6 +120,8 @@ use_tidy_github_actions <- function() {
 #'   workflow in <https://github.com/r-lib/actions> will be used.
 #' @param save_as Name of the workflow file. Defaults to `fs::path_file(url)`
 #'   for `use_github_action()`.
+#' @param readme The full URL to a `README` file that provides more details
+#'   about the action. Ignored when `url` is `NULL`.
 #'
 #' @seealso [github_actions] for generic workflows and badge generation.
 #'
@@ -128,6 +130,7 @@ use_tidy_github_actions <- function() {
 use_github_action <- function(name,
                               url = NULL,
                               save_as = NULL,
+                              readme = NULL,
                               ignore = TRUE,
                               open = FALSE) {
 
@@ -146,7 +149,6 @@ use_github_action <- function(name,
     readme <- "https://github.com/r-lib/actions/blob/master/examples/README.md"
   } else {
     stopifnot(is_string(url))
-    readme <- NULL
   }
 
   if (is.null(save_as)) {

--- a/man/use_github_action.Rd
+++ b/man/use_github_action.Rd
@@ -12,6 +12,7 @@ use_github_action(
   name,
   url = NULL,
   save_as = NULL,
+  readme = NULL,
   ignore = TRUE,
   open = FALSE
 )
@@ -49,6 +50,9 @@ workflow in \url{https://github.com/r-lib/actions} will be used.}
 
 \item{save_as}{Name of the workflow file. Defaults to \code{fs::path_file(url)}
 for \code{use_github_action()}.}
+
+\item{readme}{The full URL to a \code{README} file that provides more details
+about the action. Ignored when \code{url} is \code{NULL}.}
 
 \item{ignore}{Should the newly created file be added to \code{.Rbuildignore}?}
 

--- a/tests/testthat/_snaps/github-actions.md
+++ b/tests/testthat/_snaps/github-actions.md
@@ -1,0 +1,13 @@
+# use_github_action() allows for custom urls
+
+    Code
+      use_github_action(url = "https://raw.githubusercontent.com/r-lib/actions/master/examples/check-full.yaml",
+        readme = "https://github.com/r-lib/actions/blob/master/examples/README.md")
+    Message <message>
+      v Creating '.github/'
+      v Adding '^\\.github$' to '.Rbuildignore'
+      v Adding '*.html' to '.github/.gitignore'
+      v Creating '.github/workflows/'
+      v Writing '.github/workflows/check-full.yaml'
+      * Learn more at <https://github.com/r-lib/actions/blob/master/examples/README.md>
+

--- a/tests/testthat/test-github-actions.R
+++ b/tests/testthat/test-github-actions.R
@@ -130,7 +130,13 @@ test_that("use_github_action() allows for custom urls", {
   use_git_remote(name = "origin", url = "https://github.com/fake/fake")
 
   # Directly call to r-lib actions
-  use_github_action(url = "https://raw.githubusercontent.com/r-lib/actions/master/examples/check-full.yaml")
+  withr::local_options(usethis.quiet = FALSE)
+  expect_snapshot(
+    use_github_action(
+      url = "https://raw.githubusercontent.com/r-lib/actions/master/examples/check-full.yaml",
+      readme = "https://github.com/r-lib/actions/blob/master/examples/README.md"
+    )
+  )
   expect_proj_dir(".github")
   expect_proj_dir(".github/workflows")
   expect_proj_file(".github/workflows/check-full.yaml")


### PR DESCRIPTION
This PR exposes the `readme` argument in `use_github_action()` to allow users to specify the location of a readme. 

The purpose of this PR is to make it easier to point to documentation when writing wrappers for custom actions using the `url` argument.