### PR TITLE
Enable "internal" repositories in `use_github()`

### DIFF
--- a/man/use_github.Rd
+++ b/man/use_github.Rd
@@ -7,6 +7,7 @@
 use_github(
   organisation = NULL,
   private = FALSE,
+  visibility = c("public", "private", "internal"),
   protocol = git_protocol(),
   host = NULL,
   auth_token = deprecated(),
@@ -21,6 +22,11 @@ such that you have permission to create repositories in this
 \code{organisation}.}
 
 \item{private}{If \code{TRUE}, creates a private repository.}
+
+\item{visibility}{Only relevant for organisation-owned repos associated with
+certain GitHub Enterprise products. The special "internal" \code{visibility}
+grants read permissions to all enterprise members, i.e. an "internal"
+notion of open source, a.k.a. "innersource".}
 
 \item{protocol}{One of "https" or "ssh"}
 


### PR DESCRIPTION
Closes #1458

In my hands, this does not seem to work and I don't know why.