### PR TITLE
Indicate argument type

### DIFF
--- a/R/package.R
+++ b/R/package.R
@@ -23,8 +23,8 @@
 #'   "Suggests", "Enhances", or "LinkingTo" (or unique abbreviation). Matching
 #'   is case insensitive.
 #' @param min_version Optionally, supply a minimum version for the package. Set
-#'   to `TRUE` to use the currently installed version or use a character vector
-#'   to specify an exact version.
+#'   to `TRUE` to use the currently installed version or use a version string
+#'   suitable for [numeric_version()], such as "2.5.0".
 #' @param remote By default, an `OWNER/REPO` GitHub remote is inserted.
 #'   Optionally, you can supply a character string to specify the remote, e.g.
 #'   `"gitlab::jimhester/covr"`, using any syntax supported by the [remotes

--- a/R/package.R
+++ b/R/package.R
@@ -23,7 +23,8 @@
 #'   "Suggests", "Enhances", or "LinkingTo" (or unique abbreviation). Matching
 #'   is case insensitive.
 #' @param min_version Optionally, supply a minimum version for the package. Set
-#'   to `TRUE` to use the currently installed version.
+#'   to `TRUE` to use the currently installed version or use a charactor vector
+#'   to specify an exact version.
 #' @param remote By default, an `OWNER/REPO` GitHub remote is inserted.
 #'   Optionally, you can supply a character string to specify the remote, e.g.
 #'   `"gitlab::jimhester/covr"`, using any syntax supported by the [remotes

--- a/R/package.R
+++ b/R/package.R
@@ -23,7 +23,7 @@
 #'   "Suggests", "Enhances", or "LinkingTo" (or unique abbreviation). Matching
 #'   is case insensitive.
 #' @param min_version Optionally, supply a minimum version for the package. Set
-#'   to `TRUE` to use the currently installed version or use a charactor vector
+#'   to `TRUE` to use the currently installed version or use a character vector
 #'   to specify an exact version.
 #' @param remote By default, an `OWNER/REPO` GitHub remote is inserted.
 #'   Optionally, you can supply a character string to specify the remote, e.g.

--- a/man/use_package.Rd
+++ b/man/use_package.Rd
@@ -17,8 +17,8 @@ use_dev_package(package, type = "Imports", remote = NULL)
 is case insensitive.}
 
 \item{min_version}{Optionally, supply a minimum version for the package. Set
-to \code{TRUE} to use the currently installed version or use a character vector
-to specify an exact version.}
+to \code{TRUE} to use the currently installed version or use a version string
+suitable for \code{\link[=numeric_version]{numeric_version()}}, such as "2.5.0".}
 
 \item{remote}{By default, an \code{OWNER/REPO} GitHub remote is inserted.
 Optionally, you can supply a character string to specify the remote, e.g.

--- a/man/use_package.Rd
+++ b/man/use_package.Rd
@@ -17,7 +17,8 @@ use_dev_package(package, type = "Imports", remote = NULL)
 is case insensitive.}
 
 \item{min_version}{Optionally, supply a minimum version for the package. Set
-to \code{TRUE} to use the currently installed version.}
+to \code{TRUE} to use the currently installed version or use a character vector
+to specify an exact version.}
 
 \item{remote}{By default, an \code{OWNER/REPO} GitHub remote is inserted.
 Optionally, you can supply a character string to specify the remote, e.g.


### PR DESCRIPTION
On several occasions now I have tried to add a minimum package version using a `double` like so:

```r
usethis::use_package("my_package", min_version = 1.1.0)
```

Each time I get an error, as I incorrectly guessed that `min_version` would require a numeric type. While I think the error message is helpful enough (`Error: unexpected numeric contstant in "usethis...`), I think the documentation could be improved.

Currently, it is only clear that `min_version` should be a character vector when looking at the examples. The parameter documentation is not clear in and of itself.