### PR TITLE
Add the `push` argument to `use_dev_version()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,9 +3,9 @@
 * `use_release_issue()` will now remind you to run `use_github_links()` if 
   necessary (@Bisaloo, #1754)
 
-* `use_version()` gains a `push` argument to optionally push the result after
-  committing. This is used to eliminate a manual step from the 
-  `use_release_issue()` checklist (#1385). 
+* `use_version()` and `use_dev_version()` gain a `push` argument to optionally
+  push the result after committing. This is used to eliminate a manual step from
+  the `use_release_issue()` checklist (#1385). 
 
 * `use_github_release()` now automatically pushes to GitHub (if safe) (#1385) 
   and automatically publishes the release, rather than requiring you to edit

--- a/R/version.R
+++ b/R/version.R
@@ -85,13 +85,13 @@ use_version <- function(which = NULL, push = FALSE) {
 
 #' @rdname use_version
 #' @export
-use_dev_version <- function() {
+use_dev_version <- function(push = FALSE) {
   check_is_package("use_dev_version()")
   ver <- package_version(proj_version())
   if (length(unlist(ver)) > 3) {
     return(invisible())
   }
-  use_version(which = "dev")
+  use_version(which = "dev", push = push)
 }
 
 choose_version <- function(message, which = NULL) {

--- a/man/use_version.Rd
+++ b/man/use_version.Rd
@@ -7,7 +7,7 @@
 \usage{
 use_version(which = NULL, push = FALSE)
 
-use_dev_version()
+use_dev_version(push = FALSE)
 }
 \arguments{
 \item{which}{A string specifying which level to increment, one of: "major",


### PR DESCRIPTION
Completes the intent of #1385 and #1746

Without this PR, this item of the release checklist fails:

https://github.com/r-lib/usethis/blob/50074f88a744affc72e05865b7480c704bac502b/R/release.R#L138