### PR TITLE
Don't depend on suggested packages 'testthat' and 'mockr'

### DIFF
--- a/inst/templates/testthat.R
+++ b/inst/templates/testthat.R
@@ -1,4 +1,6 @@
-library(testthat)
-library({{{ name }}})
+if (require(testthat)) {
+  library({{{ name }}})
 
-test_check("{{{ name }}}")
+  test_check("{{{ name }}}")
+} else
+  warning("'{{{ name }}}' requires 'testthat' for tests")

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,4 +1,6 @@
-library(testthat)
-library(usethis)
+if (require(testthat)) {
+  library(usethis)
 
-test_check("usethis")
+  test_check("usethis")
+} else
+  warning("'usethis' requires 'testthat' for tests")

--- a/tests/testthat/test-ci.R
+++ b/tests/testthat/test-ci.R
@@ -1,5 +1,6 @@
 test_that("use_circleci() configures CircleCI", {
   skip_if_no_git_user()
+  skip_if_not_installed("mockr")
 
   local_interactive(FALSE)
   create_local_package()

--- a/tests/testthat/test-course.R
+++ b/tests/testthat/test-course.R
@@ -1,6 +1,7 @@
 ## download_url ----
 
 test_that("download_url() retry logic works as advertised", {
+  skip_if_not_installed("mockr")
   faux_download <- function(n_failures) {
     i <- 0
     function(url, destfile, quiet, mode, handle) {

--- a/tests/testthat/test-cpp11.R
+++ b/tests/testthat/test-cpp11.R
@@ -4,6 +4,7 @@ test_that("use_cpp11() requires a package", {
 })
 
 test_that("use_cpp11() creates files/dirs, edits DESCRIPTION and .gitignore", {
+  skip_if_not_installed("mockr")
   create_local_package()
   use_roxygen_md()
 
@@ -23,6 +24,7 @@ test_that("use_cpp11() creates files/dirs, edits DESCRIPTION and .gitignore", {
 })
 
 test_that("check_cpp_register_deps is silent if all installed, emits todo if not", {
+  skip_if_not_installed("mockr")
   withr::local_options(list(usethis.quiet = FALSE))
 
   with_mock(

--- a/tests/testthat/test-create.R
+++ b/tests/testthat/test-create.R
@@ -36,6 +36,7 @@ test_that("nested project is disallowed, by default", {
 })
 
 test_that("nested package can be created if user really, really wants to", {
+  skip_if_not_installed("mockr")
   parent <- create_local_package()
   with_mock(
     # since user can't approve interactively, use the backdoor
@@ -47,6 +48,7 @@ test_that("nested package can be created if user really, really wants to", {
 })
 
 test_that("nested project can be created if user really, really wants to", {
+  skip_if_not_installed("mockr")
   parent <- create_local_project()
   with_mock(
     # since user can't approve interactively, use the backdoor
@@ -101,6 +103,7 @@ test_that("create_* works w/ non-existing rel path, open = FALSE case", {
 
 # https://github.com/r-lib/usethis/issues/1122
 test_that("create_*() works w/ non-existing rel path, open = TRUE, not in RStudio", {
+  skip_if_not_installed("mockr")
   sandbox <- path_real(dir_create(file_temp("sandbox")))
   orig_proj <- proj_get_()
   withr::defer(dir_delete(sandbox))

--- a/tests/testthat/test-data-table.R
+++ b/tests/testthat/test-data-table.R
@@ -4,6 +4,7 @@ test_that("use_data_table() requires a package", {
 })
 
 test_that("use_data_table() Imports data.table", {
+  skip_if_not_installed("mockr")
   create_local_package()
   use_package_doc()
   with_mock(
@@ -18,6 +19,7 @@ test_that("use_data_table() Imports data.table", {
 })
 
 test_that("use_data_table() blocks use of Depends", {
+  skip_if_not_installed("mockr")
   create_local_package()
   use_package_doc()
   desc::desc_set_dep("data.table", "Depends")

--- a/tests/testthat/test-github-actions.R
+++ b/tests/testthat/test-github-actions.R
@@ -108,6 +108,7 @@ test_that("use_github_action_check_full() configures the pr commands", {
 test_that("use_tidy_github_actions() configures the full check and pr commands", {
   skip_if_no_git_user()
   skip_if_offline()
+  skip_if_not_installed("covr")
 
   create_local_package()
   use_git()

--- a/tests/testthat/test-github-actions.R
+++ b/tests/testthat/test-github-actions.R
@@ -1,6 +1,7 @@
 test_that("uses_github_actions() reports usage of GitHub Actions", {
   skip_if_no_git_user()
   skip_if_offline()
+  skip_if_not_installed("mockr")
 
   create_local_package()
   expect_false(uses_github_actions())

--- a/tests/testthat/test-lifecycle.R
+++ b/tests/testthat/test-lifecycle.R
@@ -1,4 +1,5 @@
 test_that("use_lifecycle() imports badges", {
+  skip_if_not_installed("roxygen2")
   create_local_package(fs::path_temp("test_lifecycle"))
   use_package_doc()
   withr::local_options(usethis.quiet = FALSE)

--- a/tests/testthat/test-package.R
+++ b/tests/testthat/test-package.R
@@ -27,6 +27,7 @@ test_that("use_dev_package() can override over default remote", {
 })
 
 test_that("package_remote() works for an installed package with github URL", {
+  skip_if_not_installed("mockr")
   d <- desc::desc(text = c(
     "Package: test",
     "URL: https://github.com/OWNER/test"

--- a/tests/testthat/test-pipe.R
+++ b/tests/testthat/test-pipe.R
@@ -11,6 +11,7 @@ test_that("use_pipe(export = TRUE) adds promised file, Imports magrittr", {
 })
 
 test_that("use_pipe(export = FALSE) adds roxygen to package doc", {
+  skip_if_not_installed("roxygen2")
   create_local_package()
   use_package_doc()
   use_pipe(export = FALSE)

--- a/tests/testthat/test-pkgdown.R
+++ b/tests/testthat/test-pkgdown.R
@@ -4,6 +4,7 @@ test_that("use_pkgdown() requires a package", {
 })
 
 test_that("use_pkgdown() creates and ignores the promised file/dir", {
+  skip_if_not_installed("mockr")
   create_local_package()
   local_interactive(FALSE)
   with_mock(
@@ -25,6 +26,7 @@ test_that("pkgdown helpers behave in the absence of pkgdown", {
 })
 
 test_that("pkgdown_config_meta() returns a list", {
+  skip_if_not_installed("mockr")
   create_local_package()
   local_interactive(FALSE)
   with_mock(
@@ -40,6 +42,7 @@ test_that("pkgdown_config_meta() returns a list", {
 })
 
 test_that("pkgdown_url() returns correct data, warns if pedantic", {
+  skip_if_not_installed("mockr")
   create_local_package()
   local_interactive(FALSE)
   with_mock(

--- a/tests/testthat/test-proj.R
+++ b/tests/testthat/test-proj.R
@@ -203,6 +203,7 @@ test_that("local_project() activates proj til scope ends", {
 
 # https://github.com/r-lib/usethis/issues/954
 test_that("proj_activate() works with relative path when RStudio is not detected", {
+  skip_if_not_installed("mockr")
   sandbox <- path_real(dir_create(file_temp("sandbox")))
   withr::defer(dir_delete(sandbox))
   orig_proj <- proj_get_()

--- a/tests/testthat/test-rcpp.R
+++ b/tests/testthat/test-rcpp.R
@@ -17,6 +17,7 @@ test_that("use_rcpp() creates files/dirs, edits DESCRIPTION and .gitignore", {
 })
 
 test_that("use_rcpp_armadillo() creates Makevars files and edits DESCRIPTION", {
+  skip_if_not_installed("mockr")
   create_local_package()
   use_roxygen_md()
 
@@ -32,6 +33,7 @@ test_that("use_rcpp_armadillo() creates Makevars files and edits DESCRIPTION", {
 })
 
 test_that("use_rcpp_eigen() edits DESCRIPTION", {
+  skip_if_not_installed("mockr")
   create_local_package()
   use_roxygen_md()
 

--- a/tests/testthat/test-rcpp.R
+++ b/tests/testthat/test-rcpp.R
@@ -4,6 +4,7 @@ test_that("use_rcpp() requires a package", {
 })
 
 test_that("use_rcpp() creates files/dirs, edits DESCRIPTION and .gitignore", {
+  skip_if_not_installed("roxygen2")
   pkg <- create_local_package()
   use_roxygen_md()
 
@@ -46,6 +47,7 @@ test_that("use_rcpp_eigen() edits DESCRIPTION", {
 })
 
 test_that("use_src() doesn't message if not needed", {
+  skip_if_not_installed("roxygen2")
   create_local_package()
   use_roxygen_md()
   use_package_doc()

--- a/tests/testthat/test-tibble.R
+++ b/tests/testthat/test-tibble.R
@@ -4,6 +4,7 @@ test_that("use_tibble() requires a package", {
 })
 
 test_that("use_tibble() Imports tibble", {
+  skip_if_not_installed("mockr")
   create_local_package(path_temp("mypackage"))
   withr::local_options(list(usethis.quiet = FALSE))
   ui_silence(use_package_doc())

--- a/tests/testthat/test-tidyverse.R
+++ b/tests/testthat/test-tidyverse.R
@@ -13,6 +13,7 @@ test_that("use_tidy_description() alphabetises dependencies and remotes", {
 })
 
 test_that("use_tidy_dependencies() isn't overly informative", {
+  skip_if_not_installed("roxygen2")
   create_local_package(fs::path_temp("tidydeps"))
   use_package_doc()
   withr::local_options(usethis.quiet = FALSE)

--- a/tests/testthat/test-tidyverse.R
+++ b/tests/testthat/test-tidyverse.R
@@ -30,6 +30,7 @@ test_that("use_tidy_eval() inserts the template file and Imports rlang", {
 })
 
 test_that("use_tidy_GITHUB-STUFF() adds and Rbuildignores files", {
+  skip_if_not_installed("mockr")
   local_interactive(FALSE)
   create_local_package()
   use_git()
@@ -50,6 +51,7 @@ test_that("use_tidy_GITHUB-STUFF() adds and Rbuildignores files", {
 })
 
 test_that("use_tidy_github() adds and Rbuildignores files", {
+  skip_if_not_installed("mockr")
   local_interactive(FALSE)
   create_local_package()
   use_git()

--- a/tests/testthat/test-tutorial.R
+++ b/tests/testthat/test-tutorial.R
@@ -8,6 +8,7 @@ test_that("use_tutorial() checks its inputs", {
 
 test_that("use_tutorial() creates a tutorial", {
   skip_if_not_installed("rmarkdown")
+  skip_if_not_installed("mockr")
 
   create_local_package()
   with_mock(

--- a/tests/testthat/test-use_import_from.R
+++ b/tests/testthat/test-use_import_from.R
@@ -1,4 +1,5 @@
 test_that("use_import_from() imports the related package & adds line to package doc", {
+  skip_if_not_installed("roxygen2")
   create_local_package()
   use_package_doc()
   use_import_from("tibble", "tibble")
@@ -8,6 +9,7 @@ test_that("use_import_from() imports the related package & adds line to package 
 })
 
 test_that("use_import_from() adds one line for each function", {
+  skip_if_not_installed("roxygen2")
   create_local_package()
   use_package_doc()
   use_import_from("tibble", c("tibble", "enframe", "deframe"))

--- a/tests/testthat/test-utils-github.R
+++ b/tests/testthat/test-utils-github.R
@@ -159,6 +159,7 @@ test_that("fork_upstream_is_not_origin_parent is detected", {
   # 3. parent repo becomes r-lib/gh, due to transfer or ownership or owner
   #    name change
   # Now upstream looks like it does not point to fork parent.
+  skip_if_not_installed("mockr")
   local_interactive(FALSE)
   create_local_project()
   use_git()

--- a/tests/testthat/test-vignette.R
+++ b/tests/testthat/test-vignette.R
@@ -16,6 +16,7 @@ test_that("use_vignette() gives useful errors", {
 })
 
 test_that("use_vignette() does the promised setup", {
+  skip_if_not_installed("rmarkdown")
   create_local_package()
 
   use_vignette("name", "title")
@@ -38,6 +39,7 @@ test_that("use_vignette() does the promised setup", {
 # use_article -------------------------------------------------------------
 
 test_that("use_article goes in article subdirectory", {
+  skip_if_not_installed("rmarkdown")
   create_local_package()
 
   use_article("test")


### PR DESCRIPTION
Cascades of errors in the winUCRT tests on CRAN are caused by tests using `testthat` unconditionally.  This changes the template so that `testthat` is only used if present, and a warning is given if not.

The second commit skips tests that need `mockr` if it is not found. 