### PR TITLE
Don't mention GHA for README-rendering in README templates

### DIFF
--- a/inst/templates/package-README
+++ b/inst/templates/package-README
@@ -60,7 +60,7 @@ What is special about using `README.Rmd` instead of just `README.md`? You can in
 summary(cars)
 ```
 
-You'll still need to render `README.Rmd` regularly, to keep `README.md` up-to-date. `devtools::build_readme()` is handy for this. You could also use GitHub Actions to re-render `README.Rmd` every time you push. An example workflow can be found here: <https://github.com/r-lib/actions/tree/v1/examples>.
+You'll still need to render `README.Rmd` regularly, to keep `README.md` up-to-date. `devtools::build_readme()` is handy for this.
 
 You can also embed plots, for example:
 

--- a/inst/templates/project-README
+++ b/inst/templates/project-README
@@ -27,7 +27,7 @@ What is special about using `README.Rmd` instead of just `README.md`? You can in
 summary(cars)
 ```
 
-You'll still need to render `README.Rmd` regularly, to keep `README.md` up-to-date. `devtools::build_readme()` is handy for this. You could also use GitHub Actions to re-render `README.Rmd` every time you push. An example workflow can be found here: <https://github.com/r-lib/actions/tree/v1/examples>.
+You'll still need to render `README.Rmd` regularly, to keep `README.md` up-to-date.
 
 You can also embed plots, for example:
 

--- a/tests/testthat/_snaps/readme.md
+++ b/tests/testthat/_snaps/readme.md
@@ -111,7 +111,7 @@
       summary(cars)
       ```
       
-      You'll still need to render `README.Rmd` regularly, to keep `README.md` up-to-date. `devtools::build_readme()` is handy for this. You could also use GitHub Actions to re-render `README.Rmd` every time you push. An example workflow can be found here: <https://github.com/r-lib/actions/tree/v1/examples>.
+      You'll still need to render `README.Rmd` regularly, to keep `README.md` up-to-date. `devtools::build_readme()` is handy for this.
       
       You can also embed plots, for example:
       
@@ -172,7 +172,7 @@
       summary(cars)
       ```
       
-      You'll still need to render `README.Rmd` regularly, to keep `README.md` up-to-date. `devtools::build_readme()` is handy for this. You could also use GitHub Actions to re-render `README.Rmd` every time you push. An example workflow can be found here: <https://github.com/r-lib/actions/tree/v1/examples>.
+      You'll still need to render `README.Rmd` regularly, to keep `README.md` up-to-date. `devtools::build_readme()` is handy for this.
       
       You can also embed plots, for example:
       


### PR DESCRIPTION
Inspired by R Package 2e revision. We don't actually wire this up in our own repos, so I think we should get it out of the templates. Streamlining content for the majority is always good. The GHA/CI keeners are always able to use the GHA example for rendering an `.Rmd`, if they are so motivated.