### PR TITLE
Rationalize use_description_field() & proj_desc_field_append()

### DIFF
--- a/R/description.R
+++ b/R/description.R
@@ -149,36 +149,3 @@ tidy_desc <- function(desc) {
   # Wrap in a try() so it always succeeds, even if user options are malformed
   try(desc$normalize(), silent = TRUE)
 }
-
-# 2021-10-10, while adding use_description_list(), I moved this helper here
-#
-# this helper feels out-of-sync with current usethis practices around active
-# project and how overwrite is handled
-#
-# I won't change use_description_field() now, but use_description_list() is
-# implemented differently, more in keeping with our current style
-use_description_field <- function(name, value, overwrite = FALSE) {
-  # account for `value`s produced via `glue::glue()`
-  value <- as.character(value)
-
-  desc <- proj_desc()
-
-  curr <- desc$get_field(name, NA)
-  if (identical(curr, value)) {
-    return(invisible())
-  }
-
-  if (!is.na(curr) && !overwrite) {
-    ui_stop(
-      "{ui_field(name)} has a different value in DESCRIPTION. \\
-      Use {ui_code('overwrite = TRUE')} to overwrite."
-    )
-  }
-
-  ui_done("Setting {ui_field(name)} field in DESCRIPTION to {ui_value(value)}")
-  desc$set(name, value)
-  desc$write()
-
-  invisible()
-}
-

--- a/R/github.R
+++ b/R/github.R
@@ -223,15 +223,13 @@ use_github_links <- function(auth_token = deprecated(),
 
   gh <- gh_tr(tr)
   res <- gh("GET /repos/{owner}/{repo}")
+  gh_url <- res$html_url
 
-  desc <- proj_desc()
-  if (!res$html_url %in% desc$get_urls()) {
-    use_description_field("URL", res$html_url, overwrite = overwrite)
-  }
+  proj_desc_field_update("URL", gh_url, overwrite = overwrite, append = TRUE)
 
-  use_description_field(
+  proj_desc_field_update(
     "BugReports",
-    glue("{res$html_url}/issues"),
+    glue("{gh_url}/issues"),
     overwrite = overwrite
   )
 

--- a/R/license.R
+++ b/R/license.R
@@ -61,7 +61,7 @@ use_mit_license <- function(copyright_holder = NULL) {
   )
 
   if (is_package()) {
-    use_description_field("License", "MIT + file LICENSE", overwrite = TRUE)
+    proj_desc_field_update("License", "MIT + file LICENSE", overwrite = TRUE)
     use_template("year-copyright.txt", save_as = "LICENSE", data = data)
   }
 
@@ -75,7 +75,7 @@ use_gpl_license <- function(version = 3, include_future = TRUE) {
 
   if (is_package()) {
     abbr <- license_abbr("GPL", version, include_future)
-    use_description_field("License", abbr, overwrite = TRUE)
+    proj_desc_field_update("License", abbr, overwrite = TRUE)
   }
   use_license_template(glue("GPL-{version}"))
 }
@@ -87,7 +87,7 @@ use_agpl_license <- function(version = 3, include_future = TRUE) {
 
   if (is_package()) {
     abbr <- license_abbr("AGPL", version, include_future)
-    use_description_field("License", abbr, overwrite = TRUE)
+    proj_desc_field_update("License", abbr, overwrite = TRUE)
   }
   use_license_template(glue("AGPL-{version}"))
 }
@@ -98,7 +98,7 @@ use_lgpl_license <- function(version = 3, include_future = TRUE) {
   version <- check_license_version(version, c(2.1, 3))
   if (is_package()) {
     abbr <- license_abbr("LGPL", version, include_future)
-    use_description_field("License", abbr, overwrite = TRUE)
+    proj_desc_field_update("License", abbr, overwrite = TRUE)
   }
   use_license_template(glue("LGPL-{version}"))
 }
@@ -110,7 +110,7 @@ use_apache_license <- function(version = 2, include_future = TRUE) {
 
   if (is_package()) {
     abbr <- license_abbr("Apache License", version, include_future)
-    use_description_field("License", abbr, overwrite = TRUE)
+    proj_desc_field_update("License", abbr, overwrite = TRUE)
   }
   use_license_template(glue("apache-{version}"))
 }
@@ -119,7 +119,7 @@ use_apache_license <- function(version = 2, include_future = TRUE) {
 #' @export
 use_cc0_license <- function() {
   if (is_package()) {
-    use_description_field("License", "CC0", overwrite = TRUE)
+    proj_desc_field_update("License", "CC0", overwrite = TRUE)
   }
   use_license_template("cc0")
 }
@@ -128,7 +128,7 @@ use_cc0_license <- function() {
 #' @export
 use_ccby_license <- function() {
   if (is_package()) {
-    use_description_field("License", "CC BY 4.0", overwrite = TRUE)
+    proj_desc_field_update("License", "CC BY 4.0", overwrite = TRUE)
   }
   use_license_template("ccby-4")
 }
@@ -142,7 +142,7 @@ use_proprietary_license <- function(copyright_holder) {
   )
 
   if (is_package()) {
-    use_description_field("License", "file LICENSE", overwrite = TRUE)
+    proj_desc_field_update("License", "file LICENSE", overwrite = TRUE)
   }
   use_template("license-proprietary.txt", save_as = "LICENSE", data = data)
 }

--- a/R/pkgdown.R
+++ b/R/pkgdown.R
@@ -77,7 +77,7 @@ use_pkgdown_github_pages <- function() {
   use_pkgdown_url(url = site_url, tr = tr)
 
   if (is_posit_pkg()) {
-    proj_desc_field_append("Config/Needs/website", "tidyverse/tidytemplate")
+    proj_desc_field_update("Config/Needs/website", "tidyverse/tidytemplate", append = TRUE)
   }
 }
 
@@ -97,7 +97,7 @@ use_pkgdown_url <- function(url, tr = NULL) {
   }
   write_utf8(config_path, yaml::as.yaml(config))
 
-  proj_desc_field_append("URL", url)
+  proj_desc_field_update("URL", url, append = TRUE)
   if (has_package_doc()) {
     ui_todo("
       Run {ui_code('devtools::document()')} to update package-level documentation.")

--- a/R/proj-desc.R
+++ b/R/proj-desc.R
@@ -27,9 +27,12 @@ proj_desc_create <- function(name, fields = list(), roxygen = TRUE) {
   }
 }
 
-proj_desc_field_append <- function(key, value) {
+# Here overwrite means "update the field if there is already a value in it,
+# including appending".
+proj_desc_field_update <- function(key, value, overwrite = TRUE, append = FALSE) {
   check_string(key)
-  check_string(value)
+  stopifnot(is.character(value) || is.numeric(value), length(value) == 1)
+  check_bool(overwrite)
 
   desc <- proj_desc()
 
@@ -38,9 +41,21 @@ proj_desc_field_append <- function(key, value) {
     return(invisible())
   }
 
+  if (!overwrite && length(old > 0) && any(old != "")) {
+    ui_stop(
+      "{ui_field(key)} has a different value in DESCRIPTION. \\
+      Use {ui_code('overwrite = TRUE')} to overwrite."
+    )
+  }
+
   ui_done("Adding {ui_value(value)} to {ui_field(key)}")
+
+  if (append) {
+    value <- c(old, value)
+  }
+
   # https://github.com/r-lib/desc/issues/117
-  desc$set_list(key, c(old, value))
+  desc$set_list(key, value)
   desc$write()
 
   invisible()

--- a/R/roxygen.R
+++ b/R/roxygen.R
@@ -16,8 +16,8 @@ use_roxygen_md <- function(overwrite = FALSE) {
   if (!uses_roxygen()) {
     roxy_ver <- as.character(utils::packageVersion("roxygen2"))
 
-    use_description_field("Roxygen", "list(markdown = TRUE)")
-    use_description_field("RoxygenNote", roxy_ver)
+    proj_desc_field_update("Roxygen", "list(markdown = TRUE)", overwrite = FALSE)
+    proj_desc_field_update("RoxygenNote", roxy_ver, overwrite = FALSE)
     ui_todo("Run {ui_code('devtools::document()')}")
     return(invisible())
   }
@@ -29,7 +29,7 @@ use_roxygen_md <- function(overwrite = FALSE) {
   }
 
   if (isFALSE(already_setup) || isTRUE(overwrite)) {
-    use_description_field("Roxygen", "list(markdown = TRUE)", overwrite = TRUE)
+    proj_desc_field_update("Roxygen", "list(markdown = TRUE)", overwrite = TRUE)
 
     check_installed("roxygen2md")
     ui_todo("

--- a/R/spelling.R
+++ b/R/spelling.R
@@ -20,7 +20,7 @@ use_spell_check <- function(vignettes = TRUE,
   check_is_package("use_spell_check()")
   check_installed("spelling")
   use_dependency("spelling", "Suggests")
-  use_description_field("Language", lang, overwrite = TRUE)
+  proj_desc_field_update("Language", lang, overwrite = TRUE)
   spelling::spell_check_setup(
     pkg = proj_get(), vignettes = vignettes, lang = lang, error = error
   )

--- a/R/test.R
+++ b/R/test.R
@@ -37,10 +37,10 @@ use_testthat_impl <- function(edition = NULL, parallel = FALSE) {
     edition <- check_edition(edition)
 
     use_dependency("testthat", "Suggests", paste0(edition, ".0.0"))
-    use_description_field("Config/testthat/edition", edition, overwrite = TRUE)
+    proj_desc_field_update("Config/testthat/edition", edition, overwrite = TRUE)
 
     if (parallel) {
-      use_description_field("Config/testthat/parallel", "true", overwrite = TRUE)
+      proj_desc_field_update("Config/testthat/parallel", "true", overwrite = TRUE)
     } else {
       proj_desc()$del("Config/testthat/parallel")
     }

--- a/R/version.R
+++ b/R/version.R
@@ -64,7 +64,7 @@ use_version <- function(which = NULL, push = FALSE) {
     return(invisible(FALSE))
   }
 
-  use_description_field("Version", new_ver, overwrite = TRUE)
+  proj_desc_field_update("Version", new_ver, overwrite = TRUE)
   if (names(new_ver) == "dev") {
     use_news_heading("(development version)")
   } else {

--- a/R/vignette.R
+++ b/R/vignette.R
@@ -28,7 +28,7 @@ use_vignette <- function(name, title = name) {
   use_dependency("knitr", "Suggests")
   use_dependency("rmarkdown", "Suggests")
 
-  use_description_field("VignetteBuilder", "knitr", overwrite = TRUE)
+  proj_desc_field_update("VignetteBuilder", "knitr", overwrite = TRUE)
   use_git_ignore("inst/doc")
 
   use_vignette_template("vignette.Rmd", name, title)
@@ -43,7 +43,7 @@ use_article <- function(name, title = name) {
 
   deps <- proj_deps()
   if (!"rmarkdown" %in% deps$package) {
-    proj_desc_field_append("Config/Needs/website", "rmarkdown")
+    proj_desc_field_update("Config/Needs/website", "rmarkdown", append = TRUE)
   }
 
   use_vignette_template("article.Rmd", name, title, subdir = "articles")

--- a/tests/testthat/_snaps/proj-desc.md
+++ b/tests/testthat/_snaps/proj-desc.md
@@ -1,12 +1,12 @@
 # proj_desc_field_append() only messages when adding
 
     Code
-      proj_desc_field_append("Config/Needs/foofy", "alfa")
+      proj_desc_field_update("Config/Needs/foofy", "alfa", append = TRUE)
     Message
       v Adding 'alfa' to Config/Needs/foofy
     Code
-      proj_desc_field_append("Config/Needs/foofy", "alfa")
-      proj_desc_field_append("Config/Needs/foofy", "bravo")
+      proj_desc_field_update("Config/Needs/foofy", "alfa", append = TRUE)
+      proj_desc_field_update("Config/Needs/foofy", "bravo", append = TRUE)
     Message
       v Adding 'bravo' to Config/Needs/foofy
 

--- a/tests/testthat/test-browse.R
+++ b/tests/testthat/test-browse.R
@@ -13,11 +13,11 @@ test_that("github_url() works on active project", {
   expect_usethis_error(github_url(), "no GitHub remotes")
 
   use_description()
-  use_description_field("URL", "https://example.com")
+  proj_desc_field_update("URL", "https://example.com")
   expect_usethis_error(github_url(), "no GitHub remotes")
 
   issues <- "https://github.com/OWNER/REPO_BUGREPORTS/issues"
-  use_description_field("BugReports", issues)
+  proj_desc_field_update("BugReports", issues)
   expect_equal(github_url(), "https://github.com/OWNER/REPO_BUGREPORTS")
 
   origin <- "https://github.com/OWNER/REPO_ORIGIN"
@@ -129,9 +129,9 @@ test_that("browse_package() returns URLs", {
 
   use_description()
   pkgdown <- "https://example.com"
-  use_description_field("URL", pkgdown)
+  proj_desc_field_update("URL", pkgdown)
   issues <- "https://github.com/OWNER/REPO/issues"
-  use_description_field("BugReports", issues)
+  proj_desc_field_update("BugReports", issues)
 
   out <- browse_package()
   expect_setequal(out, c(origin, foofy, pkgdown, issues))

--- a/tests/testthat/test-description.R
+++ b/tests/testthat/test-description.R
@@ -97,43 +97,45 @@ test_that("valid CRAN names checked", {
   )
 })
 
-test_that("use_description_field() can address an existing field", {
+test_that("proj_desc_field_update() can address an existing field", {
   pkg <- create_local_package()
   orig <- tools::md5sum(proj_path("DESCRIPTION"))
 
   ## specify existing value of existing field --> should be no op
-  use_description_field(
-    name = "Version",
-    value = proj_version()
+  proj_desc_field_update(
+    key = "Version",
+    value = proj_version(),
+    overwrite = FALSE
   )
   expect_identical(orig, tools::md5sum(proj_path("DESCRIPTION")))
 
   expect_usethis_error(
-    use_description_field(
-      name = "Version",
-      value = "1.1.1"
+    proj_desc_field_update(
+      key = "Version",
+      value = "1.1.1",
+      overwrite = FALSE
     ),
     "has a different value"
   )
 
   ## overwrite existing field
-  use_description_field(
-    name = "Version",
+  proj_desc_field_update(
+    key = "Version",
     value = "1.1.1",
     overwrite = TRUE
   )
   expect_identical(proj_version(), "1.1.1")
 })
 
-test_that("use_description_field() can add new field", {
+test_that("proj_desc_field_update() can add new field", {
   pkg <- create_local_package()
-  use_description_field(name = "foo", value = "bar")
+  proj_desc_field_update(key = "foo", value = "bar")
   expect_identical(proj_desc()$get_field("foo"), "bar")
 })
 
-test_that("use_description_field() ignores whitespace", {
+test_that("proj_desc_field_update() ignores whitespace", {
   pkg <- create_local_package()
-  use_description_field(name = "foo", value = "\n bar")
-  use_description_field(name = "foo", value = "bar")
+  proj_desc_field_update(key = "foo", value = "\n bar")
+  proj_desc_field_update(key = "foo", value = "bar", overwrite = FALSE)
   expect_identical(proj_desc()$get_field("foo", trim_ws = FALSE), "\n bar")
 })

--- a/tests/testthat/test-news.R
+++ b/tests/testthat/test-news.R
@@ -12,7 +12,7 @@ test_that("use_news_md() sets bullet to 'Added a NEWS.md file...' when on CRAN",
   create_local_package()
 
   # on CRAN, local dev version
-  use_description_field(name = "Version", value = "0.1.0.9000", overwrite = TRUE)
+  proj_desc_field_update(key = "Version", value = "0.1.0.9000")
   mock_cran_version("0.1.0")
 
   use_news_md()
@@ -24,7 +24,7 @@ test_that("use_news_md() sets bullet to 'Added a NEWS.md file...' when on CRAN",
 test_that("use_news_md() sets version number when 'production version'", {
   create_local_package()
 
-  use_description_field(name = "Version", value = "0.2.0", overwrite = TRUE)
+  proj_desc_field_update(key = "Version", value = "0.2.0")
   mock_cran_version(NULL)
 
   use_news_md()

--- a/tests/testthat/test-proj-desc.R
+++ b/tests/testthat/test-proj-desc.R
@@ -3,9 +3,9 @@ test_that("proj_desc_field_append() only messages when adding", {
   withr::local_options(list(usethis.quiet = FALSE, crayon.enabled = FALSE))
 
   expect_snapshot({
-    proj_desc_field_append("Config/Needs/foofy", "alfa")
-    proj_desc_field_append("Config/Needs/foofy", "alfa")
-    proj_desc_field_append("Config/Needs/foofy", "bravo")
+    proj_desc_field_update("Config/Needs/foofy", "alfa", append = TRUE)
+    proj_desc_field_update("Config/Needs/foofy", "alfa", append = TRUE)
+    proj_desc_field_update("Config/Needs/foofy", "bravo", append = TRUE)
   })
   expect_equal(proj_desc()$get_list("Config/Needs/foofy"), c("alfa", "bravo"))
 })

--- a/tests/testthat/test-version.R
+++ b/tests/testthat/test-version.R
@@ -18,8 +18,8 @@ test_that("use_version() errors for invalid `which`", {
 
 test_that("use_version() increments version in DESCRIPTION, edits NEWS", {
   create_local_package()
-  use_description_field(
-    name = "Version",
+  proj_desc_field_update(
+    key = "Version",
     value = "1.1.1.9000",
     overwrite = TRUE
   )
@@ -37,7 +37,7 @@ test_that("use_version() increments version in DESCRIPTION, edits NEWS", {
 
 test_that("use_dev_version() appends .9000 to Version, exactly once", {
   create_local_package()
-  use_description_field(name = "Version", value = "0.0.1", overwrite = TRUE)
+  proj_desc_field_update(key = "Version", value = "0.0.1", overwrite = TRUE)
   use_dev_version()
   expect_identical(proj_version(), "0.0.1.9000")
   use_dev_version()
@@ -46,7 +46,7 @@ test_that("use_dev_version() appends .9000 to Version, exactly once", {
 
 test_that("use_version() updates (development version) directly", {
   create_local_package()
-  use_description_field(name = "Version", value = "0.0.1", overwrite = TRUE)
+  proj_desc_field_update(key = "Version", value = "0.0.1", overwrite = TRUE)
   mock_cran_version("0.0.1")
   use_news_md()
 
@@ -64,7 +64,7 @@ test_that("use_version() updates (development version) directly", {
 
 test_that("use_version() updates version.c", {
   create_local_package()
-  use_description_field(name = "Version", value = "1.0.0", overwrite = TRUE)
+  proj_desc_field_update(key = "Version", value = "1.0.0", overwrite = TRUE)
 
   name <- project_name()
   src_path <- proj_path("src")
@@ -87,7 +87,7 @@ test_that("is_dev_version() detects dev version directly and with DESCRIPTION", 
   expect_false(is_dev_version("0.0.1"))
 
   create_local_package()
-  use_description_field(name = "Version", value = "1.0.0", overwrite = TRUE)
+  proj_desc_field_update(key = "Version", value = "1.0.0", overwrite = TRUE)
   expect_false(is_dev_version())
   use_dev_version()
   expect_true(is_dev_version())

--- a/tests/testthat/test-vignette.R
+++ b/tests/testthat/test-vignette.R
@@ -45,7 +45,7 @@ test_that("use_article() adds rmarkdown to Config/Needs/website", {
   create_local_package()
   local_interactive(FALSE)
 
-  proj_desc_field_append("Config/Needs/website", "somepackage")
+  proj_desc_field_update("Config/Needs/website", "somepackage", append = TRUE)
   use_article("name", "title")
 
   expect_setequal(


### PR DESCRIPTION
`use_description_field()` and `proj_desc_field_append()` do very similar things. This combines them into one function with arguments `overwrite` and `append` to allow the existing behaviour of the original two functions:

* `proj_desc_field_append()` -> `proj_desc_field_update()`
* remove `use_description_field()`
* add overwrite and append arguments to `proj_desc_field_update()`
* replace use of `use_description_field()` and `proj_desc_field_append()` with `proj_desc_field_update()`, setting overwrite and append arguments as appropriate
* update tests

NB: There will be merge conflicts after #1834 is merged.