### PR TITLE
fix github pages branch name

### DIFF
--- a/R/pkgdown.R
+++ b/R/pkgdown.R
@@ -12,7 +12,7 @@
 #'
 #'   - (first, it calls `use_pkgdown()`)
 #'   - [use_github_pages()] prepares to publish the pkgdown site from the
-#'     `github-pages` branch
+#'     `gh-pages` branch
 #'   - [`use_github_action("pkgdown")`][use_github_action()] configures a
 #'     GitHub Action to automatically build the pkgdown site and deploy it via
 #'     GitHub Pages

--- a/man/use_pkgdown.Rd
+++ b/man/use_pkgdown.Rd
@@ -28,7 +28,7 @@ automatically publish your pkgdown site to GitHub pages:
 \itemize{
 \item (first, it calls \code{use_pkgdown()})
 \item \code{\link[=use_github_pages]{use_github_pages()}} prepares to publish the pkgdown site from the
-\code{github-pages} branch
+\code{gh-pages} branch
 \item \code{\link[=use_github_action]{use_github_action("pkgdown")}} configures a
 GitHub Action to automatically build the pkgdown site and deploy it via
 GitHub Pages


### PR DESCRIPTION
As the branch is normally called `gh-pages`, not `github-pages`.