### PR TITLE
Ensure `cran_version()` does not fail when no internet or CRAN mirror is unset

### DIFF
--- a/R/release.R
+++ b/R/release.R
@@ -403,8 +403,25 @@ get_release_news <- function(SHA = gert::git_info(repo = git_repo())$commit,
   }
 }
 
-cran_version <- function(package = project_name(),
-                         available = utils::available.packages()) {
+cran_version <- function(package = project_name(), available = NULL) {
+
+  if (!curl::has_internet()) {
+    return(NULL)
+  }
+
+  if (is.null(available)) {
+  # Guard against CRAN mirror being unset
+    available <- try(
+      utils::available.packages(
+        repos = default_cran_mirror()
+      ),
+      silent = TRUE
+    )
+    if (inherits(try, "try-error")) {
+      return(NULL)
+    }
+  }
+
   idx <- available[, "Package"] == package
   if (any(idx)) {
     as.package_version(available[package, "Version"])
@@ -536,4 +553,15 @@ pkg_minimum_r_version <- function() {
     return(numeric_version(0))
   }
   numeric_version(gsub("[^0-9.]", "", r_dep))
+}
+
+
+# from pak: https://github.com/r-lib/pak/blob/168ab5d58fc244e5084c2800c87b8a574d66c3ba/R/default-cran-mirror.R
+default_cran_mirror <- function() {
+  mirror <- getOption("repos")["CRAN"]
+  if (is.null(mirror) || is.na(mirror) || mirror == "@CRAN@") {
+    c(CRAN = "https://cloud.r-project.org")
+  } else {
+    c(CRAN = unname(mirror))
+  }
 }

--- a/R/release.R
+++ b/R/release.R
@@ -410,14 +410,12 @@ cran_version <- function(package = project_name(), available = NULL) {
   }
 
   if (is.null(available)) {
-  # Guard against CRAN mirror being unset
-    available <- try(
-      utils::available.packages(
-        repos = default_cran_mirror()
-      ),
-      silent = TRUE
+    # Guard against CRAN mirror being unset
+    available <- tryCatch(
+      utils::available.packages(repos = default_cran_mirror()),
+      error = function(e) NULL
     )
-    if (inherits(available, "try-error")) {
+    if (is.null(available)) {
       return(NULL)
     }
   }

--- a/R/release.R
+++ b/R/release.R
@@ -417,7 +417,7 @@ cran_version <- function(package = project_name(), available = NULL) {
       ),
       silent = TRUE
     )
-    if (inherits(try, "try-error")) {
+    if (inherits(available, "try-error")) {
       return(NULL)
     }
   }

--- a/R/release.R
+++ b/R/release.R
@@ -555,13 +555,13 @@ pkg_minimum_r_version <- function() {
   numeric_version(gsub("[^0-9.]", "", r_dep))
 }
 
-
-# from pak: https://github.com/r-lib/pak/blob/168ab5d58fc244e5084c2800c87b8a574d66c3ba/R/default-cran-mirror.R
+# Borrowed from pak, but modified also retain user's non-cran repos:
+# https://github.com/r-lib/pak/blob/168ab5d58fc244e5084c2800c87b8a574d66c3ba/R/default-cran-mirror.R
 default_cran_mirror <- function() {
-  mirror <- getOption("repos")["CRAN"]
-  if (is.null(mirror) || is.na(mirror) || mirror == "@CRAN@") {
-    c(CRAN = "https://cloud.r-project.org")
-  } else {
-    c(CRAN = unname(mirror))
+  repos <- getOption("repos")
+  cran <- repos["CRAN"]
+  if (is.null(cran) || is.na(cran) || cran == "@CRAN@") {
+    repos["CRAN"] <- "https://cloud.r-project.org"
   }
+  repos
 }

--- a/tests/testthat/test-release.R
+++ b/tests/testthat/test-release.R
@@ -200,7 +200,7 @@ test_that("get_release_data() works for new-style CRAN-RELEASE", {
   expect_equal(path_file(res$file), "CRAN-SUBMISSION")
 })
 
-test_that("cran_version() is robust to unset CRAN mirror with unreleased pkg (#1857)", {
+test_that("cran_version() works for unreleased pkg with CRAN mirror set/unset (#1857)", {
   create_local_package()
 
   cran_repos <- list(

--- a/tests/testthat/test-release.R
+++ b/tests/testthat/test-release.R
@@ -199,3 +199,38 @@ test_that("get_release_data() works for new-style CRAN-RELEASE", {
   expect_equal(res$SHA, HEAD)
   expect_equal(path_file(res$file), "CRAN-SUBMISSION")
 })
+
+test_that("cran_version() is robust to unset CRAN mirror with unreleased pkg (#1857)", {
+  create_local_package()
+
+  cran_repos <- list(
+    c(CRAN = "https://cloud.r-project.org"),
+    c(CRAN = "@CRAN@"),
+    c(CRAN = NA),
+    NULL
+  )
+
+  lapply(cran_repos, function(x) {
+    withr::with_options(
+      list(repos = x),
+      expect_null(cran_version())
+    )
+  })
+})
+
+test_that("cran_version() is robust to unset CRAN mirror with released pkg (#1857)", {
+  cran_repos <- list(
+    c(CRAN = "https://cloud.r-project.org"),
+    c(CRAN = "@CRAN@"),
+    c(CRAN = NA),
+    NULL
+  )
+
+  lapply(cran_repos, function(x) {
+    withr::with_options(
+      list(repos = x),
+      expect_s3_class(cran_version("usethis"), "package_version")
+    )
+  })
+})
+


### PR DESCRIPTION
Fixes #1857.

This:

- Bails and returns `NULL` if offline.
- Passes `default_cran_version()` to the `repos` argument of `available.packages()` (this seemed more straightforward than setting local options). 
    - `default_cran_version()` is borrowed from [pak](https://github.com/r-lib/pak/blob/168ab5d58fc244e5084c2800c87b8a574d66c3ba/R/default-cran-mirror.R#L4), however I set the fallback mirror to `cloud.r-project.org` rather than `cran.rstudio.com`, which seems more canonical - but I'm happy to be re-educated. 
    - I modified `default_cran_version()` from pak to respect the users' other repos and append CRAN rather than replace the entire repos option with just CRAN. (As implemented in pak it only returns a CRAN repo, even if the user had other repos set in their `repos` option).
- The call to `available.packages()` is wrapped in a `try`, and returns `NULL` if it fails.

Do we want to emit any warnings or messages in case of the early returns of `NULL` (no internet or failure to check CRAN)?

