### PR TITLE
Move up "add link to blog post" release bullet

### DIFF
--- a/R/release.R
+++ b/R/release.R
@@ -137,7 +137,7 @@ release_checklist <- function(version, on_cran) {
     "Wait for CRAN...",
     "",
     todo("Accepted :tada:"),
-    todo("Add link to blog post in pkgdown news menu", type != "patch"),
+    todo("Add preemptive link to blog post in pkgdown news menu", type != "patch"),
     todo("`usethis::use_github_release()`"),
     todo("`usethis::use_dev_version(push = TRUE)`"),
     todo("`usethis::use_news_md()`", !has_news),

--- a/R/release.R
+++ b/R/release.R
@@ -137,12 +137,12 @@ release_checklist <- function(version, on_cran) {
     "Wait for CRAN...",
     "",
     todo("Accepted :tada:"),
+    todo("Add link to blog post in pkgdown news menu", type != "patch"),
     todo("`usethis::use_github_release()`"),
     todo("`usethis::use_dev_version(push = TRUE)`"),
     todo("`usethis::use_news_md()`", !has_news),
     todo("Finish blog post", type != "patch"),
-    todo("Tweet", type != "patch"),
-    todo("Add link to blog post in pkgdown news menu", type != "patch")
+    todo("Tweet", type != "patch")
   )
 }
 

--- a/tests/testthat/_snaps/release.md
+++ b/tests/testthat/_snaps/release.md
@@ -33,12 +33,12 @@
       Wait for CRAN...
       
       * [ ] Accepted :tada:
+      * [ ] Add link to blog post in pkgdown news menu
       * [ ] `usethis::use_github_release()`
       * [ ] `usethis::use_dev_version(push = TRUE)`
       * [ ] `usethis::use_news_md()`
       * [ ] Finish blog post
       * [ ] Tweet
-      * [ ] Add link to blog post in pkgdown news menu
 
 ---
 
@@ -101,12 +101,12 @@
       Wait for CRAN...
       
       * [ ] Accepted :tada:
+      * [ ] Add link to blog post in pkgdown news menu
       * [ ] `usethis::use_github_release()`
       * [ ] `usethis::use_dev_version(push = TRUE)`
       * [ ] `usethis::use_news_md()`
       * [ ] Finish blog post
       * [ ] Tweet
-      * [ ] Add link to blog post in pkgdown news menu
 
 # construct correct revdep bullet
 
@@ -158,10 +158,10 @@
       Wait for CRAN...
       
       * [ ] Accepted :tada:
+      * [ ] Add link to blog post in pkgdown news menu
       * [ ] `usethis::use_github_release()`
       * [ ] `usethis::use_dev_version(push = TRUE)`
       * [ ] `usethis::use_news_md()`
       * [ ] Finish blog post
       * [ ] Tweet
-      * [ ] Add link to blog post in pkgdown news menu
 

--- a/tests/testthat/_snaps/release.md
+++ b/tests/testthat/_snaps/release.md
@@ -33,7 +33,7 @@
       Wait for CRAN...
       
       * [ ] Accepted :tada:
-      * [ ] Add link to blog post in pkgdown news menu
+      * [ ] Add preemptive link to blog post in pkgdown news menu
       * [ ] `usethis::use_github_release()`
       * [ ] `usethis::use_dev_version(push = TRUE)`
       * [ ] `usethis::use_news_md()`
@@ -101,7 +101,7 @@
       Wait for CRAN...
       
       * [ ] Accepted :tada:
-      * [ ] Add link to blog post in pkgdown news menu
+      * [ ] Add preemptive link to blog post in pkgdown news menu
       * [ ] `usethis::use_github_release()`
       * [ ] `usethis::use_dev_version(push = TRUE)`
       * [ ] `usethis::use_news_md()`
@@ -158,7 +158,7 @@
       Wait for CRAN...
       
       * [ ] Accepted :tada:
-      * [ ] Add link to blog post in pkgdown news menu
+      * [ ] Add preemptive link to blog post in pkgdown news menu
       * [ ] `usethis::use_github_release()`
       * [ ] `usethis::use_dev_version(push = TRUE)`
       * [ ] `usethis::use_news_md()`

--- a/tests/testthat/test-proj-desc.R
+++ b/tests/testthat/test-proj-desc.R
@@ -12,9 +12,10 @@ test_that("proj_desc_field_update() only messages when adding", {
 
 test_that("proj_desc_field_update() works with multiple values", {
   create_local_package()
+  # Add something to begin with
+  proj_desc_field_update("Config/Needs/foofy", "alfa", append = TRUE)
   withr::local_options(list(usethis.quiet = FALSE, crayon.enabled = FALSE))
 
-  proj_desc_field_update("Config/Needs/foofy", "alfa", append = TRUE)
   expect_snapshot({
     proj_desc_field_update("Config/Needs/foofy", c("alfa", "bravo"),
                            append = TRUE)


### PR DESCRIPTION
Closes #1761. 

As pointed out by @DavisVaughan in the linked issue, there is no perfect place for this bullet in the checklist. I made the assumption that the user won't be pushing the released version to GitHub prior to CRAN acceptance, so I moved the bullet to after CRAN acceptance and before `use_github_release()`, which will push to GitHub and thus build the released version of the pkgdown site, with the link to the blog post in the pkgdown news. The link will 404 until the post is published but that shouldn't usually be a long delay.