### PR TITLE
Error with abs paths in `proj_path()`

### DIFF
--- a/R/pkgdown.R
+++ b/R/pkgdown.R
@@ -26,8 +26,9 @@
 #' Travis-CI.
 #'
 #' @seealso <https://pkgdown.r-lib.org/articles/pkgdown.html#configuration>
-#' @param config_file Path to the pkgdown yaml config file
-#' @param destdir Target directory for pkgdown docs
+#' @param config_file Path to the pkgdown yaml config file, relative to the
+#'  project.
+#' @param destdir Target directory for pkgdown docs.
 #' @export
 use_pkgdown <- function(config_file = "_pkgdown.yml", destdir = "docs") {
   check_is_package("use_pkgdown()")

--- a/R/proj.R
+++ b/R/proj.R
@@ -95,7 +95,13 @@ proj_set <- function(path = ".", force = FALSE) {
 #' @inheritParams fs::path
 #' @export
 proj_path <- function(..., ext = "") {
-  path_norm(path(proj_get(), ..., ext = ext))
+  paths <- path(..., ext = ext)
+  paths <- purrr::map_chr(
+    paths,
+    ~ if (is_absolute_path(.x)) .x else path(proj_get(), .x)
+  )
+
+  path_norm(paths)
 }
 
 #' @describeIn proj_utils Runs code with a temporary active project and,

--- a/R/proj.R
+++ b/R/proj.R
@@ -96,12 +96,11 @@ proj_set <- function(path = ".", force = FALSE) {
 #' @export
 proj_path <- function(..., ext = "") {
   paths <- path(..., ext = ext)
-  paths <- purrr::map_chr(
-    paths,
-    ~ if (is_absolute_path(.x)) .x else path(proj_get(), .x)
-  )
+  if (any(is_absolute_path(paths))) {
+    ui_stop("Paths must be relative to the active project")
+  }
 
-  path_norm(paths)
+  path_norm(path(proj_get(), paths))
 }
 
 #' @describeIn proj_utils Runs code with a temporary active project and,

--- a/tests/testthat/_snaps/proj.md
+++ b/tests/testthat/_snaps/proj.md
@@ -1,0 +1,8 @@
+# proj_path() errors with absolute paths
+
+    Code
+      proj_path(c("/a", "b", "/c"))
+    Condition
+      Error:
+      ! Paths must be relative to the active project
+

--- a/tests/testthat/test-proj.R
+++ b/tests/testthat/test-proj.R
@@ -48,11 +48,11 @@ test_that("proj_path() appends to the project path", {
   expect_identical(proj_path("a", "b", "c"), proj_path("a/b/c"))
 })
 
-test_that("proj_path() respects absolute paths", {
+test_that("proj_path() errors with absolute paths", {
   create_local_project()
-  expect_equal(
+  expect_error(
     proj_path(c("/a", "b", "/c")),
-    path(c("/a", path(proj_get(), "b"), "/c"))
+    "Paths must be relative to the active project"
   )
 })
 

--- a/tests/testthat/test-proj.R
+++ b/tests/testthat/test-proj.R
@@ -50,10 +50,7 @@ test_that("proj_path() appends to the project path", {
 
 test_that("proj_path() errors with absolute paths", {
   create_local_project()
-  expect_error(
-    proj_path(c("/a", "b", "/c")),
-    "Paths must be relative to the active project"
-  )
+  expect_snapshot(proj_path(c("/a", "b", "/c")), error = TRUE)
 })
 
 test_that("proj_rel_path() returns path part below the project", {

--- a/tests/testthat/test-proj.R
+++ b/tests/testthat/test-proj.R
@@ -48,6 +48,14 @@ test_that("proj_path() appends to the project path", {
   expect_identical(proj_path("a", "b", "c"), proj_path("a/b/c"))
 })
 
+test_that("proj_path() respects absolute paths", {
+  create_local_project()
+  expect_equal(
+    proj_path(c("/a", "b", "/c")),
+    path(c("/a", path(proj_get(), "b"), "/c"))
+  )
+})
+
 test_that("proj_rel_path() returns path part below the project", {
   create_local_project()
   expect_equal(proj_rel_path(proj_path("a/b/c")), "a/b/c")


### PR DESCRIPTION
`proj_path()` always returns paths with the project root prepended to it, even if the path is already absolute. This is less of a big deal with using `proj_path()` directly (since it's obviously intended to do that) and more when we use it internally to process paths, as in `use_github_file()`.  (I recently tried to save a file using an absolute path interactively, which did not work)

This PR modifies `proj_path()` to ~~respect~~ reject absolute paths