### PR TITLE
add ASCII argument to use_data

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -46,6 +46,7 @@ Imports:
     rprojroot (>= 1.2),
     rstudioapi,
     stats,
+    tools,
     utils,
     whisker,
     withr (>= 2.3.0),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # usethis (development version)
 
+`use_data()` gains an `ascii` argument, which is passed along to `save()` (@JosiahParry, #1625).
+
 `use_code_of_conduct()` has been updated to version 2.1 of the Contributor Covenant (@batpigandme, #1591).
 
 `use_github_action()` and friends gain a `ref` argument, which defaults to the tag of the latest release in <https://github.com/r-lib/actions> (#1541).

--- a/R/data.R
+++ b/R/data.R
@@ -21,7 +21,7 @@
 #' @param version The serialization format version to use. The default, 2, was
 #'   the default format from R 1.4.0 to 3.5.3. Version 3 became the default from
 #'   R 3.6.0 and can only be read by R versions 3.5.0 and higher.
-#' @param ascii Default `FALSE`. If `TRUE`, all objects will be written as an ASCII representation.
+#' @inheritParams base::save
 #'
 #' @seealso The [data chapter](https://r-pkgs.org/data.html) of [R
 #'   Packages](https://r-pkgs.org).

--- a/R/data.R
+++ b/R/data.R
@@ -21,6 +21,7 @@
 #' @param version The serialization format version to use. The default, 2, was
 #'   the default format from R 1.4.0 to 3.5.3. Version 3 became the default from
 #'   R 3.6.0 and can only be read by R versions 3.5.0 and higher.
+#' @param ascii Default `FALSE`. If `TRUE`, all objects will be written as an ASCII representation.
 #'
 #' @seealso The [data chapter](https://r-pkgs.org/data.html) of [R
 #'   Packages](https://r-pkgs.org).
@@ -37,7 +38,8 @@ use_data <- function(...,
                      internal = FALSE,
                      overwrite = FALSE,
                      compress = "bzip2",
-                     version = 2) {
+                     version = 2,
+                     ascii = FALSE) {
   check_is_package("use_data()")
 
   objs <- get_objs_from_dots(dots(...))
@@ -66,7 +68,7 @@ use_data <- function(...,
     save,
     list = objs,
     file = proj_path(paths),
-    MoreArgs = list(envir = envir, compress = compress, version = version)
+    MoreArgs = list(envir = envir, compress = compress, version = version, ascii = ascii)
   )
 
   invisible()

--- a/man/use_data.Rd
+++ b/man/use_data.Rd
@@ -10,7 +10,8 @@ use_data(
   internal = FALSE,
   overwrite = FALSE,
   compress = "bzip2",
-  version = 2
+  version = 2,
+  ascii = FALSE
 )
 
 use_data_raw(name = "DATASET", open = rlang::is_interactive())
@@ -37,6 +38,8 @@ Should be one of "gzip", "bzip2", or "xz".}
 \item{version}{The serialization format version to use. The default, 2, was
 the default format from R 1.4.0 to 3.5.3. Version 3 became the default from
 R 3.6.0 and can only be read by R versions 3.5.0 and higher.}
+
+\item{ascii}{Default \code{FALSE}. If \code{TRUE}, all objects will be written as an ASCII representation.}
 
 \item{name}{Name of the dataset to be prepared for inclusion in the package.}
 

--- a/man/use_data.Rd
+++ b/man/use_data.Rd
@@ -39,7 +39,11 @@ Should be one of "gzip", "bzip2", or "xz".}
 the default format from R 1.4.0 to 3.5.3. Version 3 became the default from
 R 3.6.0 and can only be read by R versions 3.5.0 and higher.}
 
-\item{ascii}{Default \code{FALSE}. If \code{TRUE}, all objects will be written as an ASCII representation.}
+\item{ascii}{if \code{TRUE}, an ASCII representation of the data is
+    written.  The default value of \code{ascii} is \code{FALSE} which
+    leads to a binary file being written.  If \code{NA} and
+    \code{version >= 2}, a different ASCII representation is used which
+    writes double/complex numbers as binary fractions.}
 
 \item{name}{Name of the dataset to be prepared for inclusion in the package.}
 

--- a/tests/testthat/test-data.R
+++ b/tests/testthat/test-data.R
@@ -73,6 +73,18 @@ test_that("use_data() writes version 2 by default", {
   )
 })
 
+test_that("use_data() can enforce `ascii = TRUE`", {
+  create_local_package()
+
+  x <- "h\u00EF"
+
+  use_data(x)
+  expect_false(tools::checkRdaFiles("data/x.rda")[["ASCII"]])
+
+  use_data(x, ascii = TRUE, overwrite = TRUE)
+  expect_true(tools::checkRdaFiles("data/x.rda")[["ASCII"]])
+})
+
 test_that("use_data_raw() does setup", {
   create_local_package()
   use_data_raw(open = FALSE)


### PR DESCRIPTION
This is a small pull request that closes #1625.

This PR provides the argument `ascii` to `use_data()`. By default it is set to FALSE, when true ASCII representations of the passed in objects are written. Documentation has been updated to include the new argument. 
