### PR TITLE
Shift tidy support template (and SUPPORT.md) to use inclusive language

### DIFF
--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -7,7 +7,7 @@ Before filing an issue, there are a few places to explore and pieces to put toge
 
 Start by making a minimal **repr**oducible **ex**ample using the  [reprex](https://reprex.tidyverse.org/) package. 
 If you haven't heard of or used reprex before, you're in for a treat! 
-Seriously, reprex will make all of your R-question-asking endeavors easier (which is a pretty insane ROI for the five to ten minutes it'll take you to learn what it's all about). 
+Seriously, reprex will make all of your R-question-asking endeavors easier (which is a pretty incredible ROI for the five to ten minutes it'll take you to learn what it's all about). 
 For additional reprex pointers, check out the [Get help!](https://www.tidyverse.org/help/) section of the tidyverse site.
 
 ## Where to ask?

--- a/inst/templates/tidy-support.md
+++ b/inst/templates/tidy-support.md
@@ -7,7 +7,7 @@ Before filing an issue, there are a few places to explore and pieces to put toge
 
 Start by making a minimal **repr**oducible **ex**ample using the  [reprex](https://reprex.tidyverse.org/) package. 
 If you haven't heard of or used reprex before, you're in for a treat! 
-Seriously, reprex will make all of your R-question-asking endeavors easier (which is a pretty insane ROI for the five to ten minutes it'll take you to learn what it's all about). 
+Seriously, reprex will make all of your R-question-asking endeavors easier (which is a pretty incredible ROI for the five to ten minutes it'll take you to learn what it's all about). 
 For additional reprex pointers, check out the [Get help!](https://www.tidyverse.org/help/) section of the tidyverse site.
 
 ## Where to ask?


### PR DESCRIPTION
As there's a shift away from [using descriptions of mental illness as generic intensifiers](https://www.npr.org/2019/07/08/739643765/why-people-are-arguing-to-stop-using-the-words-crazy-and-insane), and usethis provides the template for many SUPPORT.md files, I think it might be nice to use more inclusive language in the default SUPPORT.md template. This PR changes the word "insane" to "incredible" in both the tidy-support template and in the SUPPORT.md generated from this file in this repo.