### PR TITLE
No longer need to redocument after use_tidy_description()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -57,7 +57,7 @@ Suggests:
     mockr,
     pkgload,
     rmarkdown,
-    roxygen2,
+    roxygen2 (>= 7.1.2),
     spelling (>= 1.2),
     styler (>= 1.2.0),
     testthat (>= 3.1.0)

--- a/R/tidyverse.R
+++ b/R/tidyverse.R
@@ -101,7 +101,6 @@ use_tidy_description <- function() {
   tidy_desc(desc)
   desc$write()
 
-  ui_todo("Run {ui_code('devtools::document()')} to update package docs")
   invisible(TRUE)
 }
 


### PR DESCRIPTION
Since roxygen2 now automatically squashes whitespace