### PR TITLE
Set a flag to always tidy the description

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,28 +1,19 @@
 Package: usethis
 Title: Automate Package and Project Setup
 Version: 2.1.6.9000
-Authors@R: 
-    c(person(given = "Hadley",
-             family = "Wickham",
-             role = "aut",
-             email = "hadley@rstudio.com",
-             comment = c(ORCID = "0000-0003-4757-117X")),
-      person(given = "Jennifer",
-             family = "Bryan",
-             role = c("aut", "cre"),
-             email = "jenny@rstudio.com",
-             comment = c(ORCID = "0000-0002-6983-2759")),
-      person(given = "Malcolm",
-             family = "Barrett",
-             role = "aut",
-             email = "malcolmbarrett@gmail.com",
-             comment = c(ORCID = "0000-0003-0299-5825")),
-      person(given = "RStudio",
-             role = c("cph", "fnd")))
-Description: Automate package and project setup tasks that are
-    otherwise performed manually. This includes setting up unit testing,
-    test coverage, continuous integration, Git, 'GitHub', licenses,
-    'Rcpp', 'RStudio' projects, and more.
+Authors@R: c(
+    person("Hadley", "Wickham", , "hadley@rstudio.com", role = "aut",
+           comment = c(ORCID = "0000-0003-4757-117X")),
+    person("Jennifer", "Bryan", , "jenny@rstudio.com", role = c("aut", "cre"),
+           comment = c(ORCID = "0000-0002-6983-2759")),
+    person("Malcolm", "Barrett", , "malcolmbarrett@gmail.com", role = "aut",
+           comment = c(ORCID = "0000-0003-0299-5825")),
+    person("RStudio", role = c("cph", "fnd"))
+  )
+Description: Automate package and project setup tasks that are otherwise
+    performed manually. This includes setting up unit testing, test
+    coverage, continuous integration, Git, 'GitHub', licenses, 'Rcpp',
+    'RStudio' projects, and more.
 License: MIT + file LICENSE
 URL: https://usethis.r-lib.org, https://github.com/r-lib/usethis
 BugReports: https://github.com/r-lib/usethis/issues
@@ -61,10 +52,9 @@ Suggests:
     spelling (>= 1.2),
     styler (>= 1.2.0),
     testthat (>= 3.1.5)
-Config/Needs/website:
-    tidyverse/tidytemplate,
-    xml2
+Config/Needs/website:tidyverse/tidytemplate, xml2
 Config/testthat/edition: 3
+Config/usethis/tidy-description: true
 Encoding: UTF-8
 Language: en-US
 Roxygen: list(markdown = TRUE)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # usethis (development version)
 
+* `use_tidy_description()` now sets a 
+
+* `use_release_issue()` will now remind you to check/close the milestone
+  corresponding to the release, if it exists (#1642).
+
 * `use_release_issue()` now uses internal `release_extra_revdeps()` to 
   add extra revdep sources. Currently only use for internal Posit tooling,
   but we hope to extend to all users in the future (#1610).

--- a/R/description.R
+++ b/R/description.R
@@ -84,7 +84,8 @@ use_description_defaults <- function(package = NULL,
     Description = "What the package does (one paragraph).",
     "Authors@R" = 'person("First", "Last", email = "first.last@example.com", role = c("aut", "cre"), comment = c(ORCID = "YOUR-ORCID-ID"))',
     License = "`use_mit_license()`, `use_gpl3_license()` or friends to pick a license",
-    Encoding = "UTF-8"
+    Encoding = "UTF-8",
+    "Config/usethis/tidy-description" = "true"
   )
 
   if (roxygen) {
@@ -136,14 +137,6 @@ check_package_name <- function(name) {
 
 valid_package_name <- function(x) {
   grepl("^[a-zA-Z][a-zA-Z0-9.]+$", x) && !grepl("\\.$", x)
-}
-
-tidy_desc <- function(desc) {
-  desc$set("Encoding" = "UTF-8")
-
-  # Normalize all fields (includes reordering)
-  # Wrap in a try() so it always succeeds, even if user options are malformed
-  try(desc$normalize(), silent = TRUE)
 }
 
 # 2021-10-10, while adding use_description_list(), I moved this helper here

--- a/R/tidyverse.R
+++ b/R/tidyverse.R
@@ -98,7 +98,7 @@ create_tidy_package <- function(path, copyright_holder = NULL) {
 #' @rdname tidyverse
 use_tidy_description <- function() {
   desc <- proj_desc()
-  tidy_desc(desc)
+  desc$set("Config/usethis/tidy-description", "true")
   desc$write()
 
   invisible(TRUE)

--- a/tests/testthat/test-description.R
+++ b/tests/testthat/test-description.R
@@ -134,6 +134,7 @@ test_that("use_description_field() can add new field", {
 test_that("use_description_field() ignores whitespace", {
   pkg <- create_local_package()
   use_description_field(name = "foo", value = "\n bar")
+  expect_identical(proj_desc()$get_field("foo", trim_ws = FALSE), "bar")
   use_description_field(name = "foo", value = "bar")
-  expect_identical(proj_desc()$get_field("foo", trim_ws = FALSE), "\n bar")
+  expect_identical(proj_desc()$get_field("foo", trim_ws = FALSE), "bar")
 })

--- a/tests/testthat/test-latest-dependencies.R
+++ b/tests/testthat/test-latest-dependencies.R
@@ -8,9 +8,9 @@ test_that("use_tidy_versions() specifies a version for dependencies", {
   use_package("withr", "Suggests")
   use_package("gh", "Suggests")
   use_latest_dependencies()
-  desc <- read_utf8(proj_path("DESCRIPTION"))
-  desc <- grep("usethis|desc|withr|gh", desc, value = TRUE)
-  expect_true(all(grepl("\\(>= [0-9.]+\\)", desc)))
+
+  deps <- proj_deps()
+  expect_true(all(grepl(">= [0-9.]+", deps$version)))
 })
 
 test_that("use_tidy_versions() does nothing for a base package", {

--- a/tests/testthat/test-release.R
+++ b/tests/testthat/test-release.R
@@ -108,6 +108,19 @@ test_that("returns empty string if no bullets", {
   expect_equal(news_latest(lines), "")
 })
 
+test_that("can find milestone numbers", {
+  skip_on_cran()
+
+  expect_equal(
+    gh_milestone_number("r-lib/usethis", "2.1.6", state = "all"),
+    8
+  )
+  expect_equal(
+    gh_milestone_number("r-lib/usethis", "0.0.0", state = "all"),
+    NA_integer_
+  )
+})
+
 # draft release ----------------------------------------------------------------
 test_that("get_release_data() works if no file found", {
   skip_if_no_git_user()

--- a/tests/testthat/test-tidyverse.R
+++ b/tests/testthat/test-tidyverse.R
@@ -6,10 +6,15 @@ test_that("use_tidy_description() alphabetises dependencies and remotes", {
   use_package("gh", "Suggests")
   desc::desc_set_remotes(c("r-lib/styler", "jimhester/lintr"))
   use_tidy_description()
-  desc <- read_utf8(proj_path("DESCRIPTION"))
-  expect_gt(grep("usethis", desc), grep("desc", desc))
-  expect_gt(grep("withr", desc), grep("gh", desc))
-  expect_gt(grep("r\\-lib\\/styler", desc), grep("jimhester\\/lintr", desc))
+
+  imports <- proj_desc()$get_list("Imports")
+  expect_equal(imports, sort(imports))
+
+  suggests <- proj_desc()$get_list("Suggests")
+  expect_equal(suggests, sort(suggests))
+
+  remotes <- proj_desc()$get_list("Remotes")
+  expect_equal(remotes, sort(remotes))
 })
 
 test_that("use_tidy_dependencies() isn't overly informative", {


### PR DESCRIPTION
Fixes #1379

Having implemented this, I'm not sure that usethis is the right place. @gaborcsardi what do you think moving the `$write()` logic into desc itself? That would guarantee every desc operation tidies, not just those that go through `proj_desc()`.