### PR TITLE
Add 'easystats' to list of verboten meta-packages

### DIFF
--- a/R/package.R
+++ b/R/package.R
@@ -30,7 +30,7 @@
 #' }
 use_package <- function(package, type = "Imports", min_version = NULL) {
   if (type == "Imports") {
-    refuse_package(package, verboten = c("tidyverse", "tidymodels"))
+    refuse_package(package, verboten = c("tidyverse", "tidymodels", "easystats"))
   }
 
   changed <- use_dependency(package, type, min_version = min_version)


### PR DESCRIPTION
["easystats"](https:://github.com/easystats/easystats) is a meta-package similar to the tidyverse with many component packages ("performance", "parameters", "modelbased", etc.). It is designed to make probing, reporting, and plotting many kinds of statistical models in R easier, especially for new R users. Similar to `library(tidyverse)`, some statistics classes have begun to teach `library(easystats)`, which is appropriate for an analysis project, but not for package development.