### PR TITLE
Require desc 1.3.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,7 +28,7 @@ Imports:
     clipr (>= 0.3.0),
     crayon,
     curl (>= 2.7),
-    desc,
+    desc (>= 1.3.0),
     fs (>= 1.3.0),
     gert (>= 1.0.2),
     gh (>= 1.2.0),

--- a/R/description.R
+++ b/R/description.R
@@ -153,18 +153,6 @@ valid_package_name <- function(x) {
 }
 
 tidy_desc <- function(desc) {
-  # Alphabetise dependencies
-  deps <- desc$get_deps()
-  deps <- deps[order(deps$type, deps$package), , drop = FALSE]
-  desc$del_deps()
-  desc$set_deps(deps)
-
-  # Alphabetise remotes
-  remotes <- desc$get_remotes()
-  if (length(remotes) > 0) {
-    desc$set_remotes(sort(remotes))
-  }
-
   desc$set("Encoding" = "UTF-8")
 
   # Normalize all fields (includes reordering)

--- a/tests/testthat/test-tidyverse.R
+++ b/tests/testthat/test-tidyverse.R
@@ -1,13 +1,15 @@
-test_that("use_tidy_description() alphabetises dependencies", {
+test_that("use_tidy_description() alphabetises dependencies and remotes", {
   pkg <- create_local_package()
   use_package("usethis")
   use_package("desc")
   use_package("withr", "Suggests")
   use_package("gh", "Suggests")
+  desc::desc_set_remotes(c("r-lib/styler", "jimhester/lintr"))
   use_tidy_description()
   desc <- read_utf8(proj_path("DESCRIPTION"))
   expect_gt(grep("usethis", desc), grep("desc", desc))
   expect_gt(grep("withr", desc), grep("gh", desc))
+  expect_gt(grep("r\\-lib\\/styler", desc), grep("jimhester\\/lintr", desc))
 })
 
 test_that("use_tidy_eval() inserts the template file and Imports rlang", {


### PR DESCRIPTION
This PR bumps the desc dep to require 1.3.0. It also removes the code in `tidy_desc()` that sorts dependencies and remotes, instead letting `desc_normalize()` do it. Additionally, it improves the test for `use_tidy_description()` to check the order of remotes.

Closes #1394 