### PR TITLE
Improve PR targetting

### DIFF
--- a/R/pr.R
+++ b/R/pr.R
@@ -866,7 +866,7 @@ choose_pr <- function(tr = NULL) {
       {n} more {if (n > 1) 'PRs are' else 'PR is'} open; \\
       call {ui_code('browse_github_pulls()')} to browse all PRs")
   }
-  pr_pretty <- purrr::pmap(
+  pr_pretty <- purrr::pmap_chr(
     dat[c("pr_string", "pr_user", "pr_title")],
     function(pr_string, pr_user, pr_title) {
       at_user <- glue("@{pr_user}")
@@ -874,7 +874,10 @@ choose_pr <- function(tr = NULL) {
         {ui_value(pr_string)} ({ui_field(at_user)}): {ui_value(pr_title)}")
     }
   )
-  choice <- utils::menu(title = prompt, choices = pr_pretty)
+  choice <- utils::menu(
+    title = prompt,
+    choices = cli::ansi_strtrim(pr_pretty)
+  )
   as.list(dat[choice, ])
 }
 

--- a/R/pr.R
+++ b/R/pr.R
@@ -700,6 +700,7 @@ pr_data_tidy <- function(pr) {
   out <- list(
     pr_number     = pluck_int(pr, "number"),
     pr_title      = pluck_chr(pr, "title"),
+    pr_state      = pluck_chr(pr, "state"),
     pr_user       = pluck_chr(pr, "user", "login"),
     pr_created_at = pluck_chr(pr, "created_at"),
     pr_updated_at = pluck_chr(pr, "updated_at"),

--- a/R/pr.R
+++ b/R/pr.R
@@ -602,7 +602,7 @@ pr_clean <- function(number = NULL,
   branches <- gert::git_branch_list(local = TRUE, repo = repo)
   branches <- branches[!is.na(branches$upstream), ]
   if (sum(grepl(glue("^refs/remotes/{pr$pr_remote}"), branches$upstream)) == 0) {
-   ui_done("Removing remote {ui_value(pr$pr_remote)}")
+    ui_done("Removing remote {ui_value(pr$pr_remote)}")
     gert::git_remote_remove(remote = pr$pr_remote, repo = repo)
     # TODO: consider deleting this remote's section in config
   }

--- a/R/pr.R
+++ b/R/pr.R
@@ -758,11 +758,11 @@ pr_list <- function(tr = NULL,
     "GET /repos/{owner}/{repo}/pulls",
     state = state, head = head, .limit = Inf
   )
-  if (!is.null(out$error)) {
+  if (is.null(out$error)) {
+    prs <- out$result
+  } else {
     ui_oops("Unable to retrieve PRs for {ui_value(tr$repo_spec)}.")
     prs <- NULL
-  } else {
-    prs <- out$result
   }
   no_prs <- length(prs) == 0
   if (no_prs) {

--- a/R/pr.R
+++ b/R/pr.R
@@ -450,7 +450,7 @@ pr_view <- function(number = NULL, target = c("source", "primary")) {
     branch <- git_branch()
     default_branch <- git_default_branch()
     if (branch != default_branch) {
-      url <- pr_url(tr = tr)
+      url <- pr_url(branch = branch, tr = tr)
       if (is.null(url)) {
         ui_info("
           Current branch ({ui_value(branch)}) does not appear to be \\

--- a/R/pr.R
+++ b/R/pr.R
@@ -583,6 +583,8 @@ pr_clean <- function(number = NULL,
   if (!is.na(pr_local_branch)) {
     ui_done("Deleting local {ui_value(pr_local_branch)} branch.")
     gert::git_branch_delete(pr_local_branch, repo = repo)
+    # TODO: consider deleting this branch's section in config, or at least any
+    # settings we've added
   }
 
   if (is.null(pr)) {
@@ -602,6 +604,7 @@ pr_clean <- function(number = NULL,
   if (sum(grepl(glue("^refs/remotes/{pr$pr_remote}"), branches$upstream)) == 0) {
    ui_done("Removing remote {ui_value(pr$pr_remote)}")
     gert::git_remote_remove(remote = pr$pr_remote, repo = repo)
+    # TODO: consider deleting this remote's section in config
   }
   invisible()
 }

--- a/R/pr.R
+++ b/R/pr.R
@@ -418,15 +418,17 @@ pr_push <- function() {
 #' @export
 #' @rdname pull-requests
 pr_pull <- function() {
-  # TODO: try to determine the associated PR and make sure pr-url is configured
-  # to help solve https://github.com/r-lib/usethis/issues/1449
-  # we're doing most of the necessary API calls anyway, with all these checks
-  check_for_config()
+  cfg <- github_remote_config(github_get = TRUE)
+  check_for_config(cfg)
   default_branch <- git_default_branch()
   check_pr_branch(default_branch)
   challenge_uncommitted_changes()
 
   git_pull()
+
+  # note associated PR in git config, if applicable
+  tr <- target_repo(cfg, ask = FALSE)
+  pr_find(tr = tr)
 
   invisible(TRUE)
 }

--- a/R/utils-git.R
+++ b/R/utils-git.R
@@ -226,13 +226,13 @@ git_pull <- function(remref = NULL, verbose = TRUE) {
   remref <- remref %||% git_branch_tracking(branch)
   if (is.na(remref)) {
     if (verbose) {
-      ui_done("No remote branch to pull from for {ui_value(branch)}")
+      ui_done("No remote branch to pull from for {ui_value(branch)}.")
     }
     return(invisible())
   }
   stopifnot(is_string(remref))
   if (verbose) {
-    ui_done("Pulling from {ui_value(remref)}")
+    ui_done("Pulling from {ui_value(remref)}.")
   }
   gert::git_fetch(
     remote = remref_remote(remref),


### PR DESCRIPTION
Closes #1449

Notes from analyzing the problem:

The problem occurs when a branch name is re-used for multiple PRs and then you try to `pr_finish()` or `pr_forget()` without specifying the PR number (i.e. you intend to discover the PR associated with the current branch) . Life is good is we already have the relevant PR recorded in the local git config.

Therefore, one half of this PR is about being more diligent to record a PR's URL during all possible `pr_*()` interactions. We were already recording it in the course of certain activities (`pr_fetch()`, `pr_view()`, `pr_push()`). But now we also do in `pr_resume()` and `pr_pull()`. The `pr-url` should now appear in local git config much more often.

The second half of this PR deals with the case where `pr_clean()` (called by `pr_finish()` and `pr_forget()`) has to infer the PR from the local branch and its upstream tracking branch. `pr_clean()` is obligated to call `pr_find(..., state = "all")`, i.e. to find all PRs -- open or closed -- which are associated with a specific repo and branch name. We have to do this, because often the target PR has already been merged, i.e. it's closed.

Things get tricky when multiple PRs have used the same branch name (e.g. "pdf"). You can't count on open vs. closed status to help you, since often we merge PRs in the browser (thereby closing them), then call `pr_finish()` locally. Now, in this ambiguous case, I present the user a choice of PRs, revealing each PR's closed/open status, open PRs followed by closed PRs, sorted by recency.