### PR TITLE
main as init branch for use_git()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # usethis (development version)
 
+* `use_git()` now initializes with branch 'main' (#1711). 
+
 * `use_article()` no longer adds the rmarkdown package to `Suggests`. Instead,
   if rmarkdown is not already a dependency, it's added to
   `Config/Needs/website`. This means that a package that only uses articles

--- a/R/utils-git.R
+++ b/R/utils-git.R
@@ -116,7 +116,7 @@ git_ask_commit <- function(message, untracked, paths = NULL) {
     gert::git_commit(message, repo = repo)
     current_branch <- git_branch()
     if (current_branch == "master") {
-      git_default_branch_rename(git_branch(), to = "main")
+      git_default_branch_rename(current_branch, to = "main")
     }
   }
 

--- a/R/utils-git.R
+++ b/R/utils-git.R
@@ -114,6 +114,10 @@ git_ask_commit <- function(message, untracked, paths = NULL) {
     gert::git_add(paths, repo = repo)
     ui_done("Making a commit with message {ui_value(message)}")
     gert::git_commit(message, repo = repo)
+    current_branch <- git_branch()
+    if (current_branch == "master") {
+      git_default_branch_rename(git_branch(), to = "main")
+    }
   }
 
   uncommitted <- git_status(untracked)$file


### PR DESCRIPTION
This ensures that the branch created when using `use_git()` is 'main'.   Fixes #1711 

This is done by renaming the default branch from 'master' to 'main' in `git_ask_commit()`, and so is 
limited to interactive mode


(I can't see how to test it other than interactively, because of how `git_ask_commit()` works).  