### PR TITLE
use remotes instead of devtools in the template

### DIFF
--- a/inst/templates/package-README
+++ b/inst/templates/package-README
@@ -35,7 +35,7 @@ And the development version from [GitHub](https://github.com/) with:
 
 ``` r
 # install.packages("devtools")
-devtools::install_github("{{{ github_spec }}}")
+remotes::install_github("{{{ github_spec }}}")
 ```
 {{/on_github}}
 ## Example


### PR DESCRIPTION
Users shouldn't have to install devtools to install the package from github

From my understanding devtools is using remotes under the hood anyway, and remotes has fewer dependencies.