### PR TITLE
Use `remotes::install_github` instead of `devtools::install_github`

### DIFF
--- a/inst/templates/package-README
+++ b/inst/templates/package-README
@@ -29,7 +29,7 @@ You can install the development version of {{{ Package }}} from [GitHub](https:/
 
 ``` r
 # install.packages("devtools")
-devtools::install_github("{{{ github_spec }}}")
+remotes::install_github("{{{ github_spec }}}")
 ```
 {{/on_github}}
 {{^on_github}}

--- a/inst/templates/package-README
+++ b/inst/templates/package-README
@@ -28,7 +28,7 @@ The goal of {{{ Package }}} is to ...
 You can install the development version of {{{ Package }}} from [GitHub](https://github.com/) with:
 
 ``` r
-# install.packages("devtools")
+# install.packages("remotes")
 remotes::install_github("{{{ github_spec }}}")
 ```
 {{/on_github}}


### PR DESCRIPTION
`remotes::install_github` should be preferred to `devtools::install_github`. This is because in particular, `remotes` has many less dependencies than `devtools`. This is evident because `remotes` is a dependency of `devtools`, but also has another 19 dependencies: 
https://github.com/r-lib/devtools/blob/a027efdff97e5a88db5abf6a0c88b6a7b1c41195/DESCRIPTION#L20-L42. Users who simply want to install a new package shouldn't be advised to install the very heavy devtools package just to do this.

There are some advantages of the `devtools` version of this function, but in my view they are not worth it. Devtools uses `pkgbuild::with_build_tools` to verify that build tools are installed, `ellipsis::check_dots_used` to check that all `...` args are correctly used, and seemingly supports an input vector of repos. In any case, these last two points are not relevant for the template that `usethis` provides.