### PR TITLE
Make compute_name() work when `ext` is not "R"

### DIFF
--- a/R/r.R
+++ b/R/r.R
@@ -78,7 +78,7 @@ compute_name <- function(name = NULL, ext = "R", error_call = caller_env()) {
 
     if (path_ext(name) == "") {
       name <- path_ext_set(name, ext)
-    } else if (path_ext(name) != "R") {
+    } else if (path_ext(name) != ext) {
       cli::cli_abort(
         "{.arg name} must have extension {.str {ext}}, not {.str {path_ext(name)}}.",
         call = error_call

--- a/tests/testthat/test-r.R
+++ b/tests/testthat/test-r.R
@@ -34,7 +34,6 @@ test_that("compute_name() validates its inputs", {
     compute_name("")
     compute_name("****")
   })
-  expect_equal(compute_name("foo.c", ext = "c"), "foo.c")
 })
 
 test_that("compute_active_name() errors if no files open", {
@@ -66,5 +65,9 @@ test_that("compute_active_name() standardises name", {
     compute_active_name(path(dir, "R/data.frame.R"), "R"),
     "data.frame.R"
   )
+})
 
+# https://github.com/r-lib/usethis/issues/1863
+test_that("compute_name() accepts the declared extension", {
+  expect_equal(compute_name("foo.cpp", ext = "cpp"), "foo.cpp")
 })

--- a/tests/testthat/test-r.R
+++ b/tests/testthat/test-r.R
@@ -34,6 +34,7 @@ test_that("compute_name() validates its inputs", {
     compute_name("")
     compute_name("****")
   })
+  expect_equal(compute_name("foo.c", ext = "c"), "foo.c")
 })
 
 test_that("compute_active_name() errors if no files open", {


### PR DESCRIPTION
Closes #1863

Please see #1863 for a description of the issue that this PR is aiming to address.