### PR TITLE
Require latest {desc} for smooth experience with usethis::use_package()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,7 +28,7 @@ Imports:
     clipr (>= 0.3.0),
     crayon,
     curl (>= 2.7),
-    desc,
+    desc (>= 1.3.0),
     fs (>= 1.3.0),
     gert (>= 1.0.2),
     gh (>= 1.2.0),


### PR DESCRIPTION
The ordering in {desc} was discussed in https://github.com/r-lib/usethis/issues/857 and fixed in {desc}, then again reported in  https://github.com/r-lib/desc/issues/95 and hopefully fixed now with release of latest CRAN version. I propose to require that version of {desc} at least to make sure `usethis::use_package()` is not disrupting the ordering.