### PR TITLE
add note to use_readme_rmd() docs

### DIFF
--- a/R/readme.R
+++ b/R/readme.R
@@ -1,8 +1,8 @@
 #' Create README files
 #'
 #' @description
-#' Creates skeleton README files with sections for
-#' * a high-level description of the package and its goals
+#' Creates skeleton README files with possible stubs for
+#' * a high-level description of the project/package and its goals
 #' * R code to install from GitHub, if GitHub usage detected
 #' * a basic example
 #'
@@ -15,10 +15,14 @@
 #' `README.md` up-to-date. `devtools::build_readme()` is handy for this. You
 #' could also use GitHub Actions to re-render `README.Rmd` every time you push.
 #' An example workflow can be found in the `examples/` directory here:
-#' <https://github.com/r-lib/actions/>. If git is used for the project, then
-#' a pre-commit hook is added that prevents `README.md` from being outdated due
-#' to changes in `README.Rmd`. (Modify `.git/hooks/pre-commit` to remove this
-#' check.)
+#' <https://github.com/r-lib/actions/>.
+#'
+#' If the current project is a Git repo, then `use_readme_rmd()` automatically
+#' configures a pre-commit hook that helps keep `README.Rmd` and `README.md`,
+#' synchronized. The hook creates friction if you try to commit when
+#' `README.Rmd` has been edited more recently than `README.md`. If this hook
+#' causes more problems than it solves for you, it is implemented in
+#' `.git/hooks/pre-commit`, which you can modify or even delete.
 #'
 #' @inheritParams use_template
 #' @seealso The [important files

--- a/R/readme.R
+++ b/R/readme.R
@@ -15,7 +15,10 @@
 #' `README.md` up-to-date. `devtools::build_readme()` is handy for this. You
 #' could also use GitHub Actions to re-render `README.Rmd` every time you push.
 #' An example workflow can be found in the `examples/` directory here:
-#' <https://github.com/r-lib/actions/>.
+#' <https://github.com/r-lib/actions/>. If git is used for the project, then
+#' a pre-commit hook is added that prevents `README.md` from being outdated due
+#' to changes in `README.Rmd`. (Modify `.git/hooks/pre-commit` to remove this
+#' check.)
 #'
 #' @inheritParams use_template
 #' @seealso The [important files

--- a/man/use_readme_rmd.Rd
+++ b/man/use_readme_rmd.Rd
@@ -30,7 +30,10 @@ If you use \code{Rmd}, you'll still need to render it regularly, to keep
 \code{README.md} up-to-date. \code{devtools::build_readme()} is handy for this. You
 could also use GitHub Actions to re-render \code{README.Rmd} every time you push.
 An example workflow can be found in the \verb{examples/} directory here:
-\url{https://github.com/r-lib/actions/}.
+\url{https://github.com/r-lib/actions/}. If git is used for the project, then
+a pre-commit hook is added that prevents \code{README.md} from being outdated due
+to changes in \code{README.Rmd}. (Modify \code{.git/hooks/pre-commit} to remove this
+check.)
 }
 \examples{
 \dontrun{

--- a/man/use_readme_rmd.Rd
+++ b/man/use_readme_rmd.Rd
@@ -14,9 +14,9 @@ use_readme_md(open = rlang::is_interactive())
 applicable, or via \code{\link[utils:file.edit]{utils::file.edit()}} otherwise.}
 }
 \description{
-Creates skeleton README files with sections for
+Creates skeleton README files with possible stubs for
 \itemize{
-\item a high-level description of the package and its goals
+\item a high-level description of the project/package and its goals
 \item R code to install from GitHub, if GitHub usage detected
 \item a basic example
 }
@@ -30,10 +30,14 @@ If you use \code{Rmd}, you'll still need to render it regularly, to keep
 \code{README.md} up-to-date. \code{devtools::build_readme()} is handy for this. You
 could also use GitHub Actions to re-render \code{README.Rmd} every time you push.
 An example workflow can be found in the \verb{examples/} directory here:
-\url{https://github.com/r-lib/actions/}. If git is used for the project, then
-a pre-commit hook is added that prevents \code{README.md} from being outdated due
-to changes in \code{README.Rmd}. (Modify \code{.git/hooks/pre-commit} to remove this
-check.)
+\url{https://github.com/r-lib/actions/}.
+
+If the current project is a Git repo, then \code{use_readme_rmd()} automatically
+configures a pre-commit hook that helps keep \code{README.Rmd} and \code{README.md},
+synchronized. The hook creates friction if you try to commit when
+\code{README.Rmd} has been edited more recently than \code{README.md}. If this hook
+causes more problems than it solves for you, it is implemented in
+\code{.git/hooks/pre-commit}, which you can modify or even delete.
 }
 \examples{
 \dontrun{


### PR DESCRIPTION
I have run into a couple of times where I need to undo the git hook* and I don't know how to, so this is a brief note about the pre-commit hook in use_readme_rmd() behavior.

\* e.g., the README.Rmd reads in a file for demonstration. The file changes and README.Rmd is knitted to give README.md. README.Rmd is unchanged, README.md is changed, but README.md cannot be committed because the unchanged README.Rmd is not also staged.