### PR TITLE
Update `use_tidy_dependencies()`

### DIFF
--- a/R/tidyverse.R
+++ b/R/tidyverse.R
@@ -110,7 +110,6 @@ use_tidy_dependencies <- function() {
   check_has_package_doc("use_tidy_dependencies()")
 
   use_dependency("rlang", "Imports")
-  use_dependency("ellipsis", "Imports")
   use_dependency("lifecycle", "Imports")
   use_dependency("cli", "Imports")
   use_dependency("glue", "Imports")

--- a/tests/testthat/_snaps/tidyverse.md
+++ b/tests/testthat/_snaps/tidyverse.md
@@ -4,7 +4,6 @@
       use_tidy_dependencies()
     Message <message>
       v Adding 'rlang' to Imports field in DESCRIPTION
-      v Adding 'ellipsis' to Imports field in DESCRIPTION
       v Adding 'lifecycle' to Imports field in DESCRIPTION
       v Adding 'cli' to Imports field in DESCRIPTION
       v Adding 'glue' to Imports field in DESCRIPTION


### PR DESCRIPTION
- Remove ellipsis now that it's folded in rlang (see https://github.com/r-lib/rlang/issues/1057).
- Remove lifecycle following discussion at the team meeting. As @DavisVaughan mentioned, lifecycle is not needed when starting new packages.