### PR TITLE
Don't update suggested dependencies

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # usethis (development version)
 
+* `use_latest_dependencies()` no longer affects `Suggests` since those
+  dependencies are not enforced (#1749).
+
 * `use_release_issue()` will now remind you to check/close the milestone
   corresponding to the release, if it exists (#1642).
 

--- a/R/latest-dependencies.R
+++ b/R/latest-dependencies.R
@@ -1,7 +1,8 @@
 #' Use "latest" versions of all dependencies
 #'
-#' Pins minimum versions of dependencies to latest ones (as determined by `source`).
-#' Useful for the tidyverse package, but should otherwise be used with extreme care.
+#' Pins minimum versions of all `Import` and `Depends` dependencies to latest
+#' ones (as determined by `source`). Useful for the tidyverse package, but
+#' should otherwise be used with extreme care.
 #'
 #' @keywords internal
 #' @export
@@ -27,7 +28,7 @@ use_latest_dependencies <- function(overwrite = TRUE, source = c("CRAN", "local"
 
 update_versions <- function(deps, overwrite = TRUE, source = c("CRAN", "local")) {
   baserec <- base_and_recommended()
-  to_change <- !deps$package %in% c("R", baserec)
+  to_change <- !deps$package %in% c("R", baserec) & deps$type != "Suggests"
   if (!overwrite) {
     to_change <- to_change & deps$version == "*"
   }

--- a/R/latest-dependencies.R
+++ b/R/latest-dependencies.R
@@ -1,6 +1,6 @@
 #' Use "latest" versions of all dependencies
 #'
-#' Pins minimum versions of all `Import` and `Depends` dependencies to latest
+#' Pins minimum versions of all `Imports` and `Depends` dependencies to latest
 #' ones (as determined by `source`). Useful for the tidyverse package, but
 #' should otherwise be used with extreme care.
 #'

--- a/man/use_latest_dependencies.Rd
+++ b/man/use_latest_dependencies.Rd
@@ -14,7 +14,8 @@ specifications.}
 \item{source}{Use "CRAN" or "local" package versions.}
 }
 \description{
-Pins minimum versions of dependencies to latest ones (as determined by \code{source}).
-Useful for the tidyverse package, but should otherwise be used with extreme care.
+Pins minimum versions of all \code{Import} and \code{Depends} dependencies to latest
+ones (as determined by \code{source}). Useful for the tidyverse package, but
+should otherwise be used with extreme care.
 }
 \keyword{internal}

--- a/man/use_latest_dependencies.Rd
+++ b/man/use_latest_dependencies.Rd
@@ -14,7 +14,7 @@ specifications.}
 \item{source}{Use "CRAN" or "local" package versions.}
 }
 \description{
-Pins minimum versions of all \code{Import} and \code{Depends} dependencies to latest
+Pins minimum versions of all \code{Imports} and \code{Depends} dependencies to latest
 ones (as determined by \code{source}). Useful for the tidyverse package, but
 should otherwise be used with extreme care.
 }

--- a/tests/testthat/test-latest-dependencies.R
+++ b/tests/testthat/test-latest-dependencies.R
@@ -2,15 +2,27 @@ test_that("use_tidy_versions() specifies a version for dependencies", {
   skip_on_cran()
   withr::local_options(list(repos = c(CRAN = "https://cloud.r-project.org")))
 
-  pkg <- create_local_package()
+  create_local_package()
   use_package("usethis")
   use_package("desc")
-  use_package("withr", "Suggests")
-  use_package("gh", "Suggests")
   use_latest_dependencies()
-  desc <- read_utf8(proj_path("DESCRIPTION"))
-  desc <- grep("usethis|desc|withr|gh", desc, value = TRUE)
-  expect_true(all(grepl("\\(>= [0-9.]+\\)", desc)))
+
+  deps <- proj_deps()
+  expect_equal(
+    deps$version[deps$package %in% c("usethis", "desc")] == "*",
+    c(FALSE, FALSE)
+  )
+})
+
+test_that("use_tidy_versions() doesn't affect suggests", {
+  skip_on_cran()
+  withr::local_options(list(repos = c(CRAN = "https://cloud.r-project.org")))
+
+  create_local_package()
+  use_package("cli", "Suggests")
+
+  deps <- proj_deps()
+  expect_equal(deps$version[deps$package == "cli"], "*")
 })
 
 test_that("use_tidy_versions() does nothing for a base package", {
@@ -18,11 +30,11 @@ test_that("use_tidy_versions() does nothing for a base package", {
   withr::local_options(list(repos = c(CRAN = "https://cloud.r-project.org")))
 
   ## if we ever depend on a recommended package, could beef up this test a bit
-  pkg <- create_local_package()
+  create_local_package()
   use_package("tools")
-  use_package("stats", "Suggests")
   use_latest_dependencies()
-  desc <- read_utf8(proj_path("DESCRIPTION"))
-  desc <- grep("tools|stats", desc, value = TRUE)
-  expect_false(any(grepl("\\(>= [0-9.]+\\)", desc)))
+
+  deps <- proj_deps()
+  expect_equal(deps$version[deps$package == "tools"], "*")
 })
+

--- a/tests/testthat/test-latest-dependencies.R
+++ b/tests/testthat/test-latest-dependencies.R
@@ -20,6 +20,7 @@ test_that("use_tidy_versions() doesn't affect suggests", {
 
   create_local_package()
   use_package("cli", "Suggests")
+  use_latest_dependencies()
 
   deps <- proj_deps()
   expect_equal(deps$version[deps$package == "cli"], "*")

--- a/tests/testthat/test-latest-dependencies.R
+++ b/tests/testthat/test-latest-dependencies.R
@@ -31,14 +31,11 @@ test_that("does nothing for a base package", {
   withr::local_options(list(repos = c(CRAN = "https://cloud.r-project.org")))
 
   create_local_package()
-  use_package("tools") # base
-  use_package("Matrix") # recommended
+  use_package("tools")
+  # if usethis ever depends on a recommended package, we could test that here too
   use_latest_dependencies()
 
   deps <- proj_deps()
-  expect_equal(
-    deps$version[deps$package %in% c("tools", "Matrix")],
-    c("*", "*")
-  )
+  expect_equal(deps$version[deps$package == "tools"], "*")
 })
 

--- a/tests/testthat/test-latest-dependencies.R
+++ b/tests/testthat/test-latest-dependencies.R
@@ -1,10 +1,10 @@
-test_that("use_tidy_versions() specifies a version for dependencies", {
+test_that("sets version for imports & depends dependencies", {
   skip_on_cran()
   withr::local_options(list(repos = c(CRAN = "https://cloud.r-project.org")))
 
   create_local_package()
   use_package("usethis")
-  use_package("desc")
+  use_package("desc", "Depends")
   use_latest_dependencies()
 
   deps <- proj_deps()
@@ -14,7 +14,7 @@ test_that("use_tidy_versions() specifies a version for dependencies", {
   )
 })
 
-test_that("use_tidy_versions() doesn't affect suggests", {
+test_that("doesn't affect suggests", {
   skip_on_cran()
   withr::local_options(list(repos = c(CRAN = "https://cloud.r-project.org")))
 
@@ -26,16 +26,19 @@ test_that("use_tidy_versions() doesn't affect suggests", {
   expect_equal(deps$version[deps$package == "cli"], "*")
 })
 
-test_that("use_tidy_versions() does nothing for a base package", {
+test_that("does nothing for a base package", {
   skip_on_cran()
   withr::local_options(list(repos = c(CRAN = "https://cloud.r-project.org")))
 
-  ## if we ever depend on a recommended package, could beef up this test a bit
   create_local_package()
-  use_package("tools")
+  use_package("tools") # base
+  use_package("Matrix") # recommended
   use_latest_dependencies()
 
   deps <- proj_deps()
-  expect_equal(deps$version[deps$package == "tools"], "*")
+  expect_equal(
+    deps$version[deps$package %in% c("tools", "Matrix")],
+    c("*", "*")
+  )
 })
 


### PR DESCRIPTION
Fixes #1749

Also a nice opportunity to use the new `proj_deps()` helper in the tests.