### PR TITLE
Avoid deprecated rlang coercion helpers

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -85,15 +85,15 @@ is_online <- function(host) {
 year <- function() format(Sys.Date(), "%Y")
 
 pluck_lgl <- function(.x, ...) {
-  as_logical(purrr::pluck(.x, ..., .default = NA))
+  as.logical(purrr::pluck(.x, ..., .default = NA))
 }
 
 pluck_chr <- function(.x, ...) {
-  as_character(purrr::pluck(.x, ..., .default = NA))
+  as.character(purrr::pluck(.x, ..., .default = NA))
 }
 
 pluck_int <- function(.x, ...) {
-  as_integer(purrr::pluck(.x, ..., .default = NA))
+  as.integer(purrr::pluck(.x, ..., .default = NA))
 }
 
 is_windows <- function() {


### PR DESCRIPTION
These have been soft deprecated for awhile, but in dev rlang they have been bumped from `deprecate_soft()` to `deprecate_warn()` https://github.com/r-lib/rlang/commit/35e87908418619f70917e191a2d9721c709527d0

So now users will see the deprecation warnings, which appear in `pr_push()`:

```r
> usethis::pr_push()
✔ Setting active project to '/Users/davis/Desktop/r/packages/dplyr'
Which repo do you want to push to? 

1: DavisVaughan/dplyr = 'origin' (external PR)
2: tidyverse/dplyr = 'upstream' (internal PR)

Selection: 1
✔ Pushing local 'fix/rlang-deprecations' branch to 'origin' remote.
• Create PR at link given below
✔ Opening URL 'https://github.com/DavisVaughan/dplyr/compare/fix/rlang-deprecations'
Warning messages:
1: `as_integer()` is deprecated as of rlang 0.4.0
Please use `vctrs::vec_cast()` instead.
This warning is displayed once every 8 hours. 
2: `as_character()` is deprecated as of rlang 0.4.0
Please use `vctrs::vec_cast()` instead.
This warning is displayed once every 8 hours. 
3: `as_logical()` is deprecated as of rlang 0.4.0
Please use `vctrs::vec_cast()` instead.
This warning is displayed once every 8 hours. 
```

In theory usethis was supposed to see these deprecation warnings when running its tests, but that assumes the tests hit paths where these functions are called. I imagine it is likely that `pr_push()` isn't tested at all, so that might explain why you haven't seen these warnings in your tests before.