### PR TITLE
use_import_from() outside package directory

### DIFF
--- a/R/roxygen.R
+++ b/R/roxygen.R
@@ -87,7 +87,7 @@ roxygen_update_ns <- function(load = is_interactive()) {
 
   if (load) {
     ui_done("Loading {project_name()}")
-    pkgload::load_all(quiet = TRUE)
+    pkgload::load_all(path = proj_get(), quiet = TRUE)
   }
 
   TRUE


### PR DESCRIPTION
Adds `path = proj_get()` to `pkgload::load_all()` call in `roxygen_update_ns()`.

Closes #1536 