### PR TITLE
missing `glue()` to replace correct `ref`

### DIFF
--- a/R/github-actions.R
+++ b/R/github-actions.R
@@ -121,7 +121,7 @@ use_github_action <- function(name,
     url <- glue(
       "https://raw.githubusercontent.com/r-lib/actions/{ref}/examples/{name}"
     )
-    readme <- "https://github.com/r-lib/actions/blob/{ref}/examples/README.md"
+    readme <- glue("https://github.com/r-lib/actions/blob/{ref}/examples/README.md")
   } else {
     check_string(url)
     maybe_string(readme)


### PR DESCRIPTION
Small fix so that `{ref}` gets correctly replaced. 

Otherwise we get 
````
* Learn more at <https://github.com/r-lib/actions/blob/{ref}/examples/README.md>.
````