### PR TITLE
Make `lowercase_r()` robust to missing directories for `use_tidy_upkeep_issue()`

### DIFF
--- a/R/tidy-upkeep.R
+++ b/R/tidy-upkeep.R
@@ -181,5 +181,7 @@ tidy_minimum_r_version <- function() {
 
 lowercase_r <- function() {
   path <- proj_path(c("R", "tests/testthat"))
+  path <- path[fs::dir_exists(path)]
   length(fs::dir_ls(path, regexp = "[.]r$")) > 0
 }
+

--- a/R/tidy-upkeep.R
+++ b/R/tidy-upkeep.R
@@ -180,8 +180,8 @@ tidy_minimum_r_version <- function() {
 }
 
 lowercase_r <- function() {
-  path <- proj_path(c("R", "tests/testthat"))
+  path <- proj_path(c("R", "tests"))
   path <- path[fs::dir_exists(path)]
-  length(fs::dir_ls(path, regexp = "[.]r$")) > 0
+  any(fs::path_ext(fs::dir_ls(path, recurse = TRUE)) == "r")
 }
 


### PR DESCRIPTION
During spring cleaning I came across a package that didn't have a tests directory so `fs::dir_ls()` fails, stopping the checklist creation.