### PR TITLE
Implement type checkers from rlang standalone-types-check.R

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,7 +33,7 @@ Imports:
     lifecycle (>= 1.0.0),
     purrr,
     rappdirs,
-    rlang (>= 1.0.0),
+    rlang (>= 1.0.6),
     rprojroot (>= 1.2),
     rstudioapi,
     stats,
@@ -58,3 +58,5 @@ Encoding: UTF-8
 Language: en-US
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.2.3
+Remotes:  
+    r-lib/rlang

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -58,5 +58,3 @@ Encoding: UTF-8
 Language: en-US
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.2.3
-Remotes: 
-    r-lib/rlang

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,7 +33,7 @@ Imports:
     lifecycle (>= 1.0.0),
     purrr,
     rappdirs,
-    rlang (>= 1.0.6),
+    rlang (>= 1.1.0),
     rprojroot (>= 1.2),
     rstudioapi,
     stats,
@@ -58,5 +58,5 @@ Encoding: UTF-8
 Language: en-US
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.2.3
-Remotes:  
+Remotes: 
     r-lib/rlang

--- a/R/browse.R
+++ b/R/browse.R
@@ -57,7 +57,7 @@ NULL
 #' @export
 #' @rdname browse-this
 browse_package <- function(package = NULL) {
-  check_name(package, allow_null = TRUE)
+  maybe_name(package)
 
   if (is.null(package)) {
     check_is_project()
@@ -157,7 +157,7 @@ browse_cran <- function(package = NULL) {
 # 2. BugReports/URL fields of DESCRIPTION (active project or arbitrary
 #    installed package)
 github_url <- function(package = NULL) {
-  check_name(package, allow_null = TRUE)
+  maybe_name(package)
 
   if (is.null(package)) {
     check_is_project()

--- a/R/browse.R
+++ b/R/browse.R
@@ -57,7 +57,8 @@ NULL
 #' @export
 #' @rdname browse-this
 browse_package <- function(package = NULL) {
-  stopifnot(is.null(package) || is_string(package))
+  check_name(package, allow_null = TRUE)
+
   if (is.null(package)) {
     check_is_project()
   }
@@ -156,7 +157,7 @@ browse_cran <- function(package = NULL) {
 # 2. BugReports/URL fields of DESCRIPTION (active project or arbitrary
 #    installed package)
 github_url <- function(package = NULL) {
-  stopifnot(is.null(package) || is_string(package))
+  check_name(package, allow_null = TRUE)
 
   if (is.null(package)) {
     check_is_project()

--- a/R/course.R
+++ b/R/course.R
@@ -410,7 +410,7 @@ tidy_unzip <- function(zipfile, cleanup = FALSE) {
 #' create_download_url("https://drive.google.com/open?id=123456789xxyyyzzz/view")
 #' @export
 create_download_url <- function(url) {
-  stopifnot(is_string(url))
+  check_name(url)
   stopifnot(grepl("^http[s]?://", url))
 
   switch(
@@ -469,7 +469,7 @@ hopeless_url <- function(url) {
 }
 
 normalize_url <- function(url) {
-  stopifnot(is.character(url))
+  check_name(url)
   has_scheme <- grepl("^http[s]?://", url)
 
   if (has_scheme) {
@@ -603,7 +603,7 @@ make_filename <- function(cd,
   ## https://tools.ietf.org/html/rfc6266
   cd <- cd[["filename"]]
   if (is.null(cd) || is.na(cd)) {
-    stopifnot(is_string(fallback))
+    check_name(fallback)
     return(path_sanitize(fallback))
   }
 

--- a/R/data.R
+++ b/R/data.R
@@ -128,7 +128,7 @@ check_files_absent <- function(paths, overwrite) {
 #' use_data_raw("daisy")
 #' }
 use_data_raw <- function(name = "DATASET", open = rlang::is_interactive()) {
-  stopifnot(is_string(name))
+  check_name(name)
   r_path <- path("data-raw", asciify(name), ext = "R")
   use_directory("data-raw", ignore = TRUE)
 

--- a/R/git-default-branch.R
+++ b/R/git-default-branch.R
@@ -318,8 +318,8 @@ git_default_branch_rediscover <- function(current_local_default = NULL) {
 #' }
 git_default_branch_rename <- function(from = NULL, to = "main") {
   repo <- git_repo()
-  maybe_string(from)
-  check_string(to)
+  check_name(from, allow_null = TRUE)
+  check_name(to)
 
   if (!is.null(from) &&
       !gert::git_branch_exists(from, local = TRUE, repo = repo)) {
@@ -395,7 +395,7 @@ git_default_branch_rename <- function(from = NULL, to = "main") {
 }
 
 rediscover_default_branch <- function(old_name = NULL, report_on_source = TRUE) {
-  maybe_string(old_name)
+  check_name(old_name, allow_null = TRUE)
 
   # GitHub's official TODOs re: manually updating local environments
   # after a source repo renames the default branch:

--- a/R/git-default-branch.R
+++ b/R/git-default-branch.R
@@ -318,7 +318,7 @@ git_default_branch_rediscover <- function(current_local_default = NULL) {
 #' }
 git_default_branch_rename <- function(from = NULL, to = "main") {
   repo <- git_repo()
-  check_name(from, allow_null = TRUE)
+  maybe_name(from)
   check_name(to)
 
   if (!is.null(from) &&
@@ -395,7 +395,7 @@ git_default_branch_rename <- function(from = NULL, to = "main") {
 }
 
 rediscover_default_branch <- function(old_name = NULL, report_on_source = TRUE) {
-  check_name(old_name, allow_null = TRUE)
+  maybe_name(old_name)
 
   # GitHub's official TODOs re: manually updating local environments
   # after a source repo renames the default branch:

--- a/R/git.R
+++ b/R/git.R
@@ -244,7 +244,7 @@ check_protocol <- function(protocol) {
 #' }
 use_git_remote <- function(name = "origin", url, overwrite = FALSE) {
   check_name(name)
-  check_name(url, allow_null = TRUE)
+  maybe_name(url)
   check_bool(overwrite)
 
   remotes <- git_remotes()

--- a/R/git.R
+++ b/R/git.R
@@ -243,9 +243,9 @@ check_protocol <- function(protocol) {
 #' use_git_remote(name = "upstream", url = upstream_url)
 #' }
 use_git_remote <- function(name = "origin", url, overwrite = FALSE) {
-  stopifnot(is_string(name))
-  stopifnot(is.null(url) || is_string(url))
-  stopifnot(is_true(overwrite) || is_false(overwrite))
+  check_name(name)
+  check_name(url, allow_null = TRUE)
+  check_bool(overwrite)
 
   remotes <- git_remotes()
   repo <- git_repo()

--- a/R/github-actions.R
+++ b/R/github-actions.R
@@ -70,13 +70,20 @@ use_github_action <- function(name = NULL,
                               open = FALSE,
                               badge = NULL) {
 
+  check_name(name, allow_null = TRUE)
+  check_name(ref, allow_null = TRUE)
+  check_name(url, allow_null = TRUE)
+  check_name(save_as, allow_null = TRUE)
+  check_name(readme, allow_null = TRUE)
+  check_bool(ignore)
+  check_bool(open)
+  check_bool(badge, allow_null = TRUE)
+
   if (is.null(url) && is.null(name)) {
     name <- choose_gha_workflow()
   }
 
   if (is.null(url)) {
-    check_string(name)
-    maybe_string(ref)
 
     if (path_ext(name) == "") {
       name <- path_ext_set(name, "yaml")
@@ -89,10 +96,8 @@ use_github_action <- function(name = NULL,
     readme <- glue(
       "https://github.com/r-lib/actions/blob/{ref}/examples/README.md"
     )
-  } else {
-    check_string(url)
-    maybe_string(readme)
   }
+
   withr::defer(rstudio_git_tickle())
 
   use_dot_github(ignore = ignore)
@@ -104,7 +109,7 @@ use_github_action <- function(name = NULL,
       save_as <- path_file(url)
     }
   }
-  check_string(save_as)
+
   save_as <- path(".github", "workflows", save_as)
   create_directory(path_dir(proj_path(save_as)))
 

--- a/R/github-actions.R
+++ b/R/github-actions.R
@@ -70,11 +70,11 @@ use_github_action <- function(name = NULL,
                               open = FALSE,
                               badge = NULL) {
 
-  check_name(name, allow_null = TRUE)
-  check_name(ref, allow_null = TRUE)
-  check_name(url, allow_null = TRUE)
-  check_name(save_as, allow_null = TRUE)
-  check_name(readme, allow_null = TRUE)
+  maybe_name(name)
+  maybe_name(ref)
+  maybe_name(url)
+  maybe_name(save_as)
+  maybe_name(readme)
   check_bool(ignore)
   check_bool(open)
   check_bool(badge, allow_null = TRUE)

--- a/R/github-actions.R
+++ b/R/github-actions.R
@@ -79,11 +79,9 @@ use_github_action <- function(name = NULL,
   check_bool(open)
   check_bool(badge, allow_null = TRUE)
 
-  if (is.null(url) && is.null(name)) {
-    name <- choose_gha_workflow()
-  }
-
   if (is.null(url)) {
+
+    name <- name %||% choose_gha_workflow()
 
     if (path_ext(name) == "") {
       name <- path_ext_set(name, "yaml")

--- a/R/github-pages.R
+++ b/R/github-pages.R
@@ -49,8 +49,9 @@
 #' use_github_pages(branch = git_default_branch(), path = "/docs")
 #' }
 use_github_pages <- function(branch = "gh-pages", path = "/", cname = NA) {
-  stopifnot(is_string(branch), is_string(path))
-  stopifnot(is.na(cname) || is.null(cname) || is_string(cname))
+  check_name(branch)
+  check_name(path)
+  check_string(cname, allow_empty = FALSE, allow_na = TRUE, allow_null = TRUE)
   tr <- target_repo(github_get = TRUE, ok_configs = c("ours", "fork"))
   check_can_push(tr = tr, "to turn on GitHub Pages")
 

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -1,6 +1,6 @@
 use_dependency <- function(package, type, min_version = NULL) {
-  stopifnot(is_string(package))
-  stopifnot(is_string(type))
+  check_name(package)
+  check_name(type)
 
   if (package != "R") {
     check_installed(package)

--- a/R/import-standalone-obj-type.R
+++ b/R/import-standalone-obj-type.R
@@ -1,0 +1,348 @@
+# Standalone file: do not edit by hand
+# Source: <https://github.com/r-lib/rlang/blob/main/R/standalone-obj-type.R>
+# ----------------------------------------------------------------------
+#
+# ---
+# repo: r-lib/rlang
+# file: standalone-obj-type.R
+# last-updated: 2022-10-04
+# license: https://unlicense.org
+# ---
+#
+# ## Changelog
+#
+# 2022-10-04:
+# - `obj_type_friendly(value = TRUE)` now shows numeric scalars
+#   literally.
+# - `stop_friendly_type()` now takes `show_value`, passed to
+#   `obj_type_friendly()` as the `value` argument.
+#
+# 2022-10-03:
+# - Added `allow_na` and `allow_null` arguments.
+# - `NULL` is now backticked.
+# - Better friendly type for infinities and `NaN`.
+#
+# 2022-09-16:
+# - Unprefixed usage of rlang functions with `rlang::` to
+#   avoid onLoad issues when called from rlang (#1482).
+#
+# 2022-08-11:
+# - Prefixed usage of rlang functions with `rlang::`.
+#
+# 2022-06-22:
+# - `friendly_type_of()` is now `obj_type_friendly()`.
+# - Added `obj_type_oo()`.
+#
+# 2021-12-20:
+# - Added support for scalar values and empty vectors.
+# - Added `stop_input_type()`
+#
+# 2021-06-30:
+# - Added support for missing arguments.
+#
+# 2021-04-19:
+# - Added support for matrices and arrays (#141).
+# - Added documentation.
+# - Added changelog.
+#
+# nocov start
+
+#' Return English-friendly type
+#' @param x Any R object.
+#' @param value Whether to describe the value of `x`. Special values
+#'   like `NA` or `""` are always described.
+#' @param length Whether to mention the length of vectors and lists.
+#' @return A string describing the type. Starts with an indefinite
+#'   article, e.g. "an integer vector".
+#' @noRd
+obj_type_friendly <- function(x, value = TRUE) {
+  if (is_missing(x)) {
+    return("absent")
+  }
+
+  if (is.object(x)) {
+    if (inherits(x, "quosure")) {
+      type <- "quosure"
+    } else {
+      type <- paste(class(x), collapse = "/")
+    }
+    return(sprintf("a <%s> object", type))
+  }
+
+  if (!is_vector(x)) {
+    return(.rlang_as_friendly_type(typeof(x)))
+  }
+
+  n_dim <- length(dim(x))
+
+  if (!n_dim) {
+    if (!is_list(x) && length(x) == 1) {
+      if (is_na(x)) {
+        return(switch(
+          typeof(x),
+          logical = "`NA`",
+          integer = "an integer `NA`",
+          double =
+            if (is.nan(x)) {
+              "`NaN`"
+            } else {
+              "a numeric `NA`"
+            },
+          complex = "a complex `NA`",
+          character = "a character `NA`",
+          .rlang_stop_unexpected_typeof(x)
+        ))
+      }
+
+      show_infinites <- function(x) {
+        if (x > 0) {
+          "`Inf`"
+        } else {
+          "`-Inf`"
+        }
+      }
+      str_encode <- function(x, width = 30, ...) {
+        if (nchar(x) > width) {
+          x <- substr(x, 1, width - 3)
+          x <- paste0(x, "...")
+        }
+        encodeString(x, ...)
+      }
+
+      if (value) {
+        if (is.numeric(x) && is.infinite(x)) {
+          return(show_infinites(x))
+        }
+
+        if (is.numeric(x) || is.complex(x)) {
+          number <- as.character(round(x, 2))
+          what <- if (is.complex(x)) "the complex number" else "the number"
+          return(paste(what, number))
+        }
+
+        return(switch(
+          typeof(x),
+          logical = if (x) "`TRUE`" else "`FALSE`",
+          character = {
+            what <- if (nzchar(x)) "the string" else "the empty string"
+            paste(what, str_encode(x, quote = "\""))
+          },
+          raw = paste("the raw value", as.character(x)),
+          .rlang_stop_unexpected_typeof(x)
+        ))
+      }
+
+      return(switch(
+        typeof(x),
+        logical = "a logical value",
+        integer = "an integer",
+        double = if (is.infinite(x)) show_infinites(x) else "a number",
+        complex = "a complex number",
+        character = if (nzchar(x)) "a string" else "\"\"",
+        raw = "a raw value",
+        .rlang_stop_unexpected_typeof(x)
+      ))
+    }
+
+    if (length(x) == 0) {
+      return(switch(
+        typeof(x),
+        logical = "an empty logical vector",
+        integer = "an empty integer vector",
+        double = "an empty numeric vector",
+        complex = "an empty complex vector",
+        character = "an empty character vector",
+        raw = "an empty raw vector",
+        list = "an empty list",
+        .rlang_stop_unexpected_typeof(x)
+      ))
+    }
+  }
+
+  vec_type_friendly(x)
+}
+
+vec_type_friendly <- function(x, length = FALSE) {
+  if (!is_vector(x)) {
+    abort("`x` must be a vector.")
+  }
+  type <- typeof(x)
+  n_dim <- length(dim(x))
+
+  add_length <- function(type) {
+    if (length && !n_dim) {
+      paste0(type, sprintf(" of length %s", length(x)))
+    } else {
+      type
+    }
+  }
+
+  if (type == "list") {
+    if (n_dim < 2) {
+      return(add_length("a list"))
+    } else if (is.data.frame(x)) {
+      return("a data frame")
+    } else if (n_dim == 2) {
+      return("a list matrix")
+    } else {
+      return("a list array")
+    }
+  }
+
+  type <- switch(
+    type,
+    logical = "a logical %s",
+    integer = "an integer %s",
+    numeric = ,
+    double = "a double %s",
+    complex = "a complex %s",
+    character = "a character %s",
+    raw = "a raw %s",
+    type = paste0("a ", type, " %s")
+  )
+
+  if (n_dim < 2) {
+    kind <- "vector"
+  } else if (n_dim == 2) {
+    kind <- "matrix"
+  } else {
+    kind <- "array"
+  }
+  out <- sprintf(type, kind)
+
+  if (n_dim >= 2) {
+    out
+  } else {
+    add_length(out)
+  }
+}
+
+.rlang_as_friendly_type <- function(type) {
+  switch(
+    type,
+
+    list = "a list",
+
+    NULL = "`NULL`",
+    environment = "an environment",
+    externalptr = "a pointer",
+    weakref = "a weak reference",
+    S4 = "an S4 object",
+
+    name = ,
+    symbol = "a symbol",
+    language = "a call",
+    pairlist = "a pairlist node",
+    expression = "an expression vector",
+
+    char = "an internal string",
+    promise = "an internal promise",
+    ... = "an internal dots object",
+    any = "an internal `any` object",
+    bytecode = "an internal bytecode object",
+
+    primitive = ,
+    builtin = ,
+    special = "a primitive function",
+    closure = "a function",
+
+    type
+  )
+}
+
+.rlang_stop_unexpected_typeof <- function(x, call = caller_env()) {
+  abort(
+    sprintf("Unexpected type <%s>.", typeof(x)),
+    call = call
+  )
+}
+
+#' Return OO type
+#' @param x Any R object.
+#' @return One of `"bare"` (for non-OO objects), `"S3"`, `"S4"`,
+#'   `"R6"`, or `"R7"`.
+#' @noRd
+obj_type_oo <- function(x) {
+  if (!is.object(x)) {
+    return("bare")
+  }
+
+  class <- inherits(x, c("R6", "R7_object"), which = TRUE)
+
+  if (class[[1]]) {
+    "R6"
+  } else if (class[[2]]) {
+    "R7"
+  } else if (isS4(x)) {
+    "S4"
+  } else {
+    "S3"
+  }
+}
+
+#' @param x The object type which does not conform to `what`. Its
+#'   `obj_type_friendly()` is taken and mentioned in the error message.
+#' @param what The friendly expected type as a string. Can be a
+#'   character vector of expected types, in which case the error
+#'   message mentions all of them in an "or" enumeration.
+#' @param show_value Passed to `value` argument of `obj_type_friendly()`.
+#' @param ... Arguments passed to [abort()].
+#' @inheritParams args_error_context
+#' @noRd
+stop_input_type <- function(x,
+                            what,
+                            ...,
+                            allow_na = FALSE,
+                            allow_null = FALSE,
+                            show_value = TRUE,
+                            arg = caller_arg(x),
+                            call = caller_env()) {
+  # From standalone-cli.R
+  cli <- env_get_list(
+    nms = c("format_arg", "format_code"),
+    last = topenv(),
+    default = function(x) sprintf("`%s`", x),
+    inherit = TRUE
+  )
+
+  if (allow_na) {
+    what <- c(what, cli$format_code("NA"))
+  }
+  if (allow_null) {
+    what <- c(what, cli$format_code("NULL"))
+  }
+  if (length(what)) {
+    what <- oxford_comma(what)
+  }
+
+  message <- sprintf(
+    "%s must be %s, not %s.",
+    cli$format_arg(arg),
+    what,
+    obj_type_friendly(x, value = show_value)
+  )
+
+  abort(message, ..., call = call, arg = arg)
+}
+
+oxford_comma <- function(chr, sep = ", ", final = "or") {
+  n <- length(chr)
+
+  if (n < 2) {
+    return(chr)
+  }
+
+  head <- chr[seq_len(n - 1)]
+  last <- chr[n]
+
+  head <- paste(head, collapse = sep)
+
+  # Write a or b. But a, b, or c.
+  if (n > 2) {
+    paste0(head, sep, final, " ", last)
+  } else {
+    paste0(head, " ", final, " ", last)
+  }
+}
+
+# nocov end

--- a/R/import-standalone-obj-type.R
+++ b/R/import-standalone-obj-type.R
@@ -7,6 +7,7 @@
 # file: standalone-obj-type.R
 # last-updated: 2022-10-04
 # license: https://unlicense.org
+# imports: rlang (>= 1.1.0)
 # ---
 #
 # ## Changelog

--- a/R/import-standalone-types-check.R
+++ b/R/import-standalone-types-check.R
@@ -1,0 +1,493 @@
+# Standalone file: do not edit by hand
+# Source: <https://github.com/r-lib/rlang/blob/main/R/standalone-types-check.R>
+# ----------------------------------------------------------------------
+#
+# ---
+# repo: r-lib/rlang
+# file: standalone-types-check.R
+# last-updated: 2023-02-15
+# license: https://unlicense.org
+# dependencies: standalone-obj-type.R
+# ---
+#
+# ## Changelog
+#
+# 2023-02-15:
+# - Added `check_logical()`.
+#
+# - `check_bool()`, `check_number_whole()`, and
+#   `check_number_decimal()` are now implemented in C.
+#
+# - For efficiency, `check_number_whole()` and
+#   `check_number_decimal()` now take a `NULL` default for `min` and
+#   `max`. This makes it possible to bypass unnecessary type-checking
+#   and comparisons in the default case of no bounds checks.
+#
+# 2022-10-07:
+# - `check_number_whole()` and `_decimal()` no longer treat
+#   non-numeric types such as factors or dates as numbers.  Numeric
+#   types are detected with `is.numeric()`.
+#
+# 2022-10-04:
+# - Added `check_name()` that forbids the empty string.
+#   `check_string()` allows the empty string by default.
+#
+# 2022-09-28:
+# - Removed `what` arguments.
+# - Added `allow_na` and `allow_null` arguments.
+# - Added `allow_decimal` and `allow_infinite` arguments.
+# - Improved errors with absent arguments.
+#
+#
+# 2022-09-16:
+# - Unprefixed usage of rlang functions with `rlang::` to
+#   avoid onLoad issues when called from rlang (#1482).
+#
+# 2022-08-11:
+# - Added changelog.
+#
+# nocov start
+
+# Scalars -----------------------------------------------------------------
+
+.standalone_types_check_dot_call <- .Call
+
+check_bool <- function(x,
+                       ...,
+                       allow_na = FALSE,
+                       allow_null = FALSE,
+                       arg = caller_arg(x),
+                       call = caller_env()) {
+  if (!missing(x) && .standalone_types_check_dot_call(ffi_standalone_is_bool_1.0.7, x, allow_na, allow_null)) {
+    return(invisible(NULL))
+  }
+
+  stop_input_type(
+    x,
+    c("`TRUE`", "`FALSE`"),
+    ...,
+    allow_na = allow_na,
+    allow_null = allow_null,
+    arg = arg,
+    call = call
+  )
+}
+
+check_string <- function(x,
+                         ...,
+                         allow_empty = TRUE,
+                         allow_na = FALSE,
+                         allow_null = FALSE,
+                         arg = caller_arg(x),
+                         call = caller_env()) {
+  if (!missing(x)) {
+    is_string <- .rlang_check_is_string(
+      x,
+      allow_empty = allow_empty,
+      allow_na = allow_na,
+      allow_null = allow_null
+    )
+    if (is_string) {
+      return(invisible(NULL))
+    }
+  }
+
+  stop_input_type(
+    x,
+    "a single string",
+    ...,
+    allow_na = allow_na,
+    allow_null = allow_null,
+    arg = arg,
+    call = call
+  )
+}
+
+.rlang_check_is_string <- function(x,
+                                   allow_empty,
+                                   allow_na,
+                                   allow_null) {
+  if (is_string(x)) {
+    if (allow_empty || !is_string(x, "")) {
+      return(TRUE)
+    }
+  }
+
+  if (allow_null && is_null(x)) {
+    return(TRUE)
+  }
+
+  if (allow_na && (identical(x, NA) || identical(x, na_chr))) {
+    return(TRUE)
+  }
+
+  FALSE
+}
+
+check_name <- function(x,
+                       ...,
+                       allow_null = FALSE,
+                       arg = caller_arg(x),
+                       call = caller_env()) {
+  if (!missing(x)) {
+    is_string <- .rlang_check_is_string(
+      x,
+      allow_empty = FALSE,
+      allow_na = FALSE,
+      allow_null = allow_null
+    )
+    if (is_string) {
+      return(invisible(NULL))
+    }
+  }
+
+  stop_input_type(
+    x,
+    "a valid name",
+    ...,
+    allow_na = FALSE,
+    allow_null = allow_null,
+    arg = arg,
+    call = call
+  )
+}
+
+IS_NUMBER_true <- 0
+IS_NUMBER_false <- 1
+IS_NUMBER_oob <- 2
+
+check_number_decimal <- function(x,
+                                 ...,
+                                 min = NULL,
+                                 max = NULL,
+                                 allow_infinite = TRUE,
+                                 allow_na = FALSE,
+                                 allow_null = FALSE,
+                                 arg = caller_arg(x),
+                                 call = caller_env()) {
+  if (missing(x)) {
+    exit_code <- IS_NUMBER_false
+  } else if (0 == (exit_code <- .standalone_types_check_dot_call(
+    ffi_standalone_check_number_1.0.7,
+    x,
+    allow_decimal = TRUE,
+    min,
+    max,
+    allow_infinite,
+    allow_na,
+    allow_null
+  ))) {
+    return(invisible(NULL))
+  }
+
+  .stop_not_number(
+    x,
+    ...,
+    exit_code = exit_code,
+    allow_decimal = TRUE,
+    min = min,
+    max = max,
+    allow_na = allow_na,
+    allow_null = allow_null,
+    arg = arg,
+    call = call
+  )
+}
+
+check_number_whole <- function(x,
+                               ...,
+                               min = NULL,
+                               max = NULL,
+                               allow_na = FALSE,
+                               allow_null = FALSE,
+                               arg = caller_arg(x),
+                               call = caller_env()) {
+  if (missing(x)) {
+    exit_code <- IS_NUMBER_false
+  } else if (0 == (exit_code <- .standalone_types_check_dot_call(
+    ffi_standalone_check_number_1.0.7,
+    x,
+    allow_decimal = FALSE,
+    min,
+    max,
+    allow_infinite = FALSE,
+    allow_na,
+    allow_null
+  ))) {
+    return(invisible(NULL))
+  }
+
+  .stop_not_number(
+    x,
+    ...,
+    exit_code = exit_code,
+    allow_decimal = FALSE,
+    min = min,
+    max = max,
+    allow_na = allow_na,
+    allow_null = allow_null,
+    arg = arg,
+    call = call
+  )
+}
+
+.stop_not_number <- function(x,
+                             ...,
+                             exit_code,
+                             allow_decimal,
+                             min,
+                             max,
+                             allow_na,
+                             allow_null,
+                             arg,
+                             call) {
+  if (exit_code == IS_NUMBER_oob) {
+    min <- min %||% -Inf
+    max <- max %||% Inf
+
+    if (min > -Inf && max < Inf) {
+      what <- sprintf("a number between %s and %s", min, max)
+    } else if (x < min) {
+      what <- sprintf("a number larger than %s", min)
+    } else if (x > max) {
+      what <- sprintf("a number smaller than %s", max)
+    } else {
+      abort("Unexpected state in OOB check", .internal = TRUE)
+    }
+  } else if (allow_decimal) {
+    what <- "a number"
+  } else {
+    what <- "a whole number"
+  }
+
+  stop_input_type(
+    x,
+    what,
+    ...,
+    allow_na = allow_na,
+    allow_null = allow_null,
+    arg = arg,
+    call = call
+  )
+}
+
+check_symbol <- function(x,
+                         ...,
+                         allow_null = FALSE,
+                         arg = caller_arg(x),
+                         call = caller_env()) {
+  if (!missing(x)) {
+    if (is_symbol(x)) {
+      return(invisible(NULL))
+    }
+    if (allow_null && is_null(x)) {
+      return(invisible(NULL))
+    }
+  }
+
+  stop_input_type(
+    x,
+    "a symbol",
+    ...,
+    allow_null = allow_null,
+    arg = arg,
+    call = call
+  )
+}
+
+check_arg <- function(x,
+                      ...,
+                      allow_null = FALSE,
+                      arg = caller_arg(x),
+                      call = caller_env()) {
+  if (!missing(x)) {
+    if (is_symbol(x)) {
+      return(invisible(NULL))
+    }
+    if (allow_null && is_null(x)) {
+      return(invisible(NULL))
+    }
+  }
+
+  stop_input_type(
+    x,
+    "an argument name",
+    ...,
+    allow_null = allow_null,
+    arg = arg,
+    call = call
+  )
+}
+
+check_call <- function(x,
+                       ...,
+                       allow_null = FALSE,
+                       arg = caller_arg(x),
+                       call = caller_env()) {
+  if (!missing(x)) {
+    if (is_call(x)) {
+      return(invisible(NULL))
+    }
+    if (allow_null && is_null(x)) {
+      return(invisible(NULL))
+    }
+  }
+
+  stop_input_type(
+    x,
+    "a defused call",
+    ...,
+    allow_null = allow_null,
+    arg = arg,
+    call = call
+  )
+}
+
+check_environment <- function(x,
+                              ...,
+                              allow_null = FALSE,
+                              arg = caller_arg(x),
+                              call = caller_env()) {
+  if (!missing(x)) {
+    if (is_environment(x)) {
+      return(invisible(NULL))
+    }
+    if (allow_null && is_null(x)) {
+      return(invisible(NULL))
+    }
+  }
+
+  stop_input_type(
+    x,
+    "an environment",
+    ...,
+    allow_null = allow_null,
+    arg = arg,
+    call = call
+  )
+}
+
+check_function <- function(x,
+                           ...,
+                           allow_null = FALSE,
+                           arg = caller_arg(x),
+                           call = caller_env()) {
+  if (!missing(x)) {
+    if (is_function(x)) {
+      return(invisible(NULL))
+    }
+    if (allow_null && is_null(x)) {
+      return(invisible(NULL))
+    }
+  }
+
+  stop_input_type(
+    x,
+    "a function",
+    ...,
+    allow_null = allow_null,
+    arg = arg,
+    call = call
+  )
+}
+
+check_closure <- function(x,
+                          ...,
+                          allow_null = FALSE,
+                          arg = caller_arg(x),
+                          call = caller_env()) {
+  if (!missing(x)) {
+    if (is_closure(x)) {
+      return(invisible(NULL))
+    }
+    if (allow_null && is_null(x)) {
+      return(invisible(NULL))
+    }
+  }
+
+  stop_input_type(
+    x,
+    "an R function",
+    ...,
+    allow_null = allow_null,
+    arg = arg,
+    call = call
+  )
+}
+
+check_formula <- function(x,
+                          ...,
+                          allow_null = FALSE,
+                          arg = caller_arg(x),
+                          call = caller_env()) {
+  if (!missing(x)) {
+    if (is_formula(x)) {
+      return(invisible(NULL))
+    }
+    if (allow_null && is_null(x)) {
+      return(invisible(NULL))
+    }
+  }
+
+  stop_input_type(
+    x,
+    "a formula",
+    ...,
+    allow_null = allow_null,
+    arg = arg,
+    call = call
+  )
+}
+
+
+# Vectors -----------------------------------------------------------------
+
+check_character <- function(x,
+                            ...,
+                            allow_null = FALSE,
+                            arg = caller_arg(x),
+                            call = caller_env()) {
+  if (!missing(x)) {
+    if (is_character(x)) {
+      return(invisible(NULL))
+    }
+    if (allow_null && is_null(x)) {
+      return(invisible(NULL))
+    }
+  }
+
+  stop_input_type(
+    x,
+    "a character vector",
+    ...,
+    allow_null = allow_null,
+    arg = arg,
+    call = call
+  )
+}
+
+check_logical <- function(x,
+                          ...,
+                          allow_null = FALSE,
+                          arg = caller_arg(x),
+                          call = caller_env()) {
+  if (!missing(x)) {
+    if (is_logical(x)) {
+      return(invisible(NULL))
+    }
+    if (allow_null && is_null(x)) {
+      return(invisible(NULL))
+    }
+  }
+
+  stop_input_type(
+    x,
+    "a logical vector",
+    ...,
+    allow_null = allow_null,
+    arg = arg,
+    call = call
+  )
+}
+
+# nocov end

--- a/R/tidyverse.R
+++ b/R/tidyverse.R
@@ -353,7 +353,8 @@ as_timestamp <- function(repo_spec, x = NULL) {
 
 ## returns a data frame on GitHub refs, defaulting to all releases
 ref_df <- function(repo_spec, refs = NULL) {
-  stopifnot(is_string(repo_spec))
+  check_name(repo_spec)
+  check_character(refs, allow_null = TRUE)
   refs <- refs %||% releases(repo_spec)
   if (is.null(refs)) {
     return(NULL)
@@ -376,7 +377,7 @@ ref_df <- function(repo_spec, refs = NULL) {
 
 ## returns character vector of release tag names
 releases <- function(repo_spec) {
-  stopifnot(is_string(repo_spec))
+  check_name(repo_spec)
   res <- gh::gh(
     "/repos/{owner}/{repo}/releases",
     owner = spec_owner(repo_spec), repo = spec_repo(repo_spec)

--- a/R/tutorial.R
+++ b/R/tutorial.R
@@ -23,8 +23,8 @@
 #' use_tutorial("learn-to-do-stuff", "Learn to do stuff")
 #' }
 use_tutorial <- function(name, title, open = rlang::is_interactive()) {
-  stopifnot(is_string(name))
-  stopifnot(is_string(title))
+  check_name(name)
+  check_name(title)
 
   dir_path <- path("inst", "tutorials", name)
   dir_create(dir_path)

--- a/R/ui.R
+++ b/R/ui.R
@@ -278,7 +278,7 @@ ui_code <- function(x) {
 #' @rdname ui
 #' @export
 ui_unset <- function(x = "unset") {
-  stopifnot(length(x) == 1)
+  check_string(x)
   x <- glue("<{x}>")
   x <- crayon::silver(x)
   x

--- a/R/use_github_file.R
+++ b/R/use_github_file.R
@@ -52,13 +52,13 @@ use_github_file <- function(repo_spec,
                             host = NULL) {
 
   check_name(repo_spec)
-  check_name(path, allow_null = TRUE)
-  check_name(save_as, allow_null = TRUE)
-  check_name(ref, allow_null = TRUE)
+  maybe_name(path)
+  maybe_name(save_as)
+  maybe_name(ref)
   check_bool(ignore)
   check_bool(open)
   check_bool(overwrite)
-  check_name(host, allow_null = TRUE)
+  maybe_name(host)
 
   dat <- parse_file_url(repo_spec)
   if (dat$parsed) {

--- a/R/use_github_file.R
+++ b/R/use_github_file.R
@@ -51,10 +51,14 @@ use_github_file <- function(repo_spec,
                             overwrite = FALSE,
                             host = NULL) {
 
-  check_string(repo_spec)
-  maybe_string(path)
-  maybe_string(ref)
-  maybe_string(host)
+  check_name(repo_spec)
+  check_name(path, allow_null = TRUE)
+  check_name(save_as, allow_null = TRUE)
+  check_name(ref, allow_null = TRUE)
+  check_bool(ignore)
+  check_bool(open)
+  check_bool(overwrite)
+  check_name(host, allow_null = TRUE)
 
   dat <- parse_file_url(repo_spec)
   if (dat$parsed) {

--- a/R/utils-git.R
+++ b/R/utils-git.R
@@ -1,7 +1,7 @@
 # gert -------------------------------------------------------------------------
 
 gert_shush <- function(expr, regexp) {
-  stopifnot(is.character(regexp))
+  check_character(regexp)
   withCallingHandlers(
     gertMessage = function(cnd) {
       m <- map_lgl(regexp, ~ grepl(.x, cnd_message(cnd), perl = TRUE))

--- a/R/utils-git.R
+++ b/R/utils-git.R
@@ -118,7 +118,7 @@ ensure_core_excludesFile <- function() {
 
 # Status------------------------------------------------------------------------
 git_status <- function(untracked) {
-  stopifnot(is_true(untracked) || is_false(untracked))
+  check_bool(untracked)
   st <- gert::git_status(repo = git_repo())
   if (!untracked) {
     st <- st[st$status != "new", ]
@@ -259,6 +259,7 @@ remref_branch <- function(remref) git_parse_remref(remref)$branch
 # Pull from remref or upstream tracking. If neither given/exists, do nothing.
 # Therefore, this does less than `git pull`.
 git_pull <- function(remref = NULL, verbose = TRUE) {
+  check_string(remref, allow_na = TRUE, allow_null = TRUE)
   repo <- git_repo()
   branch <- git_branch()
   remref <- remref %||% git_branch_tracking(branch)
@@ -268,7 +269,6 @@ git_pull <- function(remref = NULL, verbose = TRUE) {
     }
     return(invisible())
   }
-  stopifnot(is_string(remref))
   if (verbose) {
     ui_done("Pulling from {ui_value(remref)}.")
   }

--- a/R/utils-github.R
+++ b/R/utils-github.R
@@ -120,8 +120,8 @@ github_remote_list <- function(these = c("origin", "upstream"), x = NULL) {
   x <- x %||% gert::git_remote_list(repo = git_repo())
   check_character(these, allow_null = TRUE)
   check_data_frame(x)
-  check_name(x$name)
-  check_name(x$url)
+  check_character(x$name)
+  check_character(x$url)
   if (length(these) > 0) {
     x <- x[x$name %in% these, ]
   }

--- a/R/utils-github.R
+++ b/R/utils-github.R
@@ -69,7 +69,7 @@ parse_github_remotes <- function(x) {
 }
 
 parse_repo_url <- function(x) {
-  stopifnot(is_string(x))
+  check_name(x)
   dat <- re_match(x, github_remote_regex)
   if (is.na(dat$.match)) {
     list(repo_spec = x, host = NULL)
@@ -118,8 +118,10 @@ github_url_from_git_remotes <- function() {
 #' @noRd
 github_remote_list <- function(these = c("origin", "upstream"), x = NULL) {
   x <- x %||% gert::git_remote_list(repo = git_repo())
-  stopifnot(is.null(these) || is.character(these))
-  stopifnot(is.data.frame(x), is.character(x$name), is.character(x$url))
+  check_character(these, allow_null = TRUE)
+  check_data_frame(x)
+  check_name(x$name)
+  check_name(x$url)
   if (length(these) > 0) {
     x <- x[x$name %in% these, ]
   }

--- a/R/utils-rematch2.R
+++ b/R/utils-rematch2.R
@@ -4,7 +4,7 @@
 
 re_match <- function(text, pattern, perl = TRUE, ...) {
 
-  stopifnot(is.character(pattern), length(pattern) == 1, !is.na(pattern))
+  check_string(pattern)
   text <- as.character(text)
 
   match <- regexpr(pattern, text, perl = perl, ...)

--- a/R/utils.R
+++ b/R/utils.R
@@ -40,7 +40,7 @@ dots <- function(...) {
 }
 
 asciify <- function(x) {
-  stopifnot(is.character(x))
+  check_character(x)
   gsub("[^a-zA-Z0-9_-]+", "-", x)
 }
 
@@ -98,21 +98,6 @@ pluck_int <- function(.x, ...) {
 
 is_windows <- function() {
   .Platform$OS.type == "windows"
-}
-
-check_string <- function(x, nm = deparse(substitute(x))) {
-  if (!is_string(x)) {
-    ui_stop("{ui_code(nm)} must be a string.")
-  }
-  x
-}
-
-maybe_string <- function(x, nm = deparse(substitute(x))) {
-  if (is.null(x)) {
-    x
-  } else {
-    check_string(x, nm = nm)
-  }
 }
 
 # For stability of `stringsAsFactors` across versions

--- a/R/utils.R
+++ b/R/utils.R
@@ -104,3 +104,11 @@ is_windows <- function() {
 data.frame <- function(..., stringsAsFactors = FALSE) {
   base::data.frame(..., stringsAsFactors = stringsAsFactors)
 }
+
+# wrapper around check_name() from import-standalone-types-check.R
+# for the common case when NULL is allowed (often default)
+maybe_name <- function(x, ..., arg = caller_arg(x),
+                       call = caller_env()) {
+  check_name(x, ..., allow_null = TRUE,
+             arg = arg, call = call)
+}

--- a/R/vignette.R
+++ b/R/vignette.R
@@ -56,7 +56,7 @@ use_vignette_template <- function(template, name, title, subdir = NULL) {
   check_name(template)
   check_name(name)
   check_name(title)
-  check_name(subdir, allow_null = TRUE)
+  maybe_name(subdir)
 
   use_directory("vignettes")
   if (!is.null(subdir)) {

--- a/R/vignette.R
+++ b/R/vignette.R
@@ -53,8 +53,8 @@ use_article <- function(name, title = name) {
 }
 
 use_vignette_template <- function(template, name, title, subdir = NULL) {
-  stopifnot(is_string(name))
-  stopifnot(is_string(title))
+  check_name(name)
+  check_name(title)
 
   use_directory("vignettes")
   if (!is.null(subdir)) {

--- a/R/vignette.R
+++ b/R/vignette.R
@@ -53,8 +53,10 @@ use_article <- function(name, title = name) {
 }
 
 use_vignette_template <- function(template, name, title, subdir = NULL) {
+  check_name(template)
   check_name(name)
   check_name(title)
+  check_name(subdir, allow_null = TRUE)
 
   use_directory("vignettes")
   if (!is.null(subdir)) {

--- a/R/write.R
+++ b/R/write.R
@@ -43,7 +43,9 @@ NULL
 #'   `.Rbuildignore` and `.gitignore`.
 #' @export
 write_union <- function(path, lines, quiet = FALSE) {
-  stopifnot(is.character(lines))
+  check_name(path)
+  check_character(lines)
+  check_bool(quiet)
   path <- user_path_prep(path)
 
   if (file_exists(path)) {
@@ -72,7 +74,10 @@ write_union <- function(path, lines, quiet = FALSE) {
 #' @param overwrite Force overwrite of existing file?
 #' @export
 write_over <- function(path, lines, quiet = FALSE, overwrite = FALSE) {
-  stopifnot(is.character(lines), length(lines) > 0)
+  check_name(path)
+  check_character(lines)
+  check_bool(quiet)
+  check_bool(overwrite)
   path <- user_path_prep(path)
 
   if (same_contents(path, lines)) {
@@ -97,8 +102,8 @@ read_utf8 <- function(path, n = -1L) {
 }
 
 write_utf8 <- function(path, lines, append = FALSE, line_ending = NULL) {
-  stopifnot(is.character(path))
-  stopifnot(is.character(lines))
+  check_name(path)
+  check_character(lines)
 
   file_mode <- if (append) "ab" else "wb"
   con <- file(path, open = file_mode, encoding = "utf-8")

--- a/R/write.R
+++ b/R/write.R
@@ -76,6 +76,7 @@ write_union <- function(path, lines, quiet = FALSE) {
 write_over <- function(path, lines, quiet = FALSE, overwrite = FALSE) {
   check_name(path)
   check_character(lines)
+  stopifnot(length(lines) > 0)
   check_bool(quiet)
   check_bool(overwrite)
   path <- user_path_prep(path)

--- a/tests/testthat/_snaps/course.md
+++ b/tests/testthat/_snaps/course.md
@@ -38,3 +38,11 @@
       i Retrying download ... attempt 3
       i Retrying download ... attempt 4
 
+# normalize_url() prepends https:// (or not)
+
+    Code
+      normalize_url(1)
+    Condition
+      Error in `normalize_url()`:
+      ! `url` must be a valid name, not the number 1.
+

--- a/tests/testthat/_snaps/tutorial.md
+++ b/tests/testthat/_snaps/tutorial.md
@@ -1,0 +1,16 @@
+# use_tutorial() checks its inputs
+
+    Code
+      use_tutorial()
+    Condition
+      Error in `use_tutorial()`:
+      ! `name` must be a valid name, not absent.
+
+---
+
+    Code
+      use_tutorial(name = "tutorial-file")
+    Condition
+      Error in `use_tutorial()`:
+      ! `title` must be a valid name, not absent.
+

--- a/tests/testthat/test-course.R
+++ b/tests/testthat/test-course.R
@@ -154,7 +154,7 @@ test_that("create_download_url() works", {
 })
 
 test_that("normalize_url() prepends https:// (or not)", {
-  expect_error(normalize_url(1), "must be a valid name")
+  expect_snapshot(normalize_url(1), error = TRUE)
   expect_identical(normalize_url("http://bit.ly/abc"), "http://bit.ly/abc")
   expect_identical(normalize_url("bit.ly/abc"), "https://bit.ly/abc")
   expect_identical(

--- a/tests/testthat/test-course.R
+++ b/tests/testthat/test-course.R
@@ -154,7 +154,7 @@ test_that("create_download_url() works", {
 })
 
 test_that("normalize_url() prepends https:// (or not)", {
-  expect_error(normalize_url(1), "is\\.character.*not TRUE")
+  expect_error(normalize_url(1), "must be a valid name")
   expect_identical(normalize_url("http://bit.ly/abc"), "http://bit.ly/abc")
   expect_identical(normalize_url("bit.ly/abc"), "https://bit.ly/abc")
   expect_identical(

--- a/tests/testthat/test-tutorial.R
+++ b/tests/testthat/test-tutorial.R
@@ -2,8 +2,8 @@ test_that("use_tutorial() checks its inputs", {
   skip_if_not_installed("rmarkdown")
 
   create_local_package()
-  expect_error(use_tutorial(), "must be a valid name")
-  expect_error(use_tutorial(name = "tutorial-file"), "must be a valid name")
+  expect_snapshot(use_tutorial(), error = TRUE)
+  expect_snapshot(use_tutorial(name = "tutorial-file"), error = TRUE)
 })
 
 test_that("use_tutorial() creates a tutorial", {

--- a/tests/testthat/test-tutorial.R
+++ b/tests/testthat/test-tutorial.R
@@ -2,8 +2,8 @@ test_that("use_tutorial() checks its inputs", {
   skip_if_not_installed("rmarkdown")
 
   create_local_package()
-  expect_error(use_tutorial(), "no default")
-  expect_error(use_tutorial(name = "tutorial-file"), "no default")
+  expect_error(use_tutorial(), "must be a valid name")
+  expect_error(use_tutorial(name = "tutorial-file"), "must be a valid name")
 })
 
 test_that("use_tutorial() creates a tutorial", {


### PR DESCRIPTION
Closes #1803 

Replaces the bespoke type-checking with with the checkers from `use_standalone("r-lib/rlang", "types-check")`.

Most are pretty straightforward, but I did rearrange some to try to simplify the logic - particularly in `use_github_action()`.

I used `check_name()` a lot over `check_string()` as it disallows `""`, which I think is warranted, though the previous checks would have allowed it.

I created a `maybe_name()` wrapper around `check_name(x, allow_null = TRUE)` as there are lots of arguments with NULL as a default value.

This PR replaces #1798, which I closed then rebased this branch as `main` had got quite far ahead.