### PR TITLE
handle case where user-email not set

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,7 +3,7 @@
 * `git_sitrep()` gains two arguments: `tool` and `scope`, which enables 
   you to limit the report to, for example, `tool = "git"` or `scope = "user"`.
   The default remains to provide a full report. Also, provides more
-  feedback if git user-email is not set. (@ijlyttle, #1714, #1706).
+  feedback if git user's information is not set. (@ijlyttle, #1714, #1706).
   
 * `use_article()` no longer adds the rmarkdown package to `Suggests`. Instead,
   if rmarkdown is not already a dependency, it's added to

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,8 +2,9 @@
 
 * `git_sitrep()` gains two arguments: `tool` and `scope`, which enables 
   you to limit the report to, for example, `tool = "git"` or `scope = "user"`.
-  The default remains to provide a full report (@ijlyttle #1714).
-
+  The default remains to provide a full report. Also, provides more
+  feedback if git user-email is not set. (@ijlyttle, #1714, #1706).
+  
 * `use_article()` no longer adds the rmarkdown package to `Suggests`. Instead,
   if rmarkdown is not already a dependency, it's added to
   `Config/Needs/website`. This means that a package that only uses articles

--- a/R/git.R
+++ b/R/git.R
@@ -435,8 +435,7 @@ git_sitrep <- function(tool = c("git", "github"),
 git_user_sitrep <- function(scope = c("user", "project")) {
   scope <- match.arg(scope)
 
-  where_scope <- c(user = "global", project = "de_facto")
-  where <- where_scope[scope]
+  where <- where_from_scope(scope)
 
   user <- git_user_get(where)
   user_local <- git_user_get("local")
@@ -448,6 +447,12 @@ git_user_sitrep <- function(scope = c("user", "project")) {
   kv_line("Name", user$name)
   kv_line("Email", user$email)
 
+  git_user_check(user)
+
+  invisible(NULL)
+}
+
+git_user_check <- function(user) {
   if (all(map_lgl(user, is.null))) {
     hint <-
       'use_git_config(user.name = "<your name>", user.email = "<your email>")`'
@@ -466,8 +471,6 @@ git_user_sitrep <- function(scope = c("user", "project")) {
     hint <- 'use_git_config(user.email = "<your email>")`'
     ui_oops("Git user's email is not set. Configure using {ui_code(hint)}.")
   }
-
-  invisible(NULL)
 }
 
 # TODO: when I really overhaul the UI, determine if I can just re-use the

--- a/R/git.R
+++ b/R/git.R
@@ -433,7 +433,7 @@ git_sitrep <- function(tool = c("git", "github"),
 }
 
 git_user_sitrep <- function(scope = c("user", "project")) {
-  scope <- match.arg(scope)
+  scope <- rlang::arg_match(scope)
 
   where <- where_from_scope(scope)
 

--- a/R/git.R
+++ b/R/git.R
@@ -455,7 +455,7 @@ git_user_sitrep <- function(scope = c("user", "project")) {
 git_user_check <- function(user) {
   if (all(map_lgl(user, is.null))) {
     hint <-
-      'use_git_config(user.name = "<your name>", user.email = "<your email>")`'
+      'use_git_config(user.name = "<your name>", user.email = "<your email>")'
     ui_oops(
       "Git user's name and email are not set. Configure using {ui_code(hint)}."
     )
@@ -463,12 +463,12 @@ git_user_check <- function(user) {
   }
 
   if (is.null(user$name)) {
-    hint <- 'use_git_config(user.name = "<your name>")`'
+    hint <- 'use_git_config(user.name = "<your name>")'
     ui_oops("Git user's name is not set. Configure using {ui_code(hint)}.")
   }
 
   if (is.null(user$email)) {
-    hint <- 'use_git_config(user.email = "<your email>")`'
+    hint <- 'use_git_config(user.email = "<your email>")'
     ui_oops("Git user's email is not set. Configure using {ui_code(hint)}.")
   }
 }

--- a/R/github_token.R
+++ b/R/github_token.R
@@ -179,16 +179,12 @@ pat_sitrep <- function(host = "https://github.com",
     )
     kv_line("Email(s)", addresses)
     ui_silence(
-      de_facto_email <- git_cfg_get("user.email", "de_facto")
+      user <- git_user_get("de_facto")
     )
-    if (is.null(de_facto_email)) {
-      hint <- "use_git_config(user.email = \"<your email>\")"
-      ui_oops("Git user's email is not set. Configure using {ui_code(hint)}.")
-      return(invisible(FALSE))
-    }
-    if (!any(grepl(de_facto_email, addresses))) {
+    git_user_check(user)
+    if (!any(grepl(user$email, addresses))) {
       ui_oops("
-        Local Git user's email ({ui_value(de_facto_email)}) doesn't appear to \\
+        Local Git user's email ({ui_value(user$email)}) doesn't appear to \\
         be registered with GitHub host.")
     }
   }

--- a/R/github_token.R
+++ b/R/github_token.R
@@ -182,7 +182,7 @@ pat_sitrep <- function(host = "https://github.com",
       user <- git_user_get("de_facto")
     )
     git_user_check(user)
-    if (!any(grepl(user$email, addresses))) {
+    if (!is.null(user$email) && !any(grepl(user$email, addresses))) {
       ui_oops("
         Local Git user's email ({ui_value(user$email)}) doesn't appear to \\
         be registered with GitHub host.")

--- a/R/github_token.R
+++ b/R/github_token.R
@@ -181,6 +181,11 @@ pat_sitrep <- function(host = "https://github.com",
     ui_silence(
       de_facto_email <- git_cfg_get("user.email", "de_facto")
     )
+    if (is.null(de_facto_email)) {
+      hint <- "use_git_config(user.email = \"<your email>\")"
+      ui_oops("Git user's email is not set. Configure using {ui_code(hint)}.")
+      return(invisible(FALSE))
+    }
     if (!any(grepl(de_facto_email, addresses))) {
       ui_oops("
         Local Git user's email ({ui_value(de_facto_email)}) doesn't appear to \\

--- a/R/utils-git.R
+++ b/R/utils-git.R
@@ -71,6 +71,16 @@ git_cfg_get <- function(name, where = c("de_facto", "local", "global")) {
   if (length(out) > 0) out else NULL
 }
 
+# more-specific case for user-name and -email
+git_user_get <- function(where = c("de_facto", "local", "global")) {
+  where <- match.arg(where)
+
+  list(
+    name = git_cfg_get("user.name", where),
+    email = git_cfg_get("user.email", where)
+  )
+}
+
 # ensures that core.excludesFile is configured
 # if configured, leave well enough alone
 # if not, check for existence of one of the Usual Suspects; if found, configure

--- a/R/utils-git.R
+++ b/R/utils-git.R
@@ -81,6 +81,15 @@ git_user_get <- function(where = c("de_facto", "local", "global")) {
   )
 }
 
+# translate from "usethis" terminology to "git" terminology
+where_from_scope <- function(scope = c("user", "project")) {
+  scope = match.arg(scope)
+
+  where_scope <- c(user = "global", project = "de_facto")
+
+  where_scope[scope]
+}
+
 # ensures that core.excludesFile is configured
 # if configured, leave well enough alone
 # if not, check for existence of one of the Usual Suspects; if found, configure
@@ -106,7 +115,6 @@ ensure_core_excludesFile <- function() {
   gert::git_config_global_set("core.excludesFile", path)
   invisible()
 }
-
 
 # Status------------------------------------------------------------------------
 git_status <- function(untracked) {

--- a/tests/manual/manual-git-sitrep.R
+++ b/tests/manual/manual-git-sitrep.R
@@ -1,0 +1,40 @@
+# capturing some manual tests re: detecting missing user email or name
+# https://github.com/r-lib/usethis/pull/1721
+
+dat <- gert::git_config_global()
+if ("user.name" %in% dat$name) {
+  old_name <- dat$value[dat$name == "user.name"]
+  usethis::use_git_config(user.name = NULL)
+  withr::defer(usethis::use_git_config(user.name = old_name))
+}
+if ("user.email" %in% dat$name) {
+  old_email <- dat$value[dat$name == "user.email"]
+  usethis::use_git_config(user.email = NULL)
+  withr::defer(usethis::use_git_config(user.email = old_email))
+}
+usethis::git_sitrep(scope = "user")
+usethis::git_sitrep(scope = "project")
+usethis::git_sitrep()
+withr::deferred_run()
+
+dat <- gert::git_config_global()
+if ("user.name" %in% dat$name) {
+  old_name <- dat[dat$name == "user.name",]$value
+  usethis::use_git_config(user.name = NULL)
+  withr::defer(usethis::use_git_config(user.name = old_name))
+}
+usethis::git_sitrep(scope = "user")
+usethis::git_sitrep(scope = "project")
+usethis::git_sitrep()
+withr::deferred_run()
+
+dat <- gert::git_config_global()
+if ("user.email" %in% dat$name) {
+  old_email <- dat[dat$name == "user.email",]$value
+  usethis::use_git_config(user.email = NULL)
+  withr::defer(usethis::use_git_config(user.email = old_email))
+}
+usethis::git_sitrep(scope = "user")
+usethis::git_sitrep(scope = "project")
+usethis::git_sitrep()
+withr::deferred_run()


### PR DESCRIPTION
fix #1706

While `git_sitrep()` was still loaded into my brain, I thought to take a swing at this. Given that `git_sitrep()` can be run in bits-and-pieces, I thought the feedback should be proximate to where the error was happening.

Following @jonthegeek's reprex:

``` r
dat <- gert::git_config_global()
if ("user.email" %in% dat$name) {
  old_email <- dat[dat$name == "user.email",]$value
  usethis::use_git_config(user.email = NULL)
}
usethis::git_sitrep(scope = "user")
#> 
#> ── Git global (user)
#> • Name: 'Ian Lyttle'
#> • Email: <unset>
#> • Global (user-level) gitignore file: '~/.gitignore'
#> • Vaccinated: TRUE
#> ℹ Defaulting to 'https' Git protocol
#> • Default Git protocol: 'https'
#> • Default initial branch name: 'main'
#> 
#> 
#> ── GitHub user 
#> 
#> • Default GitHub host: 'https://github.com'
#> • Personal access token for 'https://github.com': '<discovered>'
#> • GitHub user: 'ijlyttle'
#> • Token scopes: 'gist, repo, user, workflow'
#> • Email(s): 'ijlyttle@me.com (primary)', 'ijlyttle@users.noreply.github.com', 'ian.lyttle@<work>.com'
#> ✖ Git user's email is not set. Configure using `use_git_config(user.email = "<your email>")`.

if ("user.email" %in% dat$name) {
  usethis::use_git_config(user.email = old_email)
}
```

<sup>Created on 2023-01-11 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup> 

I thought to combine the news item with the other work, but that may be the wrong choice.

Thanks!