### PR TITLE
Overwrite file on `file_copy()`

### DIFF
--- a/R/logo.R
+++ b/R/logo.R
@@ -28,7 +28,7 @@ use_logo <- function(img, geometry = "240x278", retina = TRUE) {
 
   if (path_ext(img) == "svg") {
     logo_path <- path("man", "figures", "logo.svg")
-    file_copy(img, proj_path(logo_path))
+    file_copy(img, proj_path(logo_path), overwrite = TRUE)
     ui_done("Copied {ui_path(img)} to {ui_path(logo_path)}")
 
     height <- as.integer(sub(".*x", "", geometry))


### PR DESCRIPTION
Asking if over writing the file is allowed is performed in the first part of `use_logo()`. If approved, the destination should be overwritten.

Current error: 

```
❯❯ usethis::use_logo("logo/shinytest2.svg")
✔ Setting active project to '/Users/barret/Documents/git/rstudio/shinytest/shinytest2.nosync'
Overwrite pre-existing file 'man/figures/logo.svg'?

1: No
2: Absolutely not
3: Yeah

Selection: 3
Error: [EEXIST] Failed to copy 'logo/shinytest2.svg' to '/Users/barret/Documents/git/rstudio/shinytest/shinytest2.nosync/man/figures/logo.svg': file already exists
```

With PR (working):

```
❯❯ usethis::use_logo("logo/shinytest2.svg")
✔ Setting active project to '/Users/barret/Documents/git/rstudio/shinytest/shinytest2.nosync'
Overwrite pre-existing file 'man/figures/logo.svg'?

1: For sure
2: Negative
3: Absolutely not

Selection: 1
✔ Copied 'logo/shinytest2.svg' to 'man/figures/logo.svg'
• Add logo to your README with the following html:
  # shinytest2 <a href="https://rstudio.github.io/shinytest2/"><img src="man/figures/logo.svg" align="right" height="139" /></a>
  [Copied to clipboard]
```
