### PR TITLE
Fix small typo in examples in GitHub Issue helpers documentation

### DIFF
--- a/R/issue.R
+++ b/R/issue.R
@@ -26,9 +26,9 @@
 #'
 #' @examples
 #' \dontrun{
-#' issue_close_community(12)
+#' issue_close_community(12, reprex = TRUE)
 #'
-#' issue_reprex_needed(241, reprex = TRUE)
+#' issue_reprex_needed(241)
 #' }
 #' @name issue-this
 NULL

--- a/man/issue-this.Rd
+++ b/man/issue-this.Rd
@@ -42,8 +42,8 @@ Unlike GitHub's "saved replies", these functions can:
 
 \examples{
 \dontrun{
-issue_close_community(12)
+issue_close_community(12, reprex = TRUE)
 
-issue_reprex_needed(241, reprex = TRUE)
+issue_reprex_needed(241)
 }
 }


### PR DESCRIPTION
#### Summary

Currently, the `reprex` argument is incorrectly included in `issue_reprex_needed()` rather than `issue_close_community()` to the wrong function in the [examples for the GitHub Issue helpers](https://usethis.r-lib.org/reference/issue-this.html#examples).

This is a small PR to correct this.

#### Additional detail

At present, the example code-block in the [examples for the GitHub Issue helpers](https://usethis.r-lib.org/reference/issue-this.html#examples) is:
```
issue_close_community(12)

issue_reprex_needed(241, reprex = TRUE)
```

However, the `reprex` argument is only used in `issue_close_community()` not `issue_reprex_needed()`. The correct example code-block should read:
```
issue_close_community(12, reprex = TRUE)

issue_reprex_needed(241)
```

To correct this, I have made the necessary changes to the source R file (`R/issue.R`) and rebuild the relevant documentation file (`man/issue-this.Rd`).

 