### PR TITLE
check for availability of `rstudioapi::OpenProject()`

### DIFF
--- a/R/proj.R
+++ b/R/proj.R
@@ -265,7 +265,7 @@ proj_activate <- function(path) {
   check_path_is_directory(path)
   path <- user_path_prep(path)
 
-  if (rstudio_available()) {
+  if (rstudio_available() && rstudioapi::hasFun("openProject")) {
     ui_done("Opening {ui_path(path, base = NA)} in new RStudio session")
     rstudioapi::openProject(path, newSession = TRUE)
     invisible(FALSE)


### PR DESCRIPTION
Closes #1455. It looks like other uses of `rstudioapi::OpenProject()` are already checked. 

I suppose we could be a bit more robust about this suggestion in `proj_sitrep()`, but it also doesn't seem like too big a deal since the user would be doing it themselves:
https://github.com/r-lib/usethis/blob/290a2017f1ed7e35b71255c8ba32516dcbf04377/R/sitrep.R#L100-L101