### PR TITLE
Change color of superseded lifecycle badge to blue.

### DIFF
--- a/man/figures/lifecycle-superseded.svg
+++ b/man/figures/lifecycle-superseded.svg
@@ -9,7 +9,7 @@
     </clipPath>
     <g clip-path="url(#r)">
         <rect width="55" height="20" fill="#555" />
-        <rect x="55" width="73" height="20" fill="#fe7d37" />
+        <rect x="55" width="73" height="20" fill="#007ec6" />
         <rect width="128" height="20" fill="url(#s)" />
     </g>
     <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" text-rendering="geometricPrecision" font-size="110">


### PR DESCRIPTION
Erroneously had it as orange in https://github.com/r-lib/usethis/pull/1663.