### PR TITLE
Improve `use_package("R", ...)` experience and add example

### DIFF
--- a/R/helpers.R
+++ b/R/helpers.R
@@ -6,10 +6,12 @@ use_dependency <- function(package, type, min_version = NULL) {
     check_installed(package)
   }
 
-  if (isTRUE(min_version)) {
+  if (isTRUE(min_version) && package == "R") {
+    min_version <- glue("{R.Version()$major}.{R.Version()$minor}")
+  } else if (isTRUE(min_version)) {
     min_version <- utils::packageVersion(package)
   }
-  version <- if (is.null(min_version)) "*" else paste0(">= ", min_version)
+  version <- if (is.null(min_version)) "*" else glue(">= {min_version}")
 
   types <- c("Depends", "Imports", "Suggests", "Enhances", "LinkingTo")
   names(types) <- tolower(types)

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -7,11 +7,13 @@ use_dependency <- function(package, type, min_version = NULL) {
   }
 
   if (package == "R" && type != "Depends") {
-    ui_stop("Specify R version requirements in Depends instead of {type}")
+    ui_stop("Set {ui_code('type = \"Depends\"')} when specifying an R version")
+  } else if (package == "R" && is.null(min_version)) {
+    ui_stop("Specify {ui_code('min_version')} when {ui_code('package = \"R\"')}")
   }
 
   if (isTRUE(min_version) && package == "R") {
-    min_version <- glue("{R.Version()$major}.{R.Version()$minor}")
+    min_version <- r_version()
   } else if (isTRUE(min_version)) {
     min_version <- utils::packageVersion(package)
   }
@@ -71,6 +73,8 @@ use_dependency <- function(package, type, min_version = NULL) {
 
   invisible(TRUE)
 }
+
+r_version <- function() glue("{R.Version()$major}.{R.Version()$minor}")
 
 use_system_requirement <- function(requirement) {
   stopifnot(is_string(requirement))

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -6,6 +6,10 @@ use_dependency <- function(package, type, min_version = NULL) {
     check_installed(package)
   }
 
+  if (package == "R" && type != "Depends") {
+    ui_stop("Specify R version requirements in Depends instead of {type}")
+  }
+
   if (isTRUE(min_version) && package == "R") {
     min_version <- glue("{R.Version()$major}.{R.Version()$minor}")
   } else if (isTRUE(min_version)) {

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -74,7 +74,10 @@ use_dependency <- function(package, type, min_version = NULL) {
   invisible(TRUE)
 }
 
-r_version <- function() glue("{R.Version()$major}.{R.Version()$minor}")
+r_version <- function() {
+  minor <- strsplit(R.Version()$minor, "\\.")[[1]][1]
+  glue("{R.Version()$major}.{minor}")
+}
 
 use_system_requirement <- function(requirement) {
   stopifnot(is_string(requirement))

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -6,7 +6,7 @@ use_dependency <- function(package, type, min_version = NULL) {
     check_installed(package)
   }
 
-  if (package == "R" && type != "Depends") {
+  if (package == "R" && tolower(type) != "depends") {
     ui_stop("Set {ui_code('type = \"Depends\"')} when specifying an R version")
   } else if (package == "R" && is.null(min_version)) {
     ui_stop("Specify {ui_code('min_version')} when {ui_code('package = \"R\"')}")
@@ -75,8 +75,8 @@ use_dependency <- function(package, type, min_version = NULL) {
 }
 
 r_version <- function() {
-  minor <- strsplit(R.Version()$minor, "\\.")[[1]][1]
-  glue("{R.Version()$major}.{minor}")
+  version <- getRversion()
+  glue("{version$major}.{version$minor}")
 }
 
 use_system_requirement <- function(requirement) {

--- a/R/package.R
+++ b/R/package.R
@@ -27,6 +27,9 @@
 #' use_package("ggplot2")
 #' use_package("dplyr", "suggests")
 #' use_dev_package("glue")
+#'
+#' # Depend on R version 4.1.0
+#' use_package("R", type = "Depends", min_version = "4.1.0")
 #' }
 use_package <- function(package, type = "Imports", min_version = NULL) {
   if (type == "Imports") {
@@ -126,6 +129,9 @@ refuse_package <- function(package, verboten) {
 how_to_use <- function(package, type) {
   types <- tolower(c("Imports", "Depends", "Suggests", "Enhances", "LinkingTo"))
   type <- match.arg(tolower(type), types)
+  if (package == "R" && type == "depends") {
+    return("")
+  }
 
   switch(type,
     imports = ui_todo("Refer to functions with {ui_code(paste0(package, '::fun()'))}"),

--- a/R/package.R
+++ b/R/package.R
@@ -28,8 +28,8 @@
 #' use_package("dplyr", "suggests")
 #' use_dev_package("glue")
 #'
-#' # Depend on R version 4.1.0
-#' use_package("R", type = "Depends", min_version = "4.1.0")
+#' # Depend on R version 4.1
+#' use_package("R", type = "Depends", min_version = "4.1")
 #' }
 use_package <- function(package, type = "Imports", min_version = NULL) {
   if (type == "Imports") {

--- a/man/use_package.Rd
+++ b/man/use_package.Rd
@@ -35,8 +35,8 @@ use_package("ggplot2")
 use_package("dplyr", "suggests")
 use_dev_package("glue")
 
-# Depend on R version 4.1.0
-use_package("R", type = "Depends", min_version = "4.1.0")
+# Depend on R version 4.1
+use_package("R", type = "Depends", min_version = "4.1")
 }
 }
 \seealso{

--- a/man/use_package.Rd
+++ b/man/use_package.Rd
@@ -34,6 +34,9 @@ it will be automatically installed from the correct location.
 use_package("ggplot2")
 use_package("dplyr", "suggests")
 use_dev_package("glue")
+
+# Depend on R version 4.1.0
+use_package("R", type = "Depends", min_version = "4.1.0")
 }
 }
 \seealso{

--- a/man/use_pkgdown.Rd
+++ b/man/use_pkgdown.Rd
@@ -13,9 +13,10 @@ use_pkgdown_github_pages()
 use_pkgdown_travis()
 }
 \arguments{
-\item{config_file}{Path to the pkgdown yaml config file}
+\item{config_file}{Path to the pkgdown yaml config file, relative to the
+project.}
 
-\item{destdir}{Target directory for pkgdown docs}
+\item{destdir}{Target directory for pkgdown docs.}
 }
 \description{
 \href{https://pkgdown.r-lib.org}{pkgdown} makes it easy to turn your package into

--- a/tests/testthat/_snaps/package.md
+++ b/tests/testthat/_snaps/package.md
@@ -45,36 +45,6 @@
     Message
       v Increasing 'R' version to '>= 4.1' in DESCRIPTION
 
----
-
-    Code
-      use_package("R")
-    Condition
-      Error:
-      ! Set `type = "Depends"` when specifying an R version
-
----
-
-    Code
-      use_package("R", type = "Depends")
-    Condition
-      Error:
-      ! Specify `min_version` when `package = "R"`
-
----
-
-    Code
-      use_package("R", type = "Depends", min_version = "3.6")
-    Message
-      v Adding 'R' to Depends field in DESCRIPTION
-
----
-
-    Code
-      use_package("R", type = "Depends", min_version = TRUE)
-    Message
-      v Increasing 'R' version to '>= 4.1' in DESCRIPTION
-
 # use_package(type = 'Suggests') guidance w/o and w/ rlang
 
     Code

--- a/tests/testthat/_snaps/package.md
+++ b/tests/testthat/_snaps/package.md
@@ -33,3 +33,33 @@
       * In your package code, use `rlang::is_installed("purrr")` or `rlang::check_installed("purrr")` to test if purrr is installed
       * Then directly refer to functions with `purrr::fun()`
 
+# use_package() handles R versions with aplomb
+
+    Code
+      use_package("R")
+    Condition
+      Error:
+      ! Set `type = "Depends"` when specifying an R version
+
+---
+
+    Code
+      use_package("R", type = "Depends")
+    Condition
+      Error:
+      ! Specify `min_version` when `package = "R"`
+
+---
+
+    Code
+      use_package("R", type = "Depends", min_version = "3.6")
+    Message
+      v Adding 'R' to Depends field in DESCRIPTION
+
+---
+
+    Code
+      use_package("R", type = "Depends", min_version = TRUE)
+    Message
+      v Increasing 'R' version to '>= 4.1' in DESCRIPTION
+

--- a/tests/testthat/test-package.R
+++ b/tests/testthat/test-package.R
@@ -40,23 +40,6 @@ test_that("use_package(type = 'Suggests') guidance w/o and w/ rlang", {
   expect_snapshot(use_package("purrr", "Suggests"))
 })
 
-test_that("use_package() handles R versions with aplomb", {
-  create_local_package()
-  withr::local_options(usethis.quiet = FALSE)
-  expect_snapshot(use_package("R"), error = TRUE)
-  expect_snapshot(use_package("R", type = "Depends"), error = TRUE)
-  expect_snapshot(use_package("R", type = "Depends", min_version = "3.6"))
-  expect_equal(subset(desc::desc_get_deps(), package == "R")$version, ">= 3.6")
-  with_mock(
-    r_version = function() "4.1",
-    {
-      expect_snapshot(use_package("R", type = "Depends", min_version = TRUE))
-    }
-  )
-
-  expect_equal(subset(desc::desc_get_deps(), package == "R")$version, ">= 4.1")
-})
-
 # use_dev_package() -----------------------------------------------------------
 
 test_that("use_dev_package() can override over default remote", {

--- a/tests/testthat/test-package.R
+++ b/tests/testthat/test-package.R
@@ -31,7 +31,7 @@ test_that("use_package() handles R versions with aplomb", {
   expect_snapshot(use_package("R", type = "Depends", min_version = "3.6"))
   expect_equal(subset(desc::desc_get_deps(), package == "R")$version, ">= 3.6")
   with_mock(
-    r_version = function() glue("4.1"),
+    r_version = function() "4.1",
     {
       expect_snapshot(use_package("R", type = "Depends", min_version = TRUE))
     }

--- a/tests/testthat/test-package.R
+++ b/tests/testthat/test-package.R
@@ -23,6 +23,23 @@ test_that("use_package(type = 'Suggests') guidance w/o and w/ rlang", {
   expect_snapshot(use_package("purrr", "Suggests"))
 })
 
+test_that("use_package() handles R versions with aplomb", {
+  create_local_package()
+  withr::local_options(usethis.quiet = FALSE)
+  expect_snapshot(use_package("R"), error = TRUE)
+  expect_snapshot(use_package("R", type = "Depends"), error = TRUE)
+  expect_snapshot(use_package("R", type = "Depends", min_version = "3.6"))
+  expect_equal(subset(desc::desc_get_deps(), package == "R")$version, ">= 3.6")
+  with_mock(
+    r_version = function() glue("4.1"),
+    {
+      expect_snapshot(use_package("R", type = "Depends", min_version = TRUE))
+    }
+  )
+
+  expect_equal(subset(desc::desc_get_deps(), package == "R")$version, ">= 4.1")
+})
+
 # use_dev_package() -----------------------------------------------------------
 
 test_that("use_dev_package() can override over default remote", {


### PR DESCRIPTION
Related to #1619, this PR smooths out the process of using `use_package()` to bump the R version dependency:
* Add an example to docs
* Don't advise against using `Depends` for `R`
* Allow `min_version = TRUE` to detect current R version 
* Require that `min_version` is set and that `type` is `Depends`