### PR TITLE
TYPO: Added testthat:: prefix for example

### DIFF
--- a/inst/templates/test-example-2.1.R
+++ b/inst/templates/test-example-2.1.R
@@ -1,3 +1,3 @@
-test_that("multiplication works", {
+testthat::test_that("multiplication works", {
   expect_equal(2 * 2, 4)
 })


### PR DESCRIPTION
Very simple change that isn't technically a typo, but the change is simply adding the testthat:: namespace for the default testthat example.