### PR TITLE
Use bibentry in citation template

### DIFF
--- a/R/citation.R
+++ b/R/citation.R
@@ -11,9 +11,6 @@ use_citation <- function() {
   use_template(
     "citation-template.R",
     path("inst", "CITATION"),
-    data = list(
-      Package = proj_desc()$get_field("Package")
-    ),
     open = TRUE
   )
 }

--- a/inst/templates/citation-template.R
+++ b/inst/templates/citation-template.R
@@ -1,7 +1,5 @@
-citHeader("To cite {{Package}} in publications use:")
-
-citEntry(
-  entry    = "Article",
+bibentry(
+  bibtype  = "Article",
   title    = ,
   author   = ,
   journal  = ,
@@ -9,8 +7,5 @@ citEntry(
   volume   = ,
   number   = ,
   pages    = ,
-  url      = ,
-  textVersion = paste(
-
-  )
+  doi      =
 )

--- a/tests/testthat/test-citation.R
+++ b/tests/testthat/test-citation.R
@@ -1,0 +1,5 @@
+test_that("use_citation() creates promised file", {
+  create_local_package()
+  use_citation()
+  expect_proj_file("inst", "CITATION")
+})


### PR DESCRIPTION
This PR:

- replaces the scaffolding for CITATION using `bibentry`
- adds a test

As per #1695 the `textVersion` field is not needed unless specific LaTeX formatting (e.g, mathematical symbols, accented characters) is required. The `citation()` print method uses the fields in `bibentry()` to automatically generate the "To cite package {packagename} in publications use:..." text. It infers the package name, so there is no need to populate it when copying the template.

Closes #1695 