### PR TITLE
Refactor `use_vignette()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # usethis (development version)
 
+* `use_article()` no longer adds the rmarkdown package to `Suggests`. Instead,
+  if rmarkdown is not already a dependency, it's added to
+  `Config/Needs/website`. This means that a package that only uses articles
+  (vs. vignettes) won't gain an unnecessary dependency on rmarkdown (#1700).
+
 * `use_rstudio()` gains a `reformat` argument which omits `.Rproj` settings 
   that enforce file formatting conventions, e.g. around whitespace.   
   `create_from_github()` uses this option when it introduces an `.Rproj` to a 

--- a/R/vignette.R
+++ b/R/vignette.R
@@ -56,12 +56,11 @@ use_vignette_template <- function(template, name, title, subdir = NULL) {
   use_git_ignore(c("*.html", "*.R"), directory = "vignettes")
   use_dependency("rmarkdown", "Suggests")
 
-  if (!is.null(subdir)) {
-    path <- path("vignettes", subdir, asciify(name), ext = "Rmd")
-  } else {
+  if (is.null(subdir)) {
     path <- path("vignettes", asciify(name), ext = "Rmd")
+  } else {
+    path <- path("vignettes", subdir, asciify(name), ext = "Rmd")
   }
-
 
   data <- list(
     Package = project_name(),

--- a/R/vignette.R
+++ b/R/vignette.R
@@ -26,6 +26,8 @@ use_vignette <- function(name, title = name) {
   check_vignette_name(name)
 
   use_dependency("knitr", "Suggests")
+  use_dependency("rmarkdown", "Suggests")
+
   use_description_field("VignetteBuilder", "knitr", overwrite = TRUE)
   use_git_ignore("inst/doc")
 
@@ -38,6 +40,13 @@ use_vignette <- function(name, title = name) {
 #' @rdname use_vignette
 use_article <- function(name, title = name) {
   check_is_package("use_article()")
+
+  deps <- desc::desc_get_deps(proj_get())
+  if (!"rmarkdown" %in% deps$package) {
+    ui_done("
+      Adding {ui_value('rmarkdown')} to {ui_field('Config/Needs/website')}")
+    use_description_list("Config/Needs/website", "rmarkdown")
+  }
 
   use_vignette_template("article.Rmd", name, title, subdir = "articles")
   use_build_ignore("vignettes/articles")
@@ -54,7 +63,6 @@ use_vignette_template <- function(template, name, title, subdir = NULL) {
     use_directory(path("vignettes", subdir))
   }
   use_git_ignore(c("*.html", "*.R"), directory = "vignettes")
-  use_dependency("rmarkdown", "Suggests")
 
   if (is.null(subdir)) {
     path <- path("vignettes", asciify(name), ext = "Rmd")

--- a/tests/testthat/test-vignette.R
+++ b/tests/testthat/test-vignette.R
@@ -44,6 +44,24 @@ test_that("use_article goes in article subdirectory", {
   expect_proj_file("vignettes/articles/test.Rmd")
 })
 
+test_that("use_article() adds rmarkdown to Config/Needs/website", {
+  create_local_package()
+  local_interactive(FALSE)
+
+  with_mock(
+    can_overwrite = function(path) TRUE,
+    {
+      use_description_list("Config/Needs/website", "somepackage")
+      use_article("name", "title")
+    }
+  )
+
+  expect_setequal(
+    desc::desc_get_list("Config/Needs/website", proj_get()),
+    c("rmarkdown", "somepackage")
+  )
+})
+
 # helpers -----------------------------------------------------------------
 
 test_that("valid_vignette_name() works", {


### PR DESCRIPTION
Motivated by experiments made while updating R Packages

Basically I found it confusing that knitr was added to `DESCRIPTION` early on and then ... later ... rmarkdown was added.

I can't think of any reason why we had it this way and looking through git blame didn't shed any light either.

This seems more obvious and obviously correct to me.

---

BEFORE

``` r
> use_vignette("my-vignette")
✔ Adding 'knitr' to Suggests field in DESCRIPTION
✔ Setting VignetteBuilder field in DESCRIPTION to 'knitr'
✔ Adding 'inst/doc' to '.gitignore'
✔ Creating 'vignettes/'
✔ Adding '*.html', '*.R' to 'vignettes/.gitignore'
✔ Adding 'rmarkdown' to Suggests field in DESCRIPTION
✔ Writing 'vignettes/my-vignette.Rmd'
• Modify 'vignettes/my-vignette.Rmd'
```

AFTER

``` r
> use_vignette("my-vignette")
✔ Adding 'knitr' to Suggests field in DESCRIPTION
✔ Adding 'rmarkdown' to Suggests field in DESCRIPTION
✔ Setting VignetteBuilder field in DESCRIPTION to 'knitr'
✔ Adding 'inst/doc' to '.gitignore'
✔ Creating 'vignettes/'
✔ Adding '*.html', '*.R' to 'vignettes/.gitignore'
✔ Writing 'vignettes/my-vignette.Rmd'
• Modify 'vignettes/my-vignette.Rmd'
```