### PR TITLE
Use non-deprecated `use_tidy_github_labels()` in checklist

### DIFF
--- a/R/tidy-upkeep.R
+++ b/R/tidy-upkeep.R
@@ -41,7 +41,7 @@ upkeep_checklist <- function(year = NULL) {
       todo("`usethis::use_roxygen_md()`"),
       todo("`usethis::use_github_links()`"),
       todo("`usethis::use_pkgdown_github_pages()`"),
-      todo("`usethis::use_tidy_labels()`"),
+      todo("`usethis::use_tidy_github_labels()`"),
       todo("`usethis::use_tidy_style()`"),
       todo("`usethis::use_tidy_description()`"),
       todo("`urlchecker::url_check()`"),

--- a/tests/testthat/_snaps/tidy-upkeep.md
+++ b/tests/testthat/_snaps/tidy-upkeep.md
@@ -9,7 +9,7 @@
       * [ ] `usethis::use_roxygen_md()`
       * [ ] `usethis::use_github_links()`
       * [ ] `usethis::use_pkgdown_github_pages()`
-      * [ ] `usethis::use_tidy_labels()`
+      * [ ] `usethis::use_tidy_github_labels()`
       * [ ] `usethis::use_tidy_style()`
       * [ ] `usethis::use_tidy_description()`
       * [ ] `urlchecker::url_check()`


### PR DESCRIPTION
Since `use_tidy_labels()` is deprecated