### PR TITLE
Don't include CRAN install instructions to start

### DIFF
--- a/inst/templates/package-README
+++ b/inst/templates/package-README
@@ -24,20 +24,15 @@ The goal of {{{ Package }}} is to ...
 
 ## Installation
 
-You can install the released version of {{{ Package }}} from [CRAN](https://CRAN.R-project.org) with:
-
-``` r
-install.packages("{{{ Package }}}")
-```
-
 {{#on_github}}
-And the development version from [GitHub](https://github.com/) with:
+You can install the the development version of {{{ Package }}} from [GitHub](https://github.com/) with:
 
 ``` r
 # install.packages("devtools")
 devtools::install_github("{{{ github_spec }}}")
 ```
 {{/on_github}}
+
 ## Example
 
 This is a basic example which shows you how to solve a common problem:


### PR DESCRIPTION
This closes #1451 by tweaking the default README instructions. We don't need to add a release bullet point reminding to tweak install instructions because, as it turns out, there's been one for a [few years already](https://github.com/r-lib/usethis/commit/87f743abdc76193ebc9a3c2009bfd680c0605034) (😆)

The downside of this simple change is that, if the repo is not on GitHub, nothing gets added to the installation section, and it will be just the header. We could only include the header if already on GH or we could leave it empty as a prompt. 

I think there's a lot of people (🤚) who create the README prior to putting on GH, as well.