### PR TITLE
`use_logo()` adds appropriate alt-text in README

### DIFF
--- a/R/logo.R
+++ b/R/logo.R
@@ -51,8 +51,8 @@ use_logo <- function(img, geometry = "240x278", retina = TRUE) {
   ui_todo("Add logo to your README with the following html:")
   pd_link <- pkgdown_url(pedantic = TRUE)
   if (is.null(pd_link)) {
-    ui_code_block("# {pkg} <img src=\"{proj_rel_path(logo_path)}\" align=\"right\" height=\"{height}\" />")
+    ui_code_block("# {pkg} <img src=\"{proj_rel_path(logo_path)}\" align=\"right\" height=\"{height}\" alt=\"\" />")
   } else {
-    ui_code_block("# {pkg} <a href=\"{pd_link}\"><img src=\"{proj_rel_path(logo_path)}\" align=\"right\" height=\"{height}\" /></a>")
+    ui_code_block("# {pkg} <a href=\"{pd_link}\"><img src=\"{proj_rel_path(logo_path)}\" align=\"right\" height=\"{height}\" alt=\"{pkg} website\" /></a>")
   }
 }

--- a/R/use_standalone.R
+++ b/R/use_standalone.R
@@ -182,7 +182,7 @@ standalone_dependencies <- function(lines, path, error_call = caller_env()) {
   imports <- as_chr_field(yaml$imports)
   imports <- as_version_info(imports, error_call = error_call)
 
-  if (any(na.omit(imports$cmp) != ">=")) {
+  if (any(stats::na.omit(imports$cmp) != ">=")) {
     cli::cli_abort(
       "Version specification must use {.code >=}.",
       call = error_call

--- a/README.Rmd
+++ b/README.Rmd
@@ -13,7 +13,7 @@ knitr::opts_chunk$set(
 )
 ```
 
-# usethis <a href="https://usethis.r-lib.org"><img src="man/figures/logo.png" align="right" height="138" /></a>
+# usethis <a href="https://usethis.r-lib.org"><img src="man/figures/logo.png" align="right" height="138" alt="usethis website" /></a>
 
 <!-- badges: start -->
 [![R-CMD-check](https://github.com/r-lib/usethis/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/r-lib/usethis/actions/workflows/R-CMD-check.yaml)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 <!-- README.md is generated from README.Rmd. Please edit that file -->
 
-# usethis <a href="https://usethis.r-lib.org"><img src="man/figures/logo.png" align="right" height="138" /></a>
+# usethis <a href="https://usethis.r-lib.org"><img src="man/figures/logo.png" align="right" height="138" alt="usethis website" /></a>
 
 <!-- badges: start -->
 
@@ -61,8 +61,8 @@ library(usethis)
 # Create a new package -------------------------------------------------
 path <- file.path(tempdir(), "mypkg")
 create_package(path)
-#> ✔ Creating '/tmp/Rtmpztuf0Z/mypkg/'
-#> ✔ Setting active project to '/private/tmp/Rtmpztuf0Z/mypkg'
+#> ✔ Creating '/var/folders/5r/wrwbj0sn3m71clq0l1rm4pmm0000gp/T/Rtmpt7SYWI/mypkg/'
+#> ✔ Setting active project to '/private/var/folders/5r/wrwbj0sn3m71clq0l1rm4pmm0000gp/T/Rtmpt7SYWI/mypkg'
 #> ✔ Creating 'R/'
 #> ✔ Writing 'DESCRIPTION'
 #> Package: mypkg
@@ -80,8 +80,8 @@ create_package(path)
 #> ✔ Setting active project to '<no active project>'
 # only needed since this session isn't interactive
 proj_activate(path)
-#> ✔ Setting active project to '/private/tmp/Rtmpztuf0Z/mypkg'
-#> ✔ Changing working directory to '/tmp/Rtmpztuf0Z/mypkg/'
+#> ✔ Setting active project to '/private/var/folders/5r/wrwbj0sn3m71clq0l1rm4pmm0000gp/T/Rtmpt7SYWI/mypkg'
+#> ✔ Changing working directory to '/var/folders/5r/wrwbj0sn3m71clq0l1rm4pmm0000gp/T/Rtmpt7SYWI/mypkg/'
 
 # Modify the description ----------------------------------------------
 use_mit_license("My Name")
@@ -123,7 +123,7 @@ use_data(x, y)
 # Use git ------------------------------------------------------------
 use_git()
 #> ✔ Initialising Git repo
-#> ✔ Adding '.Rproj.user', '.Rhistory', '.Rdata', '.httr-oauth', '.DS_Store' to '.gitignore'
+#> ✔ Adding '.Rproj.user', '.Rhistory', '.Rdata', '.httr-oauth', '.DS_Store', '.quarto' to '.gitignore'
 ```
 
 ## Code of Conduct


### PR DESCRIPTION
Closes #1804 

* When the logo is not a link to the pkgdown site, alt text is simply "", as the logo is decorative.
* When the logo is also a link to the pkgdown site, the alt text describes the link destination as per accessibility standards (https://www.w3.org/WAI/WCAG21/Techniques/html/H30.html)