### PR TITLE
fix: make use_testthat() work for brand-new package

### DIFF
--- a/R/proj-desc.R
+++ b/R/proj-desc.R
@@ -31,13 +31,13 @@ proj_desc_create <- function(name, fields = list(), roxygen = TRUE) {
 # including appending".
 proj_desc_field_update <- function(key, value, overwrite = TRUE, append = FALSE) {
   check_string(key)
-  stopifnot(is.character(value) || is.numeric(value), length(value) == 1)
+  check_character(value)
   check_bool(overwrite)
 
   desc <- proj_desc()
 
   old <- desc$get_list(key, default = "")
-  if (value %in% old) {
+  if (all(value %in% old)) {
     return(invisible())
   }
 
@@ -51,7 +51,7 @@ proj_desc_field_update <- function(key, value, overwrite = TRUE, append = FALSE)
   ui_done("Adding {ui_value(value)} to {ui_field(key)}")
 
   if (append) {
-    value <- c(old, value)
+    value <- union(old, value)
   }
 
   # https://github.com/r-lib/desc/issues/117

--- a/R/test.R
+++ b/R/test.R
@@ -37,7 +37,7 @@ use_testthat_impl <- function(edition = NULL, parallel = FALSE) {
     edition <- check_edition(edition)
 
     use_dependency("testthat", "Suggests", paste0(edition, ".0.0"))
-    proj_desc_field_update("Config/testthat/edition", edition, overwrite = TRUE)
+    proj_desc_field_update("Config/testthat/edition", as.character(edition), overwrite = TRUE)
 
     if (parallel) {
       proj_desc_field_update("Config/testthat/parallel", "true", overwrite = TRUE)

--- a/tests/testthat/_snaps/proj-desc.md
+++ b/tests/testthat/_snaps/proj-desc.md
@@ -1,4 +1,4 @@
-# proj_desc_field_append() only messages when adding
+# proj_desc_field_update() only messages when adding
 
     Code
       proj_desc_field_update("Config/Needs/foofy", "alfa", append = TRUE)
@@ -9,4 +9,11 @@
       proj_desc_field_update("Config/Needs/foofy", "bravo", append = TRUE)
     Message
       v Adding 'bravo' to Config/Needs/foofy
+
+# proj_desc_field_update() works with multiple values
+
+    Code
+      proj_desc_field_update("Config/Needs/foofy", c("alfa", "bravo"), append = TRUE)
+    Message
+      v Adding 'alfa', 'bravo' to Config/Needs/foofy
 

--- a/tests/testthat/test-proj-desc.R
+++ b/tests/testthat/test-proj-desc.R
@@ -1,4 +1,4 @@
-test_that("proj_desc_field_append() only messages when adding", {
+test_that("proj_desc_field_update() only messages when adding", {
   create_local_package()
   withr::local_options(list(usethis.quiet = FALSE, crayon.enabled = FALSE))
 
@@ -6,6 +6,18 @@ test_that("proj_desc_field_append() only messages when adding", {
     proj_desc_field_update("Config/Needs/foofy", "alfa", append = TRUE)
     proj_desc_field_update("Config/Needs/foofy", "alfa", append = TRUE)
     proj_desc_field_update("Config/Needs/foofy", "bravo", append = TRUE)
+  })
+  expect_equal(proj_desc()$get_list("Config/Needs/foofy"), c("alfa", "bravo"))
+})
+
+test_that("proj_desc_field_update() works with multiple values", {
+  create_local_package()
+  withr::local_options(list(usethis.quiet = FALSE, crayon.enabled = FALSE))
+
+  proj_desc_field_update("Config/Needs/foofy", "alfa", append = TRUE)
+  expect_snapshot({
+    proj_desc_field_update("Config/Needs/foofy", c("alfa", "bravo"),
+                           append = TRUE)
   })
   expect_equal(proj_desc()$get_list("Config/Needs/foofy"), c("alfa", "bravo"))
 })


### PR DESCRIPTION
Coming from https://github.com/r-lib/desc/issues/117#issuecomment-1554499421

I understand why this doesn't happen in usethis test where testthat edition field is already set by `create_local_package()`; after digging a bit I see that prior to https://github.com/r-lib/usethis/commit/747931bdee400be9969b7ab75af390c05ff2e7a9 there was `as.character()`. Now I am at peace, having the whole story :jigsaw: :relieved: 

@krlmlr 
