### PR TITLE
Modify `edit_r_buildignore()` to only work locally

### DIFF
--- a/R/edit.R
+++ b/R/edit.R
@@ -122,9 +122,9 @@ edit_r_environ <- function(scope = c("user", "project")) {
 
 #' @export
 #' @rdname edit
-edit_r_buildignore <- function(scope = c("user", "project")) {
-  path <- scoped_path_r(scope, ".Rbuildignore")
-  edit_file(path)
+edit_r_buildignore <- function() {
+  check_is_package("edit_r_buildignore()")
+  edit_file(proj_path(".Rbuildignore"))
 }
 
 #' @export

--- a/man/edit.Rd
+++ b/man/edit.Rd
@@ -16,7 +16,7 @@ edit_r_profile(scope = c("user", "project"))
 
 edit_r_environ(scope = c("user", "project"))
 
-edit_r_buildignore(scope = c("user", "project"))
+edit_r_buildignore()
 
 edit_r_makevars(scope = c("user", "project"))
 

--- a/tests/testthat/test-edit.R
+++ b/tests/testthat/test-edit.R
@@ -77,11 +77,18 @@ test_that("edit_r_XXX('user') ensures the file exists", {
   edit_r_profile("user")
   expect_r_file(".Rprofile")
 
-  edit_r_buildignore()
-  expect_r_file(".Rbuildignore")
-
   edit_r_makevars("user")
   expect_r_file(".R", "Makevars")
+})
+
+test_that("edit_r_buildignore() only works with packages", {
+  create_local_project()
+
+  expect_usethis_error(edit_r_buildignore(), "not an R package")
+
+  use_description()
+  edit_r_buildignore()
+  expect_r_file(".Rbuildignore")
 })
 
 test_that("can edit snippets", {

--- a/tests/testthat/test-edit.R
+++ b/tests/testthat/test-edit.R
@@ -88,7 +88,7 @@ test_that("edit_r_buildignore() only works with packages", {
 
   use_description()
   edit_r_buildignore()
-  expect_r_file(".Rbuildignore")
+  expect_proj_file(".Rbuildignore")
 })
 
 test_that("can edit snippets", {

--- a/tests/testthat/test-edit.R
+++ b/tests/testthat/test-edit.R
@@ -77,7 +77,7 @@ test_that("edit_r_XXX('user') ensures the file exists", {
   edit_r_profile("user")
   expect_r_file(".Rprofile")
 
-  edit_r_buildignore("user")
+  edit_r_buildignore()
   expect_r_file(".Rbuildignore")
 
   edit_r_makevars("user")


### PR DESCRIPTION
This PR modifies `edit_r_buildignore()` to only work locally, not attempting to create a user-level `.Rbuildignore`. 

Fixes #1428