### PR TITLE
Remove self-reference from use_description() documentation

### DIFF
--- a/R/create.R
+++ b/R/create.R
@@ -10,6 +10,9 @@
 #' any existing files are changed.
 #'
 #' @inheritParams use_description
+#' @param fields A named list of fields to add to `DESCRIPTION`, potentially
+#'   overriding default values. See [use_description()] for how you can set
+#'   personalized defaults using package options.
 #' @param path A path. If it exists, it is used. If it does not exist, it is
 #'   created, provided that the parent path exists.
 #' @param roxygen Do you plan to use roxygen2 to document your package?

--- a/R/description.R
+++ b/R/description.R
@@ -13,7 +13,7 @@
 
 #' usethis consults the following sources, in this order, to set `DESCRIPTION`
 #' fields:
-#' * `fields` argument of [create_package()] or [use_description()]
+#' * `fields` argument of [create_package()] or `use_description()`
 #' * `getOption("usethis.description")`
 #' * Defaults built into usethis
 #'
@@ -44,8 +44,9 @@
 #' supported.
 #'
 #' @param fields A named list of fields to add to `DESCRIPTION`, potentially
-#'   overriding default values. See [use_description()] for how you can set
-#'   personalized defaults using package options.
+#'   overriding default values. Default values are taken from the
+#'   `"usethis.description"` option or the usethis package (in that order), and
+#'   can be viewed with `use_description_defaults()`.
 #' @param check_name Whether to check if the name is valid for CRAN and throw an
 #'   error if not.
 #' @param roxygen If `TRUE`, sets `RoxygenNote` to current roxygen2 version

--- a/man/use_description.Rd
+++ b/man/use_description.Rd
@@ -11,8 +11,9 @@ use_description_defaults(package = NULL, roxygen = TRUE, fields = list())
 }
 \arguments{
 \item{fields}{A named list of fields to add to \code{DESCRIPTION}, potentially
-overriding default values. See \code{\link[=use_description]{use_description()}} for how you can set
-personalized defaults using package options.}
+overriding default values. Default values are taken from the
+\code{"usethis.description"} option or the usethis package (in that order), and
+can be viewed with \code{use_description_defaults()}.}
 
 \item{check_name}{Whether to check if the name is valid for CRAN and throw an
 error if not.}
@@ -32,7 +33,7 @@ CRAN-compliant package name. You can turn this off with \code{check_name = FALSE
 usethis consults the following sources, in this order, to set \code{DESCRIPTION}
 fields:
 \itemize{
-\item \code{fields} argument of \code{\link[=create_package]{create_package()}} or \code{\link[=use_description]{use_description()}}
+\item \code{fields} argument of \code{\link[=create_package]{create_package()}} or \code{use_description()}
 \item \code{getOption("usethis.description")}
 \item Defaults built into usethis
 }


### PR DESCRIPTION
Fixes #1881 