### PR TITLE
prefer no spaces between arguments in chunk options

### DIFF
--- a/inst/templates/vignette.Rmd
+++ b/inst/templates/vignette.Rmd
@@ -7,7 +7,7 @@ vignette: >
   %\VignetteEncoding{UTF-8}
 ---
 
-```{r, include = FALSE}
+```{r include=FALSE}
 knitr::opts_chunk$set(
   collapse = TRUE,
   comment = "#>"


### PR DESCRIPTION
A style tweak for the default vignette.