### PR TITLE
Update CoC to Contributor Covenant 2.1

### DIFF
--- a/R/code-of-conduct.R
+++ b/R/code-of-conduct.R
@@ -4,8 +4,8 @@
 #' `.Rbuildignore`, in the case of a package. The goal of a code of conduct is
 #' to foster an environment of inclusiveness, and to explicitly discourage
 #' inappropriate behaviour. The template comes from
-#' <https://www.contributor-covenant.org>, version 2:
-#' <https://www.contributor-covenant.org/version/2/0/code_of_conduct/>.
+#' <https://www.contributor-covenant.org>, version 2.1:
+#' <https://www.contributor-covenant.org/version/2/1/code_of_conduct/>.
 #'
 #' If your package is going to CRAN, the link to the CoC in your README must
 #' be an absolute link to a rendered website as `CODE_OF_CONDUCT.md` is not
@@ -41,7 +41,7 @@ use_code_of_conduct <- function(contact, path = NULL) {
   )
 
   href <- pkgdown_url(pedantic = TRUE) %||%
-    "https://contributor-covenant.org/version/2/0"
+    "https://contributor-covenant.org/version/2/1"
   href <- sub("/$", "", href)
   href <- paste0(href, "/CODE_OF_CONDUCT.html")
 

--- a/inst/templates/CODE_OF_CONDUCT.md
+++ b/inst/templates/CODE_OF_CONDUCT.md
@@ -6,8 +6,8 @@ We as members, contributors, and leaders pledge to make participation in our
 community a harassment-free experience for everyone, regardless of age, body
 size, visible or invisible disability, ethnicity, sex characteristics, gender
 identity and expression, level of experience, education, socio-economic status,
-nationality, personal appearance, race, religion, or sexual identity and
-orientation.
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
 
 We pledge to act and interact in ways that contribute to an open, welcoming,
 diverse, inclusive, and healthy community.
@@ -21,25 +21,25 @@ community include:
 * Being respectful of differing opinions, viewpoints, and experiences
 * Giving and gracefully accepting constructive feedback
 * Accepting responsibility and apologizing to those affected by our mistakes,
-and learning from the experience
+  and learning from the experience
 * Focusing on what is best not just for us as individuals, but for the overall
-community
+  community
 
 Examples of unacceptable behavior include:
 
-* The use of sexualized language or imagery, and sexual attention or
-advances of any kind
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
 * Trolling, insulting or derogatory comments, and personal or political attacks
 * Public or private harassment
-* Publishing others' private information, such as a physical or email
-address, without their explicit permission
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
 * Other conduct which could reasonably be considered inappropriate in a
-professional setting
+  professional setting
 
 ## Enforcement Responsibilities
 
-Community leaders are responsible for clarifying and enforcing our standards
-of acceptable behavior and will take appropriate and fair corrective action in
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
 response to any behavior that they deem inappropriate, threatening, offensive,
 or harmful.
 
@@ -50,10 +50,10 @@ decisions when appropriate.
 
 ## Scope
 
-This Code of Conduct applies within all community spaces, and also applies
-when an individual is officially representing the community in public spaces.
-Examples of representing our community include using an official e-mail
-address, posting via an official social media account, or acting as an appointed
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
 representative at an online or offline event.
 
 ## Enforcement
@@ -114,14 +114,13 @@ community.
 ## Attribution
 
 This Code of Conduct is adapted from the [Contributor Covenant][homepage],
-version 2.0,
-available at <https://www.contributor-covenant.org/version/2/0/code_of_conduct.html>.
+version 2.1, available at
+<https://www.contributor-covenant.org/version/2/1/code_of_conduct.html>.
 
-Community Impact Guidelines were inspired by [Mozilla's code of conduct
-enforcement ladder](https://github.com/mozilla/diversity).
-
-[homepage]: https://www.contributor-covenant.org
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][https://github.com/mozilla/inclusion].
 
 For answers to common questions about this code of conduct, see the FAQ at
 <https://www.contributor-covenant.org/faq>. Translations are available at <https://www.contributor-covenant.org/translations>.
 
+[homepage]: https://www.contributor-covenant.org


### PR DESCRIPTION
Updates `use_code_of_conduct()`, and the associated wrapper functions (e.g. `use_tidy_coc()`, as well as the CODE_OF_CONDUCT.md template to use Contributor Covenant v. 2.1.