### PR TITLE
Documentation readability edits.

### DIFF
--- a/R/create.R
+++ b/R/create.R
@@ -22,7 +22,7 @@
 #'   [rprojroot](https://rprojroot.r-lib.org) packages.
 #' @param open If `TRUE`, [activates][proj_activate()] the new project:
 #'
-#'   * If RStudio desktop, the package is opened in a new session.
+#'   * If using RStudio desktop, the package is opened in a new session.
 #'   * If on RStudio server, the current RStudio project is activated.
 #'   * Otherwise, the working directory and active project is changed.
 #'
@@ -111,7 +111,7 @@ create_project <- function(path,
 #' [fork-and-cloning](https://docs.github.com/en/get-started/quickstart/fork-a-repo).
 #' In the fork-and-clone case, `create_from_github()` also does additional
 #' remote and branch setup, leaving you in the perfect position to make a pull
-#' request with [pr_init()], one of several [functions that work pull
+#' request with [pr_init()], one of several [functions for working with pull
 #' requests][pull-requests].
 #'
 #' `create_from_github()` works best when your GitHub credentials are
@@ -138,7 +138,7 @@ create_project <- function(path,
 #'   also a project and Git repo.
 #' @inheritParams use_course
 #' @param fork If `FALSE`, we clone `repo_spec`. If `TRUE`, we fork
-#'   `repo_spec`, clone that fork, and do additional set up favorable for
+#'   `repo_spec`, clone that fork, and do additional setup favorable for
 #'   future pull requests:
 #'   * The source repo, `repo_spec`, is configured as the `upstream` remote,
 #'   using the indicated `protocol`.

--- a/R/git.R
+++ b/R/git.R
@@ -31,7 +31,7 @@ use_git <- function(message = "Initial commit") {
 
 #' Add a git hook
 #'
-#' Sets up a git hook using specified script. Creates hook directory if
+#' Sets up a git hook using the specified script. Creates a hook directory if
 #' needed, and sets correct permissions on hook.
 #'
 #' @param hook Hook name. One of "pre-commit", "prepare-commit-msg",
@@ -323,8 +323,7 @@ git_clean <- function() {
 #' Git/GitHub sitrep
 #'
 #' Get a situation report on your current Git/GitHub status. Useful for
-#' diagnosing problems. [git_vaccinate()] adds some basic R- and RStudio-related
-#' entries to the user-level git ignore file.
+#' diagnosing problems.
 #' @export
 #' @examples
 #' \dontrun{

--- a/man/create_from_github.Rd
+++ b/man/create_from_github.Rd
@@ -36,7 +36,7 @@ location using the option \code{usethis.destdir}, e.g.
 \code{.Rprofile} with \code{\link[=edit_r_profile]{edit_r_profile()}}}
 
 \item{fork}{If \code{FALSE}, we clone \code{repo_spec}. If \code{TRUE}, we fork
-\code{repo_spec}, clone that fork, and do additional set up favorable for
+\code{repo_spec}, clone that fork, and do additional setup favorable for
 future pull requests:
 \itemize{
 \item The source repo, \code{repo_spec}, is configured as the \code{upstream} remote,
@@ -57,7 +57,7 @@ the cloned repo may already be an RStudio Project, i.e. may already have a
 
 \item{open}{If \code{TRUE}, \link[=proj_activate]{activates} the new project:
 \itemize{
-\item If RStudio desktop, the package is opened in a new session.
+\item If using RStudio desktop, the package is opened in a new session.
 \item If on RStudio server, the current RStudio project is activated.
 \item Otherwise, the working directory and active project is changed.
 }}
@@ -85,7 +85,7 @@ GitHub, by either cloning or
 \href{https://docs.github.com/en/get-started/quickstart/fork-a-repo}{fork-and-cloning}.
 In the fork-and-clone case, \code{create_from_github()} also does additional
 remote and branch setup, leaving you in the perfect position to make a pull
-request with \code{\link[=pr_init]{pr_init()}}, one of several \link[=pull-requests]{functions that work pull requests}.
+request with \code{\link[=pr_init]{pr_init()}}, one of several \link[=pull-requests]{functions for working with pull requests}.
 
 \code{create_from_github()} works best when your GitHub credentials are
 discoverable. See below for more about authentication.

--- a/man/create_package.Rd
+++ b/man/create_package.Rd
@@ -42,7 +42,7 @@ error if not.}
 
 \item{open}{If \code{TRUE}, \link[=proj_activate]{activates} the new project:
 \itemize{
-\item If RStudio desktop, the package is opened in a new session.
+\item If using RStudio desktop, the package is opened in a new session.
 \item If on RStudio server, the current RStudio project is activated.
 \item Otherwise, the working directory and active project is changed.
 }}

--- a/man/git_sitrep.Rd
+++ b/man/git_sitrep.Rd
@@ -8,8 +8,7 @@ git_sitrep()
 }
 \description{
 Get a situation report on your current Git/GitHub status. Useful for
-diagnosing problems. \code{\link[=git_vaccinate]{git_vaccinate()}} adds some basic R- and RStudio-related
-entries to the user-level git ignore file.
+diagnosing problems.
 }
 \examples{
 \dontrun{

--- a/man/use_git_hook.Rd
+++ b/man/use_git_hook.Rd
@@ -15,7 +15,7 @@ use_git_hook(hook, script)
 \item{script}{Text of script to run}
 }
 \description{
-Sets up a git hook using specified script. Creates hook directory if
+Sets up a git hook using the specified script. Creates a hook directory if
 needed, and sets correct permissions on hook.
 }
 \seealso{


### PR DESCRIPTION
We're reading all of the usethis docs "cover to cover" in a new "book club" at R4DS. These are some tweaks I noticed while reading the Configuration and Git & GitHub sections. I didn't re-document, since I *think* that happens automatically.

I removed the git_vaccinate() reference in git_sitrep help, because I *think* it's left over from them previously living in the same doc.