### PR TITLE
`use_github()` - allow repo creation when repo is a redirect

### DIFF
--- a/R/github.R
+++ b/R/github.R
@@ -268,6 +268,7 @@ check_no_origin <- function() {
 }
 
 check_no_github_repo <- function(owner, repo, host) {
+  spec <- glue("{owner}/{repo}")
   repo_found <- tryCatch(
     {
       repo_info <- gh::gh(
@@ -275,14 +276,16 @@ check_no_github_repo <- function(owner, repo, host) {
         owner = owner, repo = repo,
         .api_url = host
       )
-      TRUE
+      # FALSE if there is a redirect due to renamed repo
+      # so we should be able to push, otherwise
+      # TRUE if it really exists. #1893
+      repo_info$full_name == spec
     },
     "http_error_404" = function(err) FALSE
   )
   if (!repo_found) {
     return(invisible())
   }
-  spec <- glue("{owner}/{repo}")
   empirical_host <- parse_github_remotes(repo_info$html_url)$host
   ui_stop("Repo {ui_value(spec)} already exists on {ui_value(empirical_host)}")
 }

--- a/R/github.R
+++ b/R/github.R
@@ -271,14 +271,13 @@ check_no_github_repo <- function(owner, repo, host) {
   spec <- glue("{owner}/{repo}")
   repo_found <- tryCatch(
     {
-      repo_info <- gh::gh(
-        "/repos/{owner}/{repo}",
-        owner = owner, repo = repo,
-        .api_url = host
-      )
-      # FALSE if there is a redirect due to renamed repo
-      # so we should be able to push, otherwise
-      # TRUE if it really exists. #1893
+      repo_info <- gh::gh("/repos/{spec}", spec = spec, .api_url = host)
+      # when does repo_info$full_name != the spec we sent?
+      # this happens if you reuse the original name of a repo that has since
+      # been renamed
+      # there's no 404, because of the automatic redirect, but you CAN create
+      # a new repo with this name
+      # https://github.com/r-lib/usethis/issues/1893
       repo_info$full_name == spec
     },
     "http_error_404" = function(err) FALSE


### PR DESCRIPTION
This changes `check_no_github_repo()` to check the name of the response from the GitHub API against the provided spec (user/repo) - If they are different it assumes it's a redirect and then proceeds and allows repo creation. It retains the behaviour where if request to the GitHub API returns a 404 it similarly passes and allows the creation of the new repo.

Unfortunately the response returned from the GitHub API doesn't appear to explicitly say it's been redirected (i.e., it's a 200 HTTP code, not a 301).

Fixes #1893.

I didn't add any tests - though could add to the manual tests if you like?