### PR TITLE
coverage.R: update codecov URL of badge

### DIFF
--- a/R/coverage.R
+++ b/R/coverage.R
@@ -42,7 +42,7 @@ use_covr_ignore <- function(files) {
 
 use_codecov_badge <- function(repo_spec) {
   default_branch <- git_default_branch()
-  url <- glue("https://app.codecov.io/gh/{repo_spec}?branch={default_branch}")
+  url <- glue("https://app.codecov.io/gh/{repo_spec}/tree/{default_branch}")
   img <- glue("https://codecov.io/gh/{repo_spec}/branch/{default_branch}/graph/badge.svg")
   use_badge("Codecov test coverage", url, img)
 }


### PR DESCRIPTION
The URL format with `?branch=` does not appear to work anymore, it is ignored by codecov.