### PR TITLE
Rationalize nested projects

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # usethis (development version)
 
+* Although nested projects are discouraged, they can be useful in development contexts. `create_package()` now sets the correct package name and returns the correct package path for a package nested inside a project (#1647). 
+
 # usethis 2.1.6
 
 ### GitHub-related

--- a/R/create.R
+++ b/R/create.R
@@ -307,17 +307,15 @@ create_from_github <- function(repo_spec,
   invisible(proj_get())
 }
 
-# creates a backdoor we can exploit in tests
-allow_nested_project <- function() FALSE
-
 challenge_nested_project <- function(path, name) {
   if (!possibly_in_proj(path)) {
     return(invisible())
   }
 
-  # we mock this in a few tests, to allow a nested project
-  if (allow_nested_project()) {
-    return()
+  # creates an undocumented backdoor we can exploit when the interactive
+  # approval is impractical, e.g. in tests
+  if (isTRUE(getOption("usethis.allow_nested_package", FALSE))) {
+    return(invisible())
   }
 
   ui_line(

--- a/R/create.R
+++ b/R/create.R
@@ -51,7 +51,7 @@ create_package <- function(path,
   local_project(path, force = TRUE)
 
   use_directory("R")
-  use_description(fields, check_name = FALSE, roxygen = roxygen)
+  use_description_impl_(name, fields, roxygen)
   use_namespace(roxygen = roxygen)
 
   if (rstudio) {

--- a/R/description.R
+++ b/R/description.R
@@ -65,6 +65,10 @@ use_description <- function(fields = list(),
     check_package_name(name)
   }
 
+  use_description_impl_(name = name, fields = fields, roxygen = roxygen)
+}
+
+use_description_impl_ <- function(name, fields = list(), roxygen = TRUE) {
   desc <- build_description(name, roxygen = roxygen, fields = fields)
 
   tf <- withr::local_tempfile(pattern = glue("use_description-{name}-"))

--- a/R/proj.R
+++ b/R/proj.R
@@ -69,7 +69,7 @@ proj_get <- function() {
 #'   adding a `DESCRIPTION` file.
 #' @export
 proj_set <- function(path = ".", force = FALSE) {
-  if (dir_exists(path %||% "") && is_in_proj(path)) {
+  if (!force && dir_exists(path %||% "") && is_in_proj(path)) {
     return(invisible(proj_get_()))
   }
 

--- a/tests/testthat/test-create.R
+++ b/tests/testthat/test-create.R
@@ -38,13 +38,11 @@ test_that("nested project is disallowed, by default", {
 test_that("nested package can be created if user really, really wants to", {
   parent <- create_local_package()
   child_path <- path(parent, "fghijk")
-  with_mock(
-    # since user can't approve interactively, use the backdoor
-    allow_nested_project = function() TRUE,
-    {
-      child_result <- create_package(child_path)
-    }
-  )
+
+  # since user can't approve interactively, use the backdoor
+  withr::local_options("usethis.allow_nested_package" = TRUE)
+
+  child_result <- create_package(child_path)
 
   expect_equal(child_path, child_result)
   expect_true(possibly_in_proj(child_path))
@@ -55,13 +53,12 @@ test_that("nested package can be created if user really, really wants to", {
 test_that("nested project can be created if user really, really wants to", {
   parent <- create_local_project()
   child_path <- path(parent, "fghijk")
-  with_mock(
-    # since user can't approve interactively, use the backdoor
-    allow_nested_project = function() TRUE,
-    {
-      child_result <- create_project(child_path)
-    }
-  )
+
+  # since user can't approve interactively, use the backdoor
+  withr::local_options("usethis.allow_nested_package" = TRUE)
+
+  child_result <- create_project(child_path)
+
   expect_equal(child_path, child_result)
   expect_true(possibly_in_proj(child_path))
   expect_equal(project_name(child_path), "fghijk")

--- a/tests/testthat/test-create.R
+++ b/tests/testthat/test-create.R
@@ -37,28 +37,34 @@ test_that("nested project is disallowed, by default", {
 
 test_that("nested package can be created if user really, really wants to", {
   parent <- create_local_package()
+  child_path <- path(parent, "fghijk")
   with_mock(
     # since user can't approve interactively, use the backdoor
     allow_nested_project = function() TRUE,
     {
-      child <- create_package(path(parent, "fghijk"))
+      child_result <- create_package(child_path)
     }
   )
-  expect_true(possibly_in_proj(child))
-  expect_true(is_package(child))
+
+  expect_equal(child_path, child_result)
+  expect_true(possibly_in_proj(child_path))
+  expect_true(is_package(child_path))
+  expect_equal(project_name(child_path), "fghijk")
 })
 
 test_that("nested project can be created if user really, really wants to", {
   parent <- create_local_project()
+  child_path <- path(parent, "fghijk")
   with_mock(
     # since user can't approve interactively, use the backdoor
     allow_nested_project = function() TRUE,
     {
-      child <- create_project(path(parent, "fghijk"))
+      child_result <- create_project(child_path)
     }
   )
-  expect_true(possibly_in_proj(child))
-  expect_false(is_package(child))
+  expect_equal(child_path, child_result)
+  expect_true(possibly_in_proj(child_path))
+  expect_equal(project_name(child_path), "fghijk")
 })
 
 test_that("can create package in current directory (literally in '.')", {


### PR DESCRIPTION
Closes #1643

We discourage nested projects, but it is possible, mostly for developers. So we should at least behave correctly in this code path.

Previously, a nested project would put the name of the parent project in DESCRIPTION, which causes a variety of downstream problems. The `.Rproj` file gets the wrong name. Every call to `project_name()` returns the wrong name.

Also, when `proj_set(force = TRUE)`, we should bypass the initial early return if we discover that we are already in a project. The whole point of `force = TRUE` is to do exactly as we are told. This was causing the active project to be still be set to the parent, when trying to work with a nested project.