### PR TITLE
remove usethis.protocol  = "ssh" from example .Rprofile options

### DIFF
--- a/vignettes/articles/usethis-setup.Rmd
+++ b/vignettes/articles/usethis-setup.Rmd
@@ -82,7 +82,6 @@ Define any of these options in your `.Rprofile`, which can be opened for editing
 ```{r, eval = FALSE}
 options(
   usethis.full_name = "Jane Doe",
-  usethis.protocol  = "ssh",
   usethis.description = list(
     "Authors@R" = utils::person(
         "Jane", "Doe",


### PR DESCRIPTION
Per discussion on R packages 2e https://github.com/hadley/r-pkgs/issues/854