### PR TITLE
Allow to open at line and column numbers in `edit_file()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -136,6 +136,8 @@
   
 * Updates snapshot tests (#1715).
 
+* `edit_file()` can open a file at a specified line and column number (#1841)
+
 # usethis 2.1.6
 
 ### GitHub-related


### PR DESCRIPTION
Closes #1841 

Using the pattern of cli https://cli.r-lib.org/reference/links.html#line-and-column-numbers, this feature allows to specify line and column numbers when opening a file in RStudio, they are ignored otherwise.

I'd be happy to revisit

I didn't know how to add a test, so I'd be happy to do that too.

Like, in cli, I allow `#` or `:` to be a separator between the file extension and the line numbers.