### PR TITLE
Retain names of `versions` when subsetting

### DIFF
--- a/R/version.R
+++ b/R/version.R
@@ -118,7 +118,9 @@ choose_version <- function(message, which = NULL) {
   if (choice == 0) {
     invisible()
   } else {
-    versions[[choice]]
+    # Not using `[[` even though there is only 1 `choice`,
+    # because that removes the names from `versions`
+    versions[choice]
   }
 }
 


### PR DESCRIPTION
Currently with dev usethis I see this with `use_version()` with no arguments

```r
> usethis::use_version()
Current version is 0.5.2.9000.
What should the new version be? (0 to exit) 

1: major --> 1.0.0
2: minor --> 0.6.0
3: patch --> 0.5.3
4:   dev --> 0.5.2.9001

Selection: 2
✔ Setting Version field in DESCRIPTION to '0.6.0'
Error in if (names(new_ver) == "dev") { : argument is of length zero
```

This is due to this change in `choose_version()` https://github.com/r-lib/usethis/pull/1784

Particularly, this line, which now uses `[[` to subset `versions` (which is reasonable because there is only 1 `choice`).

https://github.com/r-lib/usethis/blob/a336c671b79df60ca287a6ca60eeab5e9b0092be/R/version.R#L121

It is problematic here because `[[` drops the names of `versions`, and we actually need the name to be returned for use in `use_version()`