### PR TITLE
Tweak blog post action order

### DIFF
--- a/R/release.R
+++ b/R/release.R
@@ -137,11 +137,11 @@ release_checklist <- function(version, on_cran) {
     "Wait for CRAN...",
     "",
     todo("Accepted :tada:"),
-    todo("Add preemptive link to blog post in pkgdown news menu", type != "patch"),
+    todo("Finish & publish blog post", type != "patch"),
+    todo("Add link to blog post in pkgdown news menu", type != "patch"),
     todo("`usethis::use_github_release()`"),
     todo("`usethis::use_dev_version(push = TRUE)`"),
     todo("`usethis::use_news_md()`", !has_news),
-    todo("Finish blog post", type != "patch"),
     todo("Tweet", type != "patch")
   )
 }

--- a/tests/testthat/_snaps/release.md
+++ b/tests/testthat/_snaps/release.md
@@ -33,11 +33,11 @@
       Wait for CRAN...
       
       * [ ] Accepted :tada:
-      * [ ] Add preemptive link to blog post in pkgdown news menu
+      * [ ] Finish & publish blog post
+      * [ ] Add link to blog post in pkgdown news menu
       * [ ] `usethis::use_github_release()`
       * [ ] `usethis::use_dev_version(push = TRUE)`
       * [ ] `usethis::use_news_md()`
-      * [ ] Finish blog post
       * [ ] Tweet
 
 ---
@@ -101,11 +101,11 @@
       Wait for CRAN...
       
       * [ ] Accepted :tada:
-      * [ ] Add preemptive link to blog post in pkgdown news menu
+      * [ ] Finish & publish blog post
+      * [ ] Add link to blog post in pkgdown news menu
       * [ ] `usethis::use_github_release()`
       * [ ] `usethis::use_dev_version(push = TRUE)`
       * [ ] `usethis::use_news_md()`
-      * [ ] Finish blog post
       * [ ] Tweet
 
 # construct correct revdep bullet
@@ -158,10 +158,10 @@
       Wait for CRAN...
       
       * [ ] Accepted :tada:
-      * [ ] Add preemptive link to blog post in pkgdown news menu
+      * [ ] Finish & publish blog post
+      * [ ] Add link to blog post in pkgdown news menu
       * [ ] `usethis::use_github_release()`
       * [ ] `usethis::use_dev_version(push = TRUE)`
       * [ ] `usethis::use_news_md()`
-      * [ ] Finish blog post
       * [ ] Tweet
 


### PR DESCRIPTION
I assume the intent here is to get the blog post into the newly built site, but I found the order action a bit confusing, especially given that I like to be absolutely sure I'm getting the right url by copying it from the live site.