### PR TITLE
Shields.io experiment

### DIFF
--- a/R/coverage.R
+++ b/R/coverage.R
@@ -44,7 +44,7 @@ use_covr_ignore <- function(files) {
 use_codecov_badge <- function(repo_spec) {
   default_branch <- git_default_branch()
   url <- glue("https://app.codecov.io/gh/{repo_spec}?branch={default_branch}")
-  img <- glue("https://codecov.io/gh/{repo_spec}/branch/{default_branch}/graph/badge.svg")
+  img <- glue("https://img.shields.io/codecov/c/github/{repo_spec}?label=test%20coverage&logo=codecov")
   use_badge("Codecov test coverage", url, img)
 }
 

--- a/R/github-actions.R
+++ b/R/github-actions.R
@@ -73,15 +73,20 @@ use_github_actions <- function() {
 #' @rdname github_actions
 use_github_actions_badge <- function(name = "R-CMD-check.yaml",
                                      repo_spec = NULL) {
+  name_no_ext <- path_ext_remove(name)
   if (path_ext(name) == "") {
     name <- path_ext_set(name, "yaml")
   }
-  repo_spec <- repo_spec %||% target_repo_spec()
-  enc_name <- utils::URLencode(name)
-  img <- glue("https://github.com/{repo_spec}/actions/workflows/{enc_name}/badge.svg")
-  url <- glue("https://github.com/{repo_spec}/actions/workflows/{enc_name}")
+  name_enc <- utils::URLencode(name)
+  name_no_ext_enc <- utils::URLencode(name_no_ext)
+  badge_label <- glue("{name_no_ext} GitHub Action status")
 
-  use_badge(path_ext_remove(name), url, img)
+  repo_spec <- repo_spec %||% target_repo_spec()
+
+  img <- glue("https://img.shields.io/github/workflow/status/{repo_spec}/{name_no_ext_enc}?label={name_no_ext_enc}&logo=github")
+  url <- glue("https://github.com/{repo_spec}/actions/workflows/{name_enc}")
+
+  use_badge(badge_label, url, img)
 }
 
 uses_github_actions <- function() {

--- a/README.Rmd
+++ b/README.Rmd
@@ -16,8 +16,8 @@ knitr::opts_chunk$set(
 # usethis <img src="man/figures/logo.png" align="right" height="139" />
 
 <!-- badges: start -->
-[![R-CMD-check](https://github.com/r-lib/usethis/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/r-lib/usethis/actions/workflows/R-CMD-check.yaml)
-[![Codecov test coverage](https://codecov.io/gh/r-lib/usethis/branch/main/graph/badge.svg)](https://app.codecov.io/gh/r-lib/usethis?branch=main)
+[![R-CMD-check GitHub Action status](https://img.shields.io/github/workflow/status/r-lib/usethis/R-CMD-check?label=R-CMD-check&logo=github)](https://github.com/r-lib/usethis/actions/workflows/R-CMD-check.yaml)
+[![Codecov test coverage](https://img.shields.io/codecov/c/github/r-lib/usethis?label=test%20coverage&logo=codecov)](https://app.codecov.io/gh/r-lib/usethis?branch=main)
 [![CRAN status](https://www.r-pkg.org/badges/version/usethis)](https://CRAN.R-project.org/package=usethis)
 [![Lifecycle: stable](https://img.shields.io/badge/lifecycle-stable-brightgreen.svg)](https://lifecycle.r-lib.org/articles/stages.html#stable)
 <!-- badges: end -->

--- a/README.md
+++ b/README.md
@@ -5,9 +5,10 @@
 
 <!-- badges: start -->
 
-[![R-CMD-check](https://github.com/r-lib/usethis/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/r-lib/usethis/actions/workflows/R-CMD-check.yaml)
+[![R-CMD-check GitHub Action
+status](https://img.shields.io/github/workflow/status/r-lib/usethis/R-CMD-check?label=R-CMD-check&logo=github)](https://github.com/r-lib/usethis/actions/workflows/R-CMD-check.yaml)
 [![Codecov test
-coverage](https://codecov.io/gh/r-lib/usethis/branch/main/graph/badge.svg)](https://app.codecov.io/gh/r-lib/usethis?branch=main)
+coverage](https://img.shields.io/codecov/c/github/r-lib/usethis?label=test%20coverage&logo=codecov)](https://app.codecov.io/gh/r-lib/usethis?branch=main)
 [![CRAN
 status](https://www.r-pkg.org/badges/version/usethis)](https://CRAN.R-project.org/package=usethis)
 [![Lifecycle:


### PR DESCRIPTION
Relates to #1554 

The SVGs served by https://shields.io/ are more accessible than the native ones from GitHub and Codecov. A little experiment.