### PR TITLE
Remove rhub from release checklist

### DIFF
--- a/R/release.R
+++ b/R/release.R
@@ -67,7 +67,6 @@ use_release_issue <- function(version = NULL) {
 release_checklist <- function(version, on_cran) {
   type <- release_type(version)
   cran_results <- cran_results_url()
-  has_src <- dir_exists(proj_path("src"))
   has_news <- file_exists(proj_path("NEWS.md"))
   has_pkgdown <- uses_pkgdown()
   has_lifecycle <- proj_desc()$has_dep("lifecycle")
@@ -111,9 +110,6 @@ release_checklist <- function(version, on_cran) {
     todo("`devtools::build_readme()`", has_readme),
     todo("`devtools::check(remote = TRUE, manual = TRUE)`"),
     todo("`devtools::check_win_devel()`"),
-    todo("`rhub::check_for_cran()`"),
-    todo("`rhub::check(platform = 'ubuntu-rchk')`", has_src),
-    todo("`rhub::check_with_sanitizers()`", has_src),
     release_revdepcheck(on_cran, is_rstudio_pkg),
     todo("Update `cran-comments.md`", on_cran),
     todo("`git push`"),

--- a/tests/testthat/_snaps/release.md
+++ b/tests/testthat/_snaps/release.md
@@ -19,7 +19,6 @@
       * [ ] `urlchecker::url_check()`
       * [ ] `devtools::check(remote = TRUE, manual = TRUE)`
       * [ ] `devtools::check_win_devel()`
-      * [ ] `rhub::check_for_cran()`
       * [ ] `git push`
       * [ ] Draft blog post
       
@@ -54,7 +53,6 @@
       * [ ] `urlchecker::url_check()`
       * [ ] `devtools::check(remote = TRUE, manual = TRUE)`
       * [ ] `devtools::check_win_devel()`
-      * [ ] `rhub::check_for_cran()`
       * [ ] `revdepcheck::revdep_check(num_workers = 4)`
       * [ ] Update `cran-comments.md`
       * [ ] `git push`
@@ -87,7 +85,6 @@
       * [ ] `urlchecker::url_check()`
       * [ ] `devtools::check(remote = TRUE, manual = TRUE)`
       * [ ] `devtools::check_win_devel()`
-      * [ ] `rhub::check_for_cran()`
       * [ ] `revdepcheck::revdep_check(num_workers = 4)`
       * [ ] Update `cran-comments.md`
       * [ ] `git push`
@@ -143,7 +140,6 @@
       * [ ] `urlchecker::url_check()`
       * [ ] `devtools::check(remote = TRUE, manual = TRUE)`
       * [ ] `devtools::check_win_devel()`
-      * [ ] `rhub::check_for_cran()`
       * [ ] `revdepcheck::cloud_check()`
       * [ ] Update `cran-comments.md`
       * [ ] `git push`


### PR DESCRIPTION
This came from a discussion @hadley and I had today, while releasing httr and working on the CRAN release chapter of R Packages 2e.

We feel like we get so much value from our ongoing checks via GitHub Actions, that the last-minute pre-release r-hub checks don't really add anything, in most situations. Also, if there is some undiscovered problem, it now shows up in an automated incoming CRAN check and doesn't bother any humans. Then r-hub becomes relevant as part of the troubleshooting toolkit.

Something I considered but did not implement:

We could check if the package has `.github/workflows/R-CMD-check.yaml` and, if it **does not** have such a file, include the checklist items I'm deleting here.

