### PR TITLE
updating language around README in code-of-conduct.R

### DIFF
--- a/R/code-of-conduct.R
+++ b/R/code-of-conduct.R
@@ -45,7 +45,7 @@ use_code_of_conduct <- function(contact, path = NULL) {
   href <- sub("/$", "", href)
   href <- paste0(href, "/CODE_OF_CONDUCT.html")
 
-  ui_todo("Don't forget to describe the code of conduct in your README:")
+  ui_todo("You may also want to describe the code of conduct in your README:")
   ui_code_block("
     ## Code of Conduct
 


### PR DESCRIPTION
Changing the language in code-of-conduct.R from requiring ("don't forget) to suggesting ("you may also want to"). Since the Code of Conduct is linked in other locations, it's not required that it go in the README, but some projects may still want to include it, especially if they don't have other places, like pkgdown sites, where it's as documented. 