### PR TITLE
Correct casing in `rstudio_config_path()`

### DIFF
--- a/R/rstudio.R
+++ b/R/rstudio.R
@@ -175,7 +175,7 @@ rstudio_config_path <- function(...) {
     base <- rappdirs::user_config_dir("RStudio", appauthor = NULL)
   } else {
     # RStudio only uses windows/unix conventions, not mac
-    base <- rappdirs::user_config_dir("RStudio", os = "unix")
+    base <- rappdirs::user_config_dir("rstudio", os = "unix")
   }
   path(base, ...)
 }


### PR DESCRIPTION
Presently `rappdirs::user_config_dir("RStudio", os = "unix")` fails in Linux due to case sensitive file paths (see https://github.com/charliejhadley/rstudioprefswitcher/issues/1).

Closes #1425