### PR TITLE
Fix issues when creating nested package

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # usethis (development version)
 
-* `create_package()` now returns the correct package path when creating a package nested in another project.
+* `create_package()` now returns the correct package path and infers the correct package name when creating a package nested in another project.
 
 # usethis 2.1.6
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # usethis (development version)
 
+* `create_package()` now returns the correct package path when creating a package nested in another project.
+
 # usethis 2.1.6
 
 ### GitHub-related

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # usethis (development version)
 
+* New informal `usethis.allow_nested_package` option. This is mostly meant for developers who create packages inside other packages, e.g. in the `testthat` folder.
+
 * `create_package()` now returns the correct package path and infers the correct package name when creating a package nested in another project.
 
 # usethis 2.1.6

--- a/R/create.R
+++ b/R/create.R
@@ -312,23 +312,26 @@ create_from_github <- function(repo_spec,
 }
 
 # creates a backdoor we can exploit in tests
-allow_nested_project <- function() {
+allow_nested_project <- function(call = caller_env()) {
   opt <- getOption("usethis.allow_nested_package", FALSE)
 
   if (!is_bool(opt)) {
-    cli::cli_abort("{.code usethis.allow_nested_package} must be a boolean value.")
+    cli::cli_abort(
+      "{.code usethis.allow_nested_package} must be a boolean value.",
+      call = call
+    )
   }
 
   opt
 }
 
-challenge_nested_project <- function(path, name) {
+challenge_nested_project <- function(path, name, call = caller_env()) {
   if (!possibly_in_proj(path)) {
     return(invisible())
   }
 
   # we mock this in a few tests, to allow a nested project
-  if (allow_nested_project()) {
+  if (allow_nested_project(call = call)) {
     return()
   }
 

--- a/R/create.R
+++ b/R/create.R
@@ -51,7 +51,11 @@ create_package <- function(path,
   local_project(path, force = TRUE)
 
   use_directory("R")
-  use_description(fields, check_name = FALSE, roxygen = roxygen)
+
+  with_options(
+    "usethis:::local_package_name" = name,
+    use_description(fields, check_name = FALSE, roxygen = roxygen)
+  )
   use_namespace(roxygen = roxygen)
 
   if (rstudio) {

--- a/R/create.R
+++ b/R/create.R
@@ -312,7 +312,15 @@ create_from_github <- function(repo_spec,
 }
 
 # creates a backdoor we can exploit in tests
-allow_nested_project <- function() FALSE
+allow_nested_project <- function() {
+  opt <- getOption("usethis.allow_nested_package", FALSE)
+
+  if (!is_bool(opt)) {
+    cli::cli_abort("{.code usethis.allow_nested_package} must be a boolean value.")
+  }
+
+  opt
+}
 
 challenge_nested_project <- function(path, name) {
   if (!possibly_in_proj(path)) {

--- a/R/proj.R
+++ b/R/proj.R
@@ -233,12 +233,13 @@ package_data <- function(base_path = proj_get()) {
 }
 
 project_name <- function(base_path = proj_get()) {
-  ## escape hatch necessary to solve this chicken-egg problem:
+  ## Escape hatch necessary to solve this chicken-egg problem:
   ## create_package() calls use_description(), which calls project_name()
   ## to learn package name from the path, in order to make DESCRIPTION
   ## and DESCRIPTION is how we recognize a package as a usethis project
-  if (!possibly_in_proj(base_path)) {
-    return(path_file(base_path))
+  escape_hatch <- getOption("usethis:::local_package_name")
+  if (is_string(escape_hatch)) {
+    return(escape_hatch)
   }
 
   if (is_package(base_path)) {

--- a/R/proj.R
+++ b/R/proj.R
@@ -69,10 +69,6 @@ proj_get <- function() {
 #'   adding a `DESCRIPTION` file.
 #' @export
 proj_set <- function(path = ".", force = FALSE) {
-  if (dir_exists(path %||% "") && is_in_proj(path)) {
-    return(invisible(proj_get_()))
-  }
-
   path <- proj_path_prep(path)
   if (is.null(path) || force) {
     proj_string <- if (is.null(path)) "<no active project>" else path

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -134,3 +134,10 @@ test_file <- function(fname) testthat::test_path("ref", fname)
 
 expect_proj_file <- function(...) expect_true(file_exists(proj_path(...)))
 expect_proj_dir <- function(...) expect_true(dir_exists(proj_path(...)))
+
+with_allow_nested_package <- function(expr) {
+  with_options(
+    usethis.allow_nested_package = TRUE,
+    expr
+  )
+}

--- a/tests/testthat/test-create.R
+++ b/tests/testthat/test-create.R
@@ -37,11 +37,15 @@ test_that("nested project is disallowed, by default", {
 
 test_that("nested package can be created if user really, really wants to", {
   parent <- create_local_package()
+  child_path <- path(parent, "fghijk")
+
   with_mock(
     # since user can't approve interactively, use the backdoor
     allow_nested_project = function() TRUE,
-    child <- create_package(path(parent, "fghijk"))
+    child <- create_package(child_path)
   )
+
+  expect_equal(child, child_path)
   expect_true(possibly_in_proj(child))
   expect_true(is_package(child))
 })

--- a/tests/testthat/test-create.R
+++ b/tests/testthat/test-create.R
@@ -48,6 +48,7 @@ test_that("nested package can be created if user really, really wants to", {
   expect_equal(child, child_path)
   expect_true(possibly_in_proj(child))
   expect_true(is_package(child))
+  expect_equal(project_name(child), "fghijk")
 })
 
 test_that("nested project can be created if user really, really wants to", {

--- a/tests/testthat/test-create.R
+++ b/tests/testthat/test-create.R
@@ -39,9 +39,8 @@ test_that("nested package can be created if user really, really wants to", {
   parent <- create_local_package()
   child_path <- path(parent, "fghijk")
 
-  with_mock(
-    # since user can't approve interactively, use the backdoor
-    allow_nested_project = function() TRUE,
+  # Since user can't approve interactively, use the backdoor
+  with_allow_nested_package(
     child <- create_package(child_path)
   )
 
@@ -53,9 +52,8 @@ test_that("nested package can be created if user really, really wants to", {
 
 test_that("nested project can be created if user really, really wants to", {
   parent <- create_local_project()
-  with_mock(
-    # since user can't approve interactively, use the backdoor
-    allow_nested_project = function() TRUE,
+  # Since user can't approve interactively, use the backdoor
+  with_allow_nested_package(
     child <- create_project(path(parent, "fghijk"))
   )
   expect_true(possibly_in_proj(child))


### PR DESCRIPTION
I would like to optimise the creation of packages in the `testthat` folder when I work on packages like pkgload. This PR fixes two bugs:

- Fix the escape hatch in `project_name()` so that it works in nested packages. Currently if I create a package in `pkgload/testthat/tests` the nested package is named `pkgload`. A subsequent `load_all()` inside that package then overwrites pkgload itself with the empty package, which causes puzzling errors.

- Remove the early exit in `proj_set()` to allow `local_project()` to set a nested project. This didn't break any tests and seems like this would prevent other bugs when working with nested packages. We could find a more localised workaround for `create_package()` though.

The PR also adds an undocumented global option `usethis.allow_nested_package` to disable the user challenge.