### PR TITLE
1926 gh release

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,11 @@
 
 * `use_cpp11()` now automatically updates the `NAMESPACE` (@pachadotdev, #1921).
 
+* `use_github_release()` gains two arguments: `prerelease` and 
+  `generate_release_notes` argument to identify releases as a prerelease and 
+  automatically generate additional release notes from commits, respectively 
+  (@jmbarbone, #1926).
+
 # usethis 2.2.2
 
 * Implicit usage of `numeric_version()` via comparison now always provides

--- a/R/release.R
+++ b/R/release.R
@@ -214,9 +214,8 @@ release_type <- function(version) {
 
 #' Publish a GitHub release
 #'
-#' @description
-#' Pushes the current branch (if safe) then publishes a GitHub release for the
-#' latest CRAN submission.
+#' @description Pushes the current branch (if safe) then publishes a GitHub
+#' release for the latest CRAN submission.
 #'
 #' If you use [devtools::submit_cran()] to submit to CRAN, information about the
 #' submitted state is captured in a `CRAN-SUBMISSION` file.
@@ -230,8 +229,14 @@ release_type <- function(version) {
 #'   a URL determined from the current project's GitHub remotes.
 #' @param publish If `TRUE`, publishes a release. If `FALSE`, creates a draft
 #'   release.
+#' @param prerelease If `TRUE` identify the release as a prerelease.
+#' @param generate_release_notes If `TRUE`, the body will be append with
+#'   automatically generated notes.
+#'
 #' @export
 use_github_release <- function(publish = TRUE,
+                               prerelease = FALSE,
+                               generate_release_notes = FALSE,
                                host = deprecated(),
                                auth_token = deprecated()) {
   check_is_package("use_github_release()")
@@ -269,7 +274,9 @@ use_github_release <- function(publish = TRUE,
     tag_name = tag_name,
     target_commitish = dat$SHA,
     body = news,
-    draft = !publish
+    draft = !publish,
+    prerelease = prerelease,
+    generate_release_notes = generate_release_notes
   )
   ui_cli_inform("Release at {.url {release$html_url}}")
 

--- a/man/use_github_release.Rd
+++ b/man/use_github_release.Rd
@@ -6,6 +6,8 @@
 \usage{
 use_github_release(
   publish = TRUE,
+  prerelease = FALSE,
+  generate_release_notes = FALSE,
   host = deprecated(),
   auth_token = deprecated()
 )
@@ -14,13 +16,18 @@ use_github_release(
 \item{publish}{If \code{TRUE}, publishes a release. If \code{FALSE}, creates a draft
 release.}
 
+\item{prerelease}{If \code{TRUE} identify the release as a prerelease.}
+
+\item{generate_release_notes}{If \code{TRUE}, the body will be append with
+automatically generated notes.}
+
 \item{host, auth_token}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}: No longer
 consulted now that usethis allows the gh package to lookup a token based on
 a URL determined from the current project's GitHub remotes.}
 }
 \description{
-Pushes the current branch (if safe) then publishes a GitHub release for the
-latest CRAN submission.
+Pushes the current branch (if safe) then publishes a GitHub
+release for the latest CRAN submission.
 
 If you use \code{\link[devtools:submit_cran]{devtools::submit_cran()}} to submit to CRAN, information about the
 submitted state is captured in a \code{CRAN-SUBMISSION} file.


### PR DESCRIPTION
resolves #1926 

I've included the parameters as they are in the GH API, but `generate_release_notes` does seem a little bulky.  Something nicer could be used.