### PR TITLE
Allow appending urls in `use_github_links()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # usethis (development version)
 
+* `use_github_links()` by default now appends the GitHub url to existing urls in
+  in the `URL` field of DESCRIPTION, rather than replacing existing urls (#1805).
+
 * `use_upkeep_issue()` is a new function to facilitate regular maintenance of 
   your package. Similar to `use_release_issue()`, it opens an issue in your repo 
   with a checklist of maintenance tasks. It will include additional bullets 

--- a/R/description.R
+++ b/R/description.R
@@ -150,13 +150,10 @@ tidy_desc <- function(desc) {
   try(desc$normalize(), silent = TRUE)
 }
 
-# 2021-10-10, while adding use_description_list(), I moved this helper here
-#
-# this helper feels out-of-sync with current usethis practices around active
-# project and how overwrite is handled
-#
-# I won't change use_description_field() now, but use_description_list() is
-# implemented differently, more in keeping with our current style
+# 2023-05-03
+# TODO: Rationalize this with proj_desc_field_append(); being careful
+# about the interactions between overwrite and append behaviour,
+# https://github.com/r-lib/usethis/pull/1834
 use_description_field <- function(name, value, overwrite = FALSE) {
   # account for `value`s produced via `glue::glue()`
   value <- as.character(value)

--- a/R/description.R
+++ b/R/description.R
@@ -176,7 +176,7 @@ use_description_field <- function(name, value, overwrite = FALSE) {
   }
 
   ui_done("Setting {ui_field(name)} field in DESCRIPTION to {ui_value(value)}")
-  desc$set(name, value)
+  desc$set_list(name, value)
   desc$write()
 
   invisible()

--- a/R/github.R
+++ b/R/github.R
@@ -225,8 +225,14 @@ use_github_links <- function(auth_token = deprecated(),
   res <- gh("GET /repos/{owner}/{repo}")
 
   desc <- proj_desc()
-  if (!res$html_url %in% desc$get_urls()) {
-    use_description_field("URL", res$html_url, overwrite = overwrite)
+  existing_urls <- desc$get_urls()
+  if (!res$html_url %in% existing_urls) {
+    if (overwrite) {
+      urls <- res$html_url
+    } else {
+      urls <- paste(existing_urls, res$html_url, sep = ", ", collapse = ", ")
+    }
+    use_description_field("URL", urls, overwrite = TRUE)
   }
 
   use_description_field(

--- a/R/github.R
+++ b/R/github.R
@@ -219,22 +219,20 @@ use_github_links <- function(auth_token = deprecated(),
   }
 
   check_is_package("use_github_links()")
-  tr <- target_repo(github_get = TRUE)
 
-  gh <- gh_tr(tr)
-  res <- gh("GET /repos/{owner}/{repo}")
+  gh_url <- github_url_from_git_remotes()
 
   desc <- proj_desc()
   existing_urls <- desc$get_urls()
 
-  if (!res$html_url %in% existing_urls) {
-    urls <- c(existing_urls, res$html_url)
+  if (!gh_url %in% existing_urls) {
+    urls <- c(existing_urls, gh_url)
     use_description_field("URL", urls, overwrite = overwrite)
   }
 
   use_description_field(
     "BugReports",
-    glue("{res$html_url}/issues"),
+    glue("{gh_url}/issues"),
     overwrite = overwrite
   )
 

--- a/R/github.R
+++ b/R/github.R
@@ -226,14 +226,10 @@ use_github_links <- function(auth_token = deprecated(),
 
   desc <- proj_desc()
   existing_urls <- desc$get_urls()
-  
+
   if (!res$html_url %in% existing_urls) {
-    if (overwrite || length(existing_urls) == 0) {
-      urls <- res$html_url
-    } else {
-      urls <- paste(existing_urls, res$html_url, sep = ", ", collapse = ", ")
-    }
-    use_description_field("URL", urls, overwrite = TRUE)
+    urls <- c(existing_urls, res$html_url)
+    use_description_field("URL", urls, overwrite = overwrite)
   }
 
   use_description_field(

--- a/R/github.R
+++ b/R/github.R
@@ -226,8 +226,9 @@ use_github_links <- function(auth_token = deprecated(),
 
   desc <- proj_desc()
   existing_urls <- desc$get_urls()
+  
   if (!res$html_url %in% existing_urls) {
-    if (overwrite) {
+    if (overwrite || length(existing_urls) == 0) {
       urls <- res$html_url
     } else {
       urls <- paste(existing_urls, res$html_url, sep = ", ", collapse = ", ")

--- a/tests/testthat/_snaps/github.md
+++ b/tests/testthat/_snaps/github.md
@@ -1,0 +1,8 @@
+# use_github_links errors when overwrite = FALSE
+
+    Code
+      use_github_links(overwrite = FALSE)
+    Condition
+      Error:
+      ! URL has a different value in DESCRIPTION. Use `overwrite = TRUE` to overwrite.
+

--- a/tests/testthat/_snaps/github.md
+++ b/tests/testthat/_snaps/github.md
@@ -1,4 +1,4 @@
-# use_github_links errors when overwrite = FALSE
+# use_github_links errors when overwrite = FALSE and existing urls
 
     Code
       use_github_links(overwrite = FALSE)

--- a/tests/testthat/_snaps/github.md
+++ b/tests/testthat/_snaps/github.md
@@ -1,4 +1,4 @@
-# use_github_links errors when overwrite = FALSE and existing urls
+# use_github_links() aborts or appends URLs when it should
 
     Code
       use_github_links(overwrite = FALSE)

--- a/tests/testthat/test-github.R
+++ b/tests/testthat/test-github.R
@@ -5,10 +5,7 @@ test_that("use_github_links populates empty URL field", {
   skip_if_no_git_user()
 
   local_mocked_bindings(
-    gh_tr = function(tr) {
-        function(endpoint, ...) list(html_url = "https://github.com/OWNER/REPO")
-      },
-    target_repo = function(github_get) NULL
+    github_url_from_git_remotes = function() "https://github.com/OWNER/REPO"
   )
 
   # when no URL field
@@ -27,10 +24,7 @@ test_that("use_github_links errors when overwrite = FALSE and existing urls", {
   use_git()
   skip_if_no_git_user()
   local_mocked_bindings(
-    gh_tr = function(tr) {
-      function(endpoint, ...) list(html_url = "https://github.com/OWNER/REPO")
-    },
-    target_repo = function(github_get) NULL
+    github_url_from_git_remotes = function() "https://github.com/OWNER/REPO"
   )
 
   d <- proj_desc()
@@ -47,13 +41,9 @@ test_that("use_github_links appends to URL field when overwrite = TRUE", {
   skip_if_no_git_user()
 
   local_mocked_bindings(
-    gh_tr = function(tr) {
-        function(endpoint, ...) list(html_url = "https://github.com/OWNER/REPO")
-      },
-    target_repo = function(github_get) NULL
+    github_url_from_git_remotes = function() "https://github.com/OWNER/REPO"
   )
 
-  # when an existing field, and overwrite = TRUE, should append
   d <- proj_desc()
   d$set_urls(c("https://existing.url", "https://existing.url1"))
   d$write()

--- a/tests/testthat/test-github.R
+++ b/tests/testthat/test-github.R
@@ -1,45 +1,67 @@
 test_that("use_github_links populates empty URL field", {
+  local_interactive(FALSE)
   create_local_package()
   use_git()
+  skip_if_no_git_user()
+
   local_mocked_bindings(
     gh_tr = function(tr) {
-        function(endpoint, ...) list(html_url = "https://github.com/USER/REPO")
+        function(endpoint, ...) list(html_url = "https://github.com/OWNER/REPO")
       },
     target_repo = function(github_get) NULL
   )
 
   # when no URL field
   use_github_links()
-  expect_equal(proj_desc()$get_urls(), "https://github.com/USER/REPO")
+  expect_equal(proj_desc()$get_urls(), "https://github.com/OWNER/REPO")
+  expect_equal(
+    proj_desc()$get_field("BugReports"),
+    "https://github.com/OWNER/REPO/issues"
+    )
 })
 
-test_that("use_github_links overwrites field when overwrite = TRUE", {
+test_that("use_github_links errors when overwrite = FALSE and existing urls", {
+  local_interactive(FALSE)
   create_local_package()
+
   use_git()
+  skip_if_no_git_user()
   local_mocked_bindings(
     gh_tr = function(tr) {
-        function(endpoint, ...) list(html_url = "https://github.com/USER/REPO")
+      function(endpoint, ...) list(html_url = "https://github.com/OWNER/REPO")
+    },
+    target_repo = function(github_get) NULL
+  )
+
+  d <- proj_desc()
+  d$set_urls("https://existing.url")
+  d$write()
+
+  expect_snapshot(use_github_links(overwrite = FALSE), error = TRUE)
+})
+
+test_that("use_github_links appends to URL field when overwrite = TRUE", {
+  local_interactive(FALSE)
+  create_local_package()
+  use_git()
+  skip_if_no_git_user()
+
+  local_mocked_bindings(
+    gh_tr = function(tr) {
+        function(endpoint, ...) list(html_url = "https://github.com/OWNER/REPO")
       },
     target_repo = function(github_get) NULL
   )
-  # when an existing url, and overwrite = TRUE, should overwrite with repo URL
-  use_description_field("URL", "https://existing.url", overwrite = TRUE)
+
+  # when an existing field, and overwrite = TRUE, should append
+  d <- proj_desc()
+  d$set_urls(c("https://existing.url", "https://existing.url1"))
+  d$write()
+
   use_github_links(overwrite = TRUE)
-  expect_equal(proj_desc()$get_urls(), "https://github.com/USER/REPO")
-})
-
-test_that("use_github_links appends to URL field when overwrite = FALSE", {
-  create_local_package()
-  use_git()
-  local_mocked_bindings(
-    gh_tr = function(tr) {
-        function(endpoint, ...) list(html_url = "https://github.com/USER/REPO")
-      },
-    target_repo = function(github_get) NULL
+  expect_equal(
+    proj_desc()$get_urls(),
+    c("https://existing.url", "https://existing.url1",
+      "https://github.com/OWNER/REPO")
   )
-  # when an existing field, and overwrite = FALSE, should append
-  use_description_field("URL", "https://existing.url", overwrite = TRUE)
-  use_github_links(overwrite = FALSE)
-  expect_equal(proj_desc()$get_urls(),
-               c("https://existing.url", "https://github.com/USER/REPO"))
 })

--- a/tests/testthat/test-github.R
+++ b/tests/testthat/test-github.R
@@ -1,8 +1,8 @@
 test_that("use_github_links populates empty URL field", {
+  skip_if_no_git_user()
   local_interactive(FALSE)
   create_local_package()
   use_git()
-  skip_if_no_git_user()
 
   local_mocked_bindings(
     github_url_from_git_remotes = function() "https://github.com/OWNER/REPO"
@@ -18,10 +18,10 @@ test_that("use_github_links populates empty URL field", {
 })
 
 test_that("use_github_links() aborts or appends URLs when it should", {
+  skip_if_no_git_user()
   local_interactive(FALSE)
   create_local_package()
   use_git()
-  skip_if_no_git_user()
 
   local_mocked_bindings(
     github_url_from_git_remotes = function() "https://github.com/OWNER/REPO"

--- a/tests/testthat/test-github.R
+++ b/tests/testthat/test-github.R
@@ -1,4 +1,4 @@
-test_that("use_github_links appends to URL field", {
+test_that("use_github_links populates empty URL field", {
   create_local_package()
   use_git()
   local_mocked_bindings(
@@ -8,11 +8,35 @@ test_that("use_github_links appends to URL field", {
     target_repo = function(github_get) NULL
   )
 
+  # when no URL field
+  use_github_links()
+  expect_equal(proj_desc()$get_urls(), "https://github.com/USER/REPO")
+})
+
+test_that("use_github_links overwrites field when overwrite = TRUE", {
+  create_local_package()
+  use_git()
+  local_mocked_bindings(
+    gh_tr = function(tr) {
+        function(endpoint, ...) list(html_url = "https://github.com/USER/REPO")
+      },
+    target_repo = function(github_get) NULL
+  )
   # when an existing url, and overwrite = TRUE, should overwrite with repo URL
-  use_description_field("URL", "https://existing.url")
+  use_description_field("URL", "https://existing.url", overwrite = TRUE)
   use_github_links(overwrite = TRUE)
   expect_equal(proj_desc()$get_urls(), "https://github.com/USER/REPO")
+})
 
+test_that("use_github_links appends to URL field when overwrite = FALSE", {
+  create_local_package()
+  use_git()
+  local_mocked_bindings(
+    gh_tr = function(tr) {
+        function(endpoint, ...) list(html_url = "https://github.com/USER/REPO")
+      },
+    target_repo = function(github_get) NULL
+  )
   # when an existing field, and overwrite = FALSE, should append
   use_description_field("URL", "https://existing.url", overwrite = TRUE)
   use_github_links(overwrite = FALSE)

--- a/tests/testthat/test-github.R
+++ b/tests/testthat/test-github.R
@@ -17,24 +17,7 @@ test_that("use_github_links populates empty URL field", {
     )
 })
 
-test_that("use_github_links errors when overwrite = FALSE and existing urls", {
-  local_interactive(FALSE)
-  create_local_package()
-
-  use_git()
-  skip_if_no_git_user()
-  local_mocked_bindings(
-    github_url_from_git_remotes = function() "https://github.com/OWNER/REPO"
-  )
-
-  d <- proj_desc()
-  d$set_urls("https://existing.url")
-  d$write()
-
-  expect_snapshot(use_github_links(overwrite = FALSE), error = TRUE)
-})
-
-test_that("use_github_links appends to URL field when overwrite = TRUE", {
+test_that("use_github_links() aborts or appends URLs when it should", {
   local_interactive(FALSE)
   create_local_package()
   use_git()
@@ -47,6 +30,8 @@ test_that("use_github_links appends to URL field when overwrite = TRUE", {
   d <- proj_desc()
   d$set_urls(c("https://existing.url", "https://existing.url1"))
   d$write()
+
+  expect_snapshot(use_github_links(overwrite = FALSE), error = TRUE)
 
   use_github_links(overwrite = TRUE)
   expect_equal(

--- a/tests/testthat/test-github.R
+++ b/tests/testthat/test-github.R
@@ -1,0 +1,21 @@
+test_that("use_github_links appends to URL field", {
+  create_local_package()
+  use_git()
+  local_mocked_bindings(
+    gh_tr = function(tr) {
+        function(endpoint, ...) list(html_url = "https://github.com/USER/REPO")
+      },
+    target_repo = function(github_get) NULL
+  )
+
+  # when an existing url, and overwrite = TRUE, should overwrite with repo URL
+  use_description_field("URL", "https://existing.url")
+  use_github_links(overwrite = TRUE)
+  expect_equal(proj_desc()$get_urls(), "https://github.com/USER/REPO")
+
+  # when an existing field, and overwrite = FALSE, should append
+  use_description_field("URL", "https://existing.url", overwrite = TRUE)
+  use_github_links(overwrite = FALSE)
+  expect_equal(proj_desc()$get_urls(),
+               c("https://existing.url", "https://github.com/USER/REPO"))
+})


### PR DESCRIPTION
Closes #1805.

Allows appending of the GitHub repo url to existing urls in the `URL` `DESCRIPTION` field. Appending is the default behaviour (i.e., when `overwrite = FALSE`). When `overwrite = TRUE` it will overwrite the old value with the GitHub repo url. 

This is slightly different behaviour than before as there is now no option to leave the `URL` field as-is: it will either be replaced, or appended to. I think this is ok, since why would you use the function if you didn't want to update the field? The alternative would be to allow three options: append, overwrite, or leave as is...