### PR TITLE
Support prefixed standalone files

### DIFF
--- a/R/use_standalone.R
+++ b/R/use_standalone.R
@@ -70,7 +70,7 @@ use_standalone <- function(repo_spec, file = NULL, ref = NULL, host = NULL) {
   }
 
   src_path <- path("R", file)
-  dest_path <- path("R", paste0("import-", file))
+  dest_path <- path("R", as_standalone_dest_file(file))
 
   lines <- read_github_file(repo_spec, path = src_path, ref = ref, host = host)
   lines <- c(standalone_header(repo_spec, src_path), lines)
@@ -149,6 +149,10 @@ as_standalone_file <- function(file) {
     file <- paste0("standalone-", file)
   }
   file
+}
+
+as_standalone_dest_file <- function(file) {
+  gsub("standalone-", "import-standalone-", file)
 }
 
 standalone_header <- function(repo_spec, path) {

--- a/R/use_standalone.R
+++ b/R/use_standalone.R
@@ -66,12 +66,7 @@ use_standalone <- function(repo_spec, file = NULL, ref = NULL, host = NULL) {
   if (is.null(file)) {
     file <- standalone_choose(repo_spec, ref = ref, host = host)
   } else {
-    if (path_ext(file) == "") {
-      file <- path_ext_set(file, "R")
-    }
-    if (!startsWith(file, "standalone-")) {
-      file <- paste0("standalone-", file)
-    }
+    file <- as_standalone_file(file)
   }
 
   src_path <- path("R", file)
@@ -144,6 +139,16 @@ standalone_choose <- function(repo_spec, ref = NULL, host = NULL, error_call = c
   }
 
   names[[choice]]
+}
+
+as_standalone_file <- function(file) {
+  if (path_ext(file) == "") {
+    file <- unclass(path_ext_set(file, "R"))
+  }
+  if (!grepl("standalone-", file)) {
+    file <- paste0("standalone-", file)
+  }
+  file
 }
 
 standalone_header <- function(repo_spec, path) {

--- a/R/use_standalone.R
+++ b/R/use_standalone.R
@@ -53,6 +53,9 @@
 #' }
 use_standalone <- function(repo_spec, file = NULL, ref = NULL, host = NULL) {
   check_is_project()
+  maybe_name(file)
+  maybe_name(host)
+  maybe_name(ref)
 
   parsed_repo_spec <- parse_repo_url(repo_spec)
   if (!is.null(parsed_repo_spec$host)) {

--- a/tests/testthat/test-use_standalone.R
+++ b/tests/testthat/test-use_standalone.R
@@ -105,3 +105,8 @@ test_that("standalone file is normalised", {
   expect_equal(as_standalone_file("aaa-standalone-foo"), "aaa-standalone-foo.R")
   expect_equal(as_standalone_file("aaa-standalone-foo.R"), "aaa-standalone-foo.R")
 })
+
+test_that("standalone destination file is normalised", {
+  expect_equal(as_standalone_dest_file("standalone-foo.R"), "import-standalone-foo.R")
+  expect_equal(as_standalone_dest_file("aaa-standalone-foo.R"), "aaa-import-standalone-foo.R")
+})

--- a/tests/testthat/test-use_standalone.R
+++ b/tests/testthat/test-use_standalone.R
@@ -97,3 +97,11 @@ test_that("errors on malformed dependencies", {
     standalone_dependencies(c("# ---", "# dependencies: 1", "# ---"), "test.R")
   })
 })
+
+test_that("standalone file is normalised", {
+  expect_equal(as_standalone_file("foo"), "standalone-foo.R")
+  expect_equal(as_standalone_file("standalone-foo"), "standalone-foo.R")
+  expect_equal(as_standalone_file("standalone-foo.R"), "standalone-foo.R")
+  expect_equal(as_standalone_file("aaa-standalone-foo"), "aaa-standalone-foo.R")
+  expect_equal(as_standalone_file("aaa-standalone-foo.R"), "aaa-standalone-foo.R")
+})


### PR DESCRIPTION
- Allow passing in prefixed standalone file names like `aaa-standalone-foo`
- While I was in there I added type-checking for `file` using the rlang standalone file.