### PR TITLE
Switch to `teardown_env()`

### DIFF
--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -1,3 +1,2 @@
-pre_test_options <- options(
-  usethis.quiet = TRUE
-)
+pre_test_options <- options(usethis.quiet = TRUE)
+withr::defer(options(pre_test_options), teardown_env())

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -1,2 +1,1 @@
-pre_test_options <- options(usethis.quiet = TRUE)
-withr::defer(options(pre_test_options), teardown_env())
+withr::local_options(usethis.quiet = TRUE, .local_envir = teardown_env())

--- a/tests/testthat/teardown.R
+++ b/tests/testthat/teardown.R
@@ -1,1 +1,0 @@
-options(pre_test_options)


### PR DESCRIPTION
A small PR that removes `teardown.R` in favor of `teardown_env()`