### PR TITLE
Refactor get_active_file()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,14 @@
 # usethis (development version)
 
+* `use_r()` and `use_test()` now work with all active files in `R/`, `src/`, 
+  and `tests/testthat/` (#1566).
+
+* `use_r()` and `use_test()` now work with files containing `.` (#1690).
+
+* `use_rcpp()`, `use_c()` and friends now work the same way as `use_r()` and
+  `use_test()`: they'll take the default file name from the file you currently
+  have open in RStudio.
+
 * `git_sitrep()` gains two arguments: `tool` and `scope`, which enables 
   you to limit the report to, for example, `tool = "git"` or `scope = "user"`.
   The default remains to provide a full report (@ijlyttle #1714).

--- a/R/r.R
+++ b/R/r.R
@@ -49,7 +49,7 @@ use_r <- function(name = NULL, open = rlang::is_interactive()) {
   use_directory("R")
 
   path <- path("R", compute_name(name))
-  edit_file(path, open = open)
+  edit_file(proj_path(path), open = open)
 
   invisible(TRUE)
 }
@@ -65,7 +65,7 @@ use_test <- function(name = NULL, open = rlang::is_interactive()) {
   if (!file_exists(path)) {
     use_template("test-example-2.1.R", save_as = path)
   }
-  edit_file(path, open = open)
+  edit_file(proj_path(path), open = open)
 
   invisible(TRUE)
 }

--- a/R/r.R
+++ b/R/r.R
@@ -205,13 +205,13 @@ compute_active_name <- function(path, ext, error_call = caller_env()) {
   ## R's notion of user's home directory
   path <- proj_path_prep(path_expand_r(path))
 
-  rel_path <- path_dir(proj_rel_path(path))
-  if (!rel_path %in% c("R", "src", "tests/testthat")) {
+  dir <- path_dir(proj_rel_path(path))
+  if (!dir %in% c("R", "src", "tests/testthat")) {
     cli::cli_abort("Open file must be a code or test file.", call = error_call)
   }
 
   file <- path_file(path)
-  if (rel_path == "tests/testthat") {
+  if (dir == "tests/testthat") {
     file <- gsub("^test[-_]", "", file)
   }
   as.character(path_ext_set(file, ext))

--- a/R/r.R
+++ b/R/r.R
@@ -38,30 +38,18 @@
 #'
 #' The [rename_files()] function can also be helpful.
 #'
-#' @param name Either a name without extension, or `NULL` to create the
-#'   paired file based on currently open file in the script editor. If
-#'   the `R/` file is open, `use_test()` will create/open the corresponding
-#'   test file; if the test file is open, `use_r()` will create/open the
-#'   corresponding `R/` file.
+#' @param name Either a string giving a file name (without directory) or
+#'   `NULL` to take the name from the currently open file in RStudio.
 #' @inheritParams edit_file
 #' @seealso The [testing](https://r-pkgs.org/tests.html) and
 #'   [R code](https://r-pkgs.org/r.html) chapters of
 #'   [R Packages](https://r-pkgs.org).
 #' @export
 use_r <- function(name = NULL, open = rlang::is_interactive()) {
-  check_not_empty_file_name(name)
-  name <- name %||% get_active_r_file(path = "tests/testthat")
-  name <- gsub("^test-", "", name)
-  name <- slug(name, "R")
-  check_file_name(name)
-
   use_directory("R")
-  edit_file(proj_path("R", name), open = open)
 
-  test_path <- proj_path("tests", "testthat", paste0("test-", name, ".R"))
-  if (!file_exists(test_path)) {
-    ui_todo("Call {ui_code('use_test()')} to create a matching test file")
-  }
+  path <- path("R", compute_name(name))
+  edit_file(path, open = open)
 
   invisible(TRUE)
 }
@@ -73,18 +61,13 @@ use_test <- function(name = NULL, open = rlang::is_interactive()) {
     use_testthat_impl()
   }
 
-  check_not_empty_file_name(name)
-  name <- name %||% get_active_r_file(path = "R")
-  name <- paste0("test-", name)
-  name <- slug(name, "R")
-  check_file_name(name)
-
-  path <- path("tests", "testthat", name)
+  path <- path("tests", "testthat", paste0("test-", compute_name(name)))
   if (!file_exists(path)) {
-    use_template("test-example-2.1.R", save_as = path, open = FALSE)
+    use_template("test-example-2.1.R", save_as = path)
   }
+  edit_file(path, open = open)
 
-  edit_file(proj_path(path), open = open)
+  invisible(TRUE)
 }
 
 #' Automatically rename paired `R/` and `test/` files
@@ -179,62 +162,89 @@ rename_files <- function(old, new) {
 
 # helpers -----------------------------------------------------------------
 
-check_file_name <- function(name) {
-  if (!is_string(name)) {
-    ui_stop("Name must be a single string")
+compute_name <- function(name = NULL, ext = "R", error_call = caller_env()) {
+  if (!is.null(name)) {
+    check_file_name(name, call = error_call)
+
+    if (path_ext(name) == "") {
+      name <- path_ext_set(name, ext)
+    } else if (path_ext(name) != "R") {
+      cli::cli_abort(
+        "{.arg name} must have extension {.str {ext}}, not {.str {path_ext(name)}}.",
+        call = error_call
+      )
+    }
+    return(as.character(name))
   }
-  if (!valid_file_name(path_ext_remove(name))) {
-    ui_stop(c(
-      "{ui_value(name)} is not a valid file name. It should:",
-      "* Contain only ASCII letters, numbers, '-', and '_'."
-    ))
+
+  if (!rstudio_available()) {
+    cli::cli_abort(
+      "{.arg name} is absent but must be specified.",
+      call = error_call
+    )
   }
-  name
+  compute_active_name(
+    path = rstudioapi::getSourceEditorContext()$path,
+    ext = ext,
+    error_call = error_call
+  )
 }
 
-check_not_empty_file_name <- function(name = NULL) {
-  if (!is.null(name) && path_file(name) == "") {
-    ui_stop("Name must not be an empty string")
+compute_active_name <- function(path, ext, error_call = caller_env()) {
+  if (is.null(path)) {
+    cli::cli_abort(
+      c(
+        "No file is open in RStudio.",
+        i = "Please specify {.arg name}."
+      ),
+      call = error_call
+    )
   }
 
-  invisible(TRUE)
+  ## rstudioapi can return a path like '~/path/to/file' where '~' means
+  ## R's notion of user's home directory
+  path <- proj_path_prep(path_expand_r(path))
+
+  rel_path <- path_dir(proj_rel_path(path))
+  if (!rel_path %in% c("R", "src", "tests/testthat")) {
+    cli::cli_abort("Open file must be a code or test file.", call = error_call)
+  }
+
+  file <- path_file(path)
+  if (rel_path == "tests/testthat") {
+    file <- gsub("^test[-_]", "", file)
+  }
+  as.character(path_ext_set(file, ext))
+}
+
+check_file_name <- function(name, call = caller_env()) {
+  if (!is_string(name)) {
+    cli::cli_abort("{.arg name} must be a single string", call = call)
+  }
+
+  if (name == "") {
+    cli::cli_abort("{.arg name} must not be an empty string", call = call)
+  }
+
+  if (path_dir(name) != ".") {
+    cli::cli_abort(
+      "{.arg name} must be a file name without directory.",
+      call = call
+    )
+  }
+
+  if (!valid_file_name(path_ext_remove(name))) {
+    cli::cli_abort(
+      c(
+        "{.arg name} ({.str {name}}) must be a valid file name.",
+        i = "A valid file name consists of only ASCII letters, numbers, '-', and '_'."
+      ),
+      call = call
+    )
+  }
 }
 
 valid_file_name <- function(x) {
   grepl("^[a-zA-Z0-9._-]+$", x)
 }
 
-get_active_r_file <- function(path = "R") {
-  if (!rstudio_available()) {
-    ui_stop("Argument {ui_code('name')} must be specified.")
-  }
-
-  active_file <- rstudioapi::getSourceEditorContext()$path
-  if (is.null(active_file)) {
-    ui_stop(
-      "No file is active in the editor and argument {ui_code('name')} \\
-       is unspecified.")
-  }
-
-  ## rstudioapi can return a path like '~/path/to/file' where '~' means
-  ## R's notion of user's home directory
-  active_file <- proj_path_prep(path_expand_r(active_file))
-
-  rel_path <- proj_rel_path(active_file)
-  if (path_dir(rel_path) != path) {
-    ui_stop(c(
-      "Open file must be in the {ui_path(path)} directory of the active package.",
-      "  * Actual path: {ui_path(rel_path)}"
-    ))
-  }
-
-  ext <- path_ext(active_file)
-  if (toupper(ext) != "R") {
-    ui_stop(
-      "Open file must have {ui_value('.R')} or {ui_value('.r')} as extension,\\
-      not {ui_value(ext)}."
-    )
-  }
-
-  path_file(active_file)
-}

--- a/R/rcpp.R
+++ b/R/rcpp.R
@@ -6,28 +6,20 @@
 #'   * May create an initial placeholder `.c` or `.cpp` file
 #'   * Creates `Makevars` and `Makevars.win` files (`use_rcpp_armadillo()` only)
 #'
-#' @param name If supplied, creates and opens `src/name.{c,cpp}`.
-#'
-#' @details
-#'
-#' When using compiled code, please note that there must be at least one file
-#' inside the `src/` directory prior to building the package. As a result,
-#' if an empty `src/` directory is detected, either a `.c` or `.cpp` file will
-#' be added.
-#'
+#' @inheritParams use_r
 #' @export
 use_rcpp <- function(name = NULL) {
   check_is_package("use_rcpp()")
   check_uses_roxygen("use_rcpp()")
-  check_not_empty_file_name(name)
-
-  use_src()
 
   use_dependency("Rcpp", "LinkingTo")
   use_dependency("Rcpp", "Imports")
   roxygen_ns_append("@importFrom Rcpp sourceCpp") && roxygen_remind()
 
-  use_src_example_script(name, "cpp")
+  use_src()
+  path <- path("src", compute_name(name, "cpp"))
+  use_template("code.cpp", path)
+  edit_file(path)
 
   invisible()
 }
@@ -66,11 +58,12 @@ use_rcpp_eigen <- function(name = NULL) {
 use_c <- function(name = NULL) {
   check_is_package("use_c()")
   check_uses_roxygen("use_c()")
-  check_not_empty_file_name(name)
 
   use_src()
 
-  use_src_example_script(name, "c")
+  path <- path("src", compute_name(name, ext = "c"))
+  use_template("code.c", path)
+  edit_file(path)
 
   invisible(TRUE)
 }
@@ -109,23 +102,5 @@ use_makevars <- function(settings = NULL) {
     )
     edit_file(makevars_path)
     edit_file(makevars_win_path)
-  }
-}
-
-use_src_example_script <- function(name = NULL, src_type = c("cpp", "c")) {
-  src_type <- match.arg(src_type)
-
-  if (!directory_has_files(path("src"))) {
-    name <- name %||% "code"
-  }
-
-  if (!is.null(name)) {
-    name <- slug(name, src_type)
-    check_file_name(name)
-    use_template(
-      slug("code", src_type),
-      path("src", name),
-      open = is_interactive()
-    )
   }
 }

--- a/R/rcpp.R
+++ b/R/rcpp.R
@@ -19,7 +19,7 @@ use_rcpp <- function(name = NULL) {
   use_src()
   path <- path("src", compute_name(name, "cpp"))
   use_template("code.cpp", path)
-  edit_file(path)
+  edit_file(proj_path(path))
 
   invisible()
 }
@@ -63,7 +63,7 @@ use_c <- function(name = NULL) {
 
   path <- path("src", compute_name(name, ext = "c"))
   use_template("code.c", path)
-  edit_file(path)
+  edit_file(proj_path(path))
 
   invisible(TRUE)
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -44,13 +44,6 @@ asciify <- function(x) {
   gsub("[^a-zA-Z0-9_-]+", "-", x)
 }
 
-slug <- function(x, ext) {
-  x_base <- path_ext_remove(x)
-  x_ext <- path_ext(x)
-  ext <- if (identical(tolower(x_ext), tolower(ext))) x_ext else ext
-  as.character(path_ext_set(x_base, ext))
-}
-
 compact <- function(x) {
   is_empty <- vapply(x, function(x) length(x) == 0, logical(1))
   x[!is_empty]

--- a/man/use_r.Rd
+++ b/man/use_r.Rd
@@ -10,11 +10,8 @@ use_r(name = NULL, open = rlang::is_interactive())
 use_test(name = NULL, open = rlang::is_interactive())
 }
 \arguments{
-\item{name}{Either a name without extension, or \code{NULL} to create the
-paired file based on currently open file in the script editor. If
-the \verb{R/} file is open, \code{use_test()} will create/open the corresponding
-test file; if the test file is open, \code{use_r()} will create/open the
-corresponding \verb{R/} file.}
+\item{name}{Either a string giving a file name (without directory) or
+\code{NULL} to take the name from the currently open file in RStudio.}
 
 \item{open}{Whether to open the file for interactive editing.}
 }

--- a/man/use_rcpp.Rd
+++ b/man/use_rcpp.Rd
@@ -16,7 +16,8 @@ use_rcpp_eigen(name = NULL)
 use_c(name = NULL)
 }
 \arguments{
-\item{name}{If supplied, creates and opens \verb{src/name.\{c,cpp\}}.}
+\item{name}{Either a string giving a file name (without directory) or
+\code{NULL} to take the name from the currently open file in RStudio.}
 }
 \description{
 Adds infrastructure commonly needed when using compiled code:
@@ -26,10 +27,4 @@ Adds infrastructure commonly needed when using compiled code:
 \item May create an initial placeholder \code{.c} or \code{.cpp} file
 \item Creates \code{Makevars} and \code{Makevars.win} files (\code{use_rcpp_armadillo()} only)
 }
-}
-\details{
-When using compiled code, please note that there must be at least one file
-inside the \verb{src/} directory prior to building the package. As a result,
-if an empty \verb{src/} directory is detected, either a \code{.c} or \code{.cpp} file will
-be added.
 }

--- a/tests/testthat/_snaps/r.md
+++ b/tests/testthat/_snaps/r.md
@@ -1,16 +1,54 @@
-# use_r() creates a .R file below R/
+# compute_name() errors if no RStudio
 
     Code
-      use_r("")
+      compute_name()
     Condition
       Error:
-      ! Name must not be an empty string
+      ! `name` is absent but must be specified.
 
-# use_test() creates a test file
+# compute_name() validates its inputs
 
     Code
-      use_test("", open = FALSE)
+      compute_name("foo.c")
     Condition
       Error:
-      ! Name must not be an empty string
+      ! `name` must have extension "R", not "c".
+    Code
+      compute_name("R/foo.c")
+    Condition
+      Error:
+      ! `name` must be a file name without directory.
+    Code
+      compute_name(c("a", "b"))
+    Condition
+      Error:
+      ! `name` must be a single string
+    Code
+      compute_name("")
+    Condition
+      Error:
+      ! `name` must not be an empty string
+    Code
+      compute_name("****")
+    Condition
+      Error:
+      ! `name` ("****") must be a valid file name.
+      i A valid file name consists of only ASCII letters, numbers, '-', and '_'.
+
+# compute_active_name() errors if no files open
+
+    Code
+      compute_active_name(NULL)
+    Condition
+      Error:
+      ! No file is open in RStudio.
+      i Please specify `name`.
+
+# compute_active_name() checks directory
+
+    Code
+      compute_active_name("foo/bar.R")
+    Condition
+      Error:
+      ! Open file must be a code or test file.
 

--- a/tests/testthat/_snaps/rcpp.md
+++ b/tests/testthat/_snaps/rcpp.md
@@ -1,8 +1,0 @@
-# use_rcpp() creates files/dirs, edits DESCRIPTION and .gitignore
-
-    Code
-      use_rcpp("")
-    Condition
-      Error:
-      ! Name must not be an empty string
-

--- a/tests/testthat/test-r.R
+++ b/tests/testthat/test-r.R
@@ -1,13 +1,11 @@
 test_that("use_r() creates a .R file below R/", {
   create_local_package()
-  expect_snapshot(use_r(""), error = TRUE)
   use_r("foo")
   expect_proj_file("R/foo.R")
 })
 
 test_that("use_test() creates a test file", {
   create_local_package()
-  expect_snapshot(use_test("", open = FALSE), error = TRUE)
   use_test("foo", open = FALSE)
   expect_proj_file("tests", "testthat", "test-foo.R")
 })
@@ -72,6 +70,53 @@ test_that("rename paths in test file", {
 
 # helpers -----------------------------------------------------------------
 
-test_that("check_file_name() requires single string", {
-  expect_usethis_error(check_file_name(c("a", "b")), "single string")
+test_that("compute_name() errors if no RStudio", {
+  mockr::local_mock(rstudio_available = function(...) FALSE)
+  expect_snapshot(compute_name(), error = TRUE)
+})
+
+test_that("compute_name() sets extension if missing", {
+  expect_equal(compute_name("foo"), "foo.R")
+})
+
+test_that("compute_name() validates its inputs", {
+  expect_snapshot(error = TRUE, {
+    compute_name("foo.c")
+    compute_name("R/foo.c")
+    compute_name(c("a", "b"))
+    compute_name("")
+    compute_name("****")
+  })
+})
+
+test_that("compute_active_name() errors if no files open", {
+  expect_snapshot(compute_active_name(NULL), error = TRUE)
+})
+
+test_that("compute_active_name() checks directory", {
+  expect_snapshot(compute_active_name("foo/bar.R"), error = TRUE)
+})
+
+test_that("compute_active_name() standardises name", {
+  dir <- create_local_project()
+
+  expect_equal(
+    compute_active_name(path(dir, "R/bar.R"), "c"),
+    "bar.c"
+  )
+  expect_equal(
+    compute_active_name(path(dir, "src/bar.cpp"), "R"),
+    "bar.R"
+  )
+  expect_equal(
+    compute_active_name(path(dir, "tests/testthat/test-bar.R"), "R"),
+    "bar.R"
+  )
+
+  # https://github.com/r-lib/usethis/issues/1690
+  expect_equal(
+    compute_active_name(path(dir, "R/data.frame.R"), "R"),
+    "data.frame.R"
+  )
+
 })

--- a/tests/testthat/test-rcpp.R
+++ b/tests/testthat/test-rcpp.R
@@ -7,11 +7,11 @@ test_that("use_rcpp() creates files/dirs, edits DESCRIPTION and .gitignore", {
   pkg <- create_local_package()
   use_roxygen_md()
 
-  use_rcpp()
-  expect_snapshot(use_rcpp(""), error = TRUE)
+  use_rcpp("test")
   expect_match(desc::desc_get("LinkingTo", pkg), "Rcpp")
   expect_match(desc::desc_get("Imports", pkg), "Rcpp")
   expect_proj_dir("src")
+  expect_proj_file("src", "test.cpp")
 
   ignores <- read_utf8(proj_path("src", ".gitignore"))
   expect_true(all(c("*.o", "*.so", "*.dll") %in% ignores))
@@ -22,13 +22,11 @@ test_that("use_rcpp_armadillo() creates Makevars files and edits DESCRIPTION", {
   use_roxygen_md()
 
   local_interactive(FALSE)
-  with_mock(
-    # Required to pass the check re: whether RcppArmadillo is installed
-    check_installed = function(pkg) TRUE,
-    {
-      use_rcpp_armadillo()
-    }
-  )
+  # pretend RcppArmadillo is installed
+  mockr::local_mock(check_installed = function(pkg) TRUE)
+
+  use_rcpp_armadillo("code")
+  expect_proj_file("src", "code.cpp")
   expect_match(desc::desc_get("LinkingTo"), "RcppArmadillo")
   expect_proj_file("src", "Makevars")
   expect_proj_file("src", "Makevars.win")
@@ -38,13 +36,10 @@ test_that("use_rcpp_eigen() edits DESCRIPTION", {
   create_local_package()
   use_roxygen_md()
 
-  with_mock(
-    # Required to pass the check re: whether RcppEigen is installed
-    check_installed = function(pkg) TRUE,
-    {
-      use_rcpp_eigen()
-    }
-  )
+  # pretend RcppArmadillo is installed
+  mockr::local_mock(check_installed = function(pkg) TRUE)
+  use_rcpp_eigen("code")
+  expect_proj_file("src", "code.cpp")
   expect_match(desc::desc_get("LinkingTo"), "RcppEigen")
 })
 

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -11,13 +11,6 @@ test_that("asciify() substitutes non-ASCII but respects case", {
   expect_identical(asciify("aB!d$F+_h"), "aB-d-F-_h")
 })
 
-test_that("slug() sets file extension, iff 'ext' not aleady the extension", {
-  expect_equal(slug("abc", "R"), "abc.R")
-  expect_equal(slug("abc.R", "R"), "abc.R")
-  expect_equal(slug("abc.r", "R"), "abc.r")
-  expect_equal(slug("abc.R", "txt"), "abc.txt")
-})
-
 test_that("path_first_existing() works", {
   create_local_project()
 


### PR DESCRIPTION
* Make it much broader so it now works with any file in `R/`, `src/` or `tests/testthat`. Fixes #1566
* This new foundation made it possible to make `use_c()` and `use_rcpp()` (and friends) to work the same way as `use_r()`/use_test()`.
* Since I was in here I fixed #1690.
* I also refactored the code to make it easier to test.
* I switched the errors I touch to use `cli::cli_abort()` so the messaging can point to the correct user facing function.
* I generally refactored the error handling so it happens in one central location.