### PR TITLE
Account for more ways that RStudio can appear in pkg author's (or not appear)

### DIFF
--- a/R/release.R
+++ b/R/release.R
@@ -369,16 +369,58 @@ news_latest <- function(lines) {
 }
 
 is_rstudio_pkg <- function() {
-  is_rstudio_funded() || is_in_rstudio_org()
+  is_rstudio_cph_or_fnd() || is_in_rstudio_org()
 }
 
-is_rstudio_funded <- function() {
+is_rstudio_cph_or_fnd <- function() {
   if (!is_package()) {
     return(FALSE)
   }
+  roles <- get_rstudio_roles()
+  "cph" %in% roles || "fnd" %in% roles
+}
+
+is_rstudio_person_canonical <- function() {
+  if (!is_package()) {
+    return(FALSE)
+  }
+  roles <- get_rstudio_roles()
+  length(roles) > 0 &&
+    "fnd" %in% roles &&
+    "cph" %in% roles &&
+    attr(roles, "appears_in", exact = TRUE) == "given" &&
+    attr(roles, "appears_as", exact = TRUE) == "RStudio"
+}
+
+get_rstudio_roles <- function() {
+  if (!is_package()) {
+    return()
+  }
+
   desc <- desc::desc(file = proj_get())
-  funders <- unclass(desc$get_author("fnd"))
-  purrr::some(funders, ~ identical(.x$given, "RStudio"))
+  fnd <- unclass(desc$get_author("fnd"))
+  cph <- unclass(desc$get_author("cph"))
+
+  detect_rstudio <- function(x) {
+    any(grepl("rstudio", tolower(x[c("given", "family")])))
+  }
+  fnd <- purrr::keep(fnd, detect_rstudio)
+  cph <- purrr::keep(cph, detect_rstudio)
+
+  if (length(fnd) < 1 && length(cph) < 1) {
+    return(character())
+  }
+
+  person <- c(fnd, cph)[[1]]
+  out <- person$role
+  if (!is.null(person$given) && nzchar(person$given)) {
+    attr(out, "appears_as") <- person$given
+    attr(out, "appears_in") <- "given"
+  } else {
+    attr(out, "appears_as") <- person$family
+    attr(out, "appears_in") <- "family"
+  }
+  out
 }
 
 is_in_rstudio_org <- function() {

--- a/R/release.R
+++ b/R/release.R
@@ -378,7 +378,7 @@ is_rstudio_funded <- function() {
   }
   desc <- desc::desc(file = proj_get())
   funders <- unclass(desc$get_author("fnd"))
-  purrr::some(funders, ~ .x$given == "RStudio")
+  purrr::some(funders, ~ identical(.x$given, "RStudio"))
 }
 
 is_in_rstudio_org <- function() {

--- a/R/tidy-upkeep.R
+++ b/R/tidy-upkeep.R
@@ -28,10 +28,12 @@ use_tidy_upkeep_issue <- function(year = NULL) {
   view_url(issue$html_url)
 }
 
-upkeep_checklist <- function(year = NULL) {
+upkeep_checklist <- function(year = NULL,
+                             rstudio_pkg = is_rstudio_pkg(),
+                             rstudio_person_ok = is_rstudio_person_canonical()) {
   year <- year %||% 2000
-  is_rstudio_funded <- is_rstudio_funded()
-  is_in_rstudio_org <- is_in_rstudio_org()
+
+
   bullets <- c()
 
   if (year <= 2000) {
@@ -80,9 +82,11 @@ upkeep_checklist <- function(year = NULL) {
       todo("
         Use lifecycle instead of artisanal deprecation messages, as described \\
         in [Communicate lifecycle changes in your functions](https://lifecycle.r-lib.org/articles/communicate.html)"),
-      todo("
-        Add RStudio to DESCRIPTION as funder, if appropriate",
-        !is_rstudio_funded && is_in_rstudio_org),
+      todo('
+        Make sure RStudio appears in `Authors@R` of DESCRIPTION like so, if appropriate:
+        `person("RStudio", role = c("cph", "fnd"))`',
+        rstudio_pkg && !rstudio_person_ok),
+
       ""
     )
   }

--- a/tests/testthat/_snaps/tidy-upkeep.md
+++ b/tests/testthat/_snaps/tidy-upkeep.md
@@ -1,7 +1,7 @@
 # upkeep bullets don't change accidentally
 
     Code
-      writeLines(upkeep_checklist())
+      writeLines(upkeep_checklist(rstudio_pkg = TRUE, rstudio_person_ok = FALSE))
     Output
       Pre-history
       
@@ -30,6 +30,8 @@
       * [ ] Remove check environments section from `cran-comments.md`
       * [ ] Bump required R version in DESCRIPTION to 3.4
       * [ ] Use lifecycle instead of artisanal deprecation messages, as described in [Communicate lifecycle changes in your functions](https://lifecycle.r-lib.org/articles/communicate.html)
+      * [ ] Make sure RStudio appears in `Authors@R` of DESCRIPTION like so, if appropriate:
+      `person("RStudio", role = c("cph", "fnd"))`
       
       2022
       

--- a/tests/testthat/test-release.R
+++ b/tests/testthat/test-release.R
@@ -37,16 +37,16 @@ test_that("get extra news bullets if available", {
 test_that("RStudio-ness detection works", {
   create_local_package()
 
-  expect_false(is_rstudio_funded())
-  expect_false(is_in_rstudio_org())
+  expect_false(is_rstudio_pkg())
 
   desc <- desc::desc(file = proj_get())
-  desc$add_author(given = "RStudio", role = "fnd")
+  desc$add_author(given = "RstuDio, PbC", role = "fnd")
   desc$add_urls("https://github.com/tidyverse/WHATEVER")
   desc$write()
 
-  expect_true(is_rstudio_funded())
+  expect_true(is_rstudio_pkg())
   expect_true(is_in_rstudio_org())
+  expect_false(is_rstudio_person_canonical())
 
   expect_snapshot(
     writeLines(release_checklist("1.0.0", on_cran = TRUE)),

--- a/tests/testthat/test-tidy-upkeep.R
+++ b/tests/testthat/test-tidy-upkeep.R
@@ -1,3 +1,5 @@
 test_that("upkeep bullets don't change accidentally", {
-  expect_snapshot(writeLines(upkeep_checklist()))
+  expect_snapshot(writeLines(
+    upkeep_checklist(rstudio_pkg = TRUE, rstudio_person_ok = FALSE)
+  ))
 })


### PR DESCRIPTION
Fixes #1600 

in `person()`,  `given` field can be NULL which does not play well with `==` comparaison. In that case `is_rstudio_funded()` won't return TRUE or FALSE, but NA. 

Using `identical()` fix the issue.

I can add a NEWS bullet for this if needed.