### PR TITLE
Better defaults for use_latest_dependencies()

### DIFF
--- a/R/latest-dependencies.R
+++ b/R/latest-dependencies.R
@@ -5,10 +5,11 @@
 #'
 #' @keywords internal
 #' @export
-#' @param overwrite By default (`FALSE`), only dependencies without version
-#'   specifications will be modified. Set to `TRUE` to modify all dependencies.
+#' @param overwrite By default (`TRUE`), all dependencies will be modified.
+#'   Set to `FALSE` to only modify dependencies without version
+#'   specifications.
 #' @param source Use "local" or "CRAN" package versions.
-use_latest_dependencies <- function(overwrite = FALSE, source = c("local", "CRAN")) {
+use_latest_dependencies <- function(overwrite = TRUE, source = c("CRAN"," local")) {
   deps <- desc::desc_get_deps(proj_get())
   deps <- update_versions(deps, overwrite = overwrite, source = source)
   desc::desc_set_deps(deps, file = proj_get())

--- a/man/use_latest_dependencies.Rd
+++ b/man/use_latest_dependencies.Rd
@@ -4,11 +4,12 @@
 \alias{use_latest_dependencies}
 \title{Use "latest" versions of all dependencies}
 \usage{
-use_latest_dependencies(overwrite = FALSE, source = c("local", "CRAN"))
+use_latest_dependencies(overwrite = TRUE, source = c("CRAN", " local"))
 }
 \arguments{
-\item{overwrite}{By default (\code{FALSE}), only dependencies without version
-specifications will be modified. Set to \code{TRUE} to modify all dependencies.}
+\item{overwrite}{By default (\code{TRUE}), all dependencies will be modified.
+Set to \code{FALSE} to only modify dependencies without version
+specifications.}
 
 \item{source}{Use "local" or "CRAN" package versions.}
 }


### PR DESCRIPTION
I doubt anyone uses this apart from me, and I have to remember to change these arguments every time.