### PR TITLE
incorporate git `core.excludesfile`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -31,6 +31,8 @@
  
 * `use_package()` no longer guides the user on how to use a dependency when no 
   change was made (@malcolmbarrett, #1384)
+
+* `git_vaccinate()` and `git_vaccinated()` incorporate the value of git `core.excludesfile` (#1461, @ijlyttle).
   
 * The minimum version of gh has been bumped to help more people upgrade to the gh version that supports current GitHub PAT formats (#1454 @ijlyttle).
 

--- a/R/git.R
+++ b/R/git.R
@@ -568,8 +568,8 @@ git_vaccinate <- function() {
 }
 
 git_vaccinated <- function() {
-  path <- git_ignore_path("user")
-  if (!file_exists(path)) {
+  path <- path_expand(git_excludesfile_global_get())
+  if (is_null(path) || !file_exists(path)) {
     return(FALSE)
   }
 


### PR DESCRIPTION
Fix #1461

This is a first pass - just to get it off my computer and to give you something to react to (if you wish).

There are a couple of new internal functions: `git_excludesfile_global_get()` and `git_excludesfile_global_set()`. The new code is probably not as concise as it could be; I have tried to favour readability and preserving existing logic.

I'll want to look over the code with fresh eyes before removing the "draft" status.