### PR TITLE
Fix `use_r("")` and similar

### DIFF
--- a/R/r.R
+++ b/R/r.R
@@ -183,7 +183,6 @@ check_file_name <- function(name) {
   if (!is_string(name)) {
     ui_stop("Name must be a single string")
   }
-
   if (!valid_file_name(path_ext_remove(name))) {
     ui_stop(c(
       "{ui_value(name)} is not a valid file name. It should:",

--- a/R/r.R
+++ b/R/r.R
@@ -49,10 +49,10 @@
 #'   [R Packages](https://r-pkgs.org).
 #' @export
 use_r <- function(name = NULL, open = rlang::is_interactive()) {
+  check_not_empty_file_name(name)
   name <- name %||% get_active_r_file(path = "tests/testthat")
   name <- gsub("^test-", "", name)
   name <- slug(name, "R")
-  check_not_empty_file_name(name)
   check_file_name(name)
 
   use_directory("R")

--- a/R/r.R
+++ b/R/r.R
@@ -52,6 +52,7 @@ use_r <- function(name = NULL, open = rlang::is_interactive()) {
   name <- name %||% get_active_r_file(path = "tests/testthat")
   name <- gsub("^test-", "", name)
   name <- slug(name, "R")
+  check_not_empty_file_name(name)
   check_file_name(name)
 
   use_directory("R")
@@ -72,6 +73,7 @@ use_test <- function(name = NULL, open = rlang::is_interactive()) {
     use_testthat_impl()
   }
 
+  check_not_empty_file_name(name)
   name <- name %||% get_active_r_file(path = "R")
   name <- paste0("test-", name)
   name <- slug(name, "R")
@@ -181,9 +183,7 @@ check_file_name <- function(name) {
   if (!is_string(name)) {
     ui_stop("Name must be a single string")
   }
-  if (path_file(name) %in% c(".R", "test-.R", ".cpp", ".c")) {
-    ui_stop("Name must not be an empty string")
-  }
+
   if (!valid_file_name(path_ext_remove(name))) {
     ui_stop(c(
       "{ui_value(name)} is not a valid file name. It should:",
@@ -191,6 +191,14 @@ check_file_name <- function(name) {
     ))
   }
   name
+}
+
+check_not_empty_file_name <- function(name = NULL) {
+  if (!is.null(name) && path_file(name) == "") {
+    ui_stop("Name must not be an empty string")
+  }
+
+  invisible(TRUE)
 }
 
 valid_file_name <- function(x) {

--- a/R/r.R
+++ b/R/r.R
@@ -181,6 +181,9 @@ check_file_name <- function(name) {
   if (!is_string(name)) {
     ui_stop("Name must be a single string")
   }
+  if (path_file(name) %in% c(".R", "test-.R", ".cpp", ".c")) {
+    ui_stop("Name must not be an empty string")
+  }
   if (!valid_file_name(path_ext_remove(name))) {
     ui_stop(c(
       "{ui_value(name)} is not a valid file name. It should:",

--- a/R/rcpp.R
+++ b/R/rcpp.R
@@ -19,6 +19,7 @@
 use_rcpp <- function(name = NULL) {
   check_is_package("use_rcpp()")
   check_uses_roxygen("use_rcpp()")
+  check_not_empty_file_name(name)
 
   use_src()
 
@@ -65,6 +66,7 @@ use_rcpp_eigen <- function(name = NULL) {
 use_c <- function(name = NULL) {
   check_is_package("use_c()")
   check_uses_roxygen("use_c()")
+  check_not_empty_file_name(name)
 
   use_src()
 

--- a/tests/testthat/_snaps/r.md
+++ b/tests/testthat/_snaps/r.md
@@ -1,0 +1,16 @@
+# use_r() creates a .R file below R/
+
+    Code
+      use_r("")
+    Condition
+      Error:
+      ! Name must not be an empty string
+
+# use_test() creates a test file
+
+    Code
+      use_test("", open = FALSE)
+    Condition
+      Error:
+      ! Name must not be an empty string
+

--- a/tests/testthat/_snaps/rcpp.md
+++ b/tests/testthat/_snaps/rcpp.md
@@ -1,0 +1,8 @@
+# use_rcpp() creates files/dirs, edits DESCRIPTION and .gitignore
+
+    Code
+      use_rcpp("")
+    Condition
+      Error:
+      ! Name must not be an empty string
+

--- a/tests/testthat/test-r.R
+++ b/tests/testthat/test-r.R
@@ -1,11 +1,13 @@
 test_that("use_r() creates a .R file below R/", {
   create_local_package()
+  expect_error(use_r(""), "Name must not be an empty string")
   use_r("foo")
   expect_proj_file("R/foo.R")
 })
 
 test_that("use_test() creates a test file", {
   create_local_package()
+  expect_error(use_test("", open = FALSE), "Name must not be an empty string")
   use_test("foo", open = FALSE)
   expect_proj_file("tests", "testthat", "test-foo.R")
 })

--- a/tests/testthat/test-r.R
+++ b/tests/testthat/test-r.R
@@ -1,13 +1,13 @@
 test_that("use_r() creates a .R file below R/", {
   create_local_package()
-  expect_error(use_r(""), "Name must not be an empty string")
+  expect_snapshot(use_r(""), error = TRUE)
   use_r("foo")
   expect_proj_file("R/foo.R")
 })
 
 test_that("use_test() creates a test file", {
   create_local_package()
-  expect_error(use_test("", open = FALSE), "Name must not be an empty string")
+  expect_snapshot(use_test("", open = FALSE), error = TRUE)
   use_test("foo", open = FALSE)
   expect_proj_file("tests", "testthat", "test-foo.R")
 })

--- a/tests/testthat/test-rcpp.R
+++ b/tests/testthat/test-rcpp.R
@@ -8,7 +8,7 @@ test_that("use_rcpp() creates files/dirs, edits DESCRIPTION and .gitignore", {
   use_roxygen_md()
 
   use_rcpp()
-  expect_error(use_rcpp(""), "Name must not be an empty string")
+  expect_snapshot(use_rcpp(""), error = TRUE)
   expect_match(desc::desc_get("LinkingTo", pkg), "Rcpp")
   expect_match(desc::desc_get("Imports", pkg), "Rcpp")
   expect_proj_dir("src")

--- a/tests/testthat/test-rcpp.R
+++ b/tests/testthat/test-rcpp.R
@@ -8,6 +8,7 @@ test_that("use_rcpp() creates files/dirs, edits DESCRIPTION and .gitignore", {
   use_roxygen_md()
 
   use_rcpp()
+  expect_error(use_rcpp(""), "Name must not be an empty string")
   expect_match(desc::desc_get("LinkingTo", pkg), "Rcpp")
   expect_match(desc::desc_get("Imports", pkg), "Rcpp")
   expect_proj_dir("src")


### PR DESCRIPTION
Currently, `use_r("")` creates `R/.R`, which I don't think is ever what someone wants. This PR adds a check for `use_r()` and friends to make sure the file actually has a name. 