### PR TITLE
Add more PR links

### DIFF
--- a/R/pr.R
+++ b/R/pr.R
@@ -867,23 +867,25 @@ choose_branch <- function(exclude = character()) {
     )
     prompt <- glue("{prompt}\n{fine_print}")
   }
-  dat$pretty_name <- format(dat$name, justify = "right")
+
+  # For alignment
+  dat$leading_spaces <- sub("\\S.*$", "", format(dat$name, justify = "right"))
   dat_pretty <- purrr::pmap_chr(
-    dat[c("pretty_name", "pr_number", "pr_html_url", "pr_user", "pr_title")],
-    function(pretty_name, pr_number, pr_html_url, pr_user, pr_title) {
+    dat[c("leading_spaces", "pr_number", "pr_html_url", "pr_user", "pr_title", "name")],
+    function(leading_spaces, pr_number, pr_html_url, pr_user, pr_title, name) {
       if (is.na(pr_number)) {
-        pretty_name
+        cli::format_inline("{leading_spaces}{.run [{name}](usethis::pr_resume('{name}'))}")
       } else {
         href_number <- ui_pre_glue("{.href [PR #<<pr_number>>](<<pr_html_url>>)}")
         at_user <- glue("@{pr_user}")
         template <- ui_pre_glue(
-          "{pretty_name} {cli::symbol$arrow_right} <<href_number>> ({.field <<at_user>>}): {.val <<pr_title>>}"
+          "{leading_spaces}{.run [{name}](usethis::pr_resume('{name}'))} {cli::symbol$arrow_right} <<href_number>> ({.field <<at_user>>}): {.val <<pr_title>>}"
         )
         cli::format_inline(template)
       }
     }
   )
-  choice <- utils::menu(title = prompt, choices = cli::ansi_strtrim(dat_pretty))
+  choice <- utils::menu(title = prompt, choices = cli::ansi_strtrim(dat_pretty, width = cli::console_width() - 1L))
   dat$name[choice]
 }
 
@@ -936,7 +938,7 @@ choose_pr <- function(tr = NULL, pr_dat = NULL) {
   )
   choice <- utils::menu(
     title = prompt,
-    choices = cli::ansi_strtrim(pr_pretty)
+    choices = cli::ansi_strtrim(pr_pretty, width = cli::console_width() - 1L)
   )
   as.list(pr_dat[choice, ])
 }

--- a/R/pr.R
+++ b/R/pr.R
@@ -969,7 +969,7 @@ pr_branch_delete <- function(pr) {
 
   if (is.null(pr_ref)) {
     ui_bullets(c(
-      "i" = "PR {.val {pr$pr_string}} originated from branch {.val {pr_remref}},
+      "i" = "{.href [PR {pr$pr_string}]({pr$pr_html_url})} originated from branch {.val {pr_remref}},
              which no longer exists."
     ))
     return(invisible(FALSE))
@@ -977,14 +977,14 @@ pr_branch_delete <- function(pr) {
 
   if (is.na(pr$pr_merged_at)) {
     ui_bullets(c(
-      "i" = "PR {.val {pr$pr_string}} is unmerged, we will not delete the
+      "i" = "{.href [PR {pr$pr_string}]({pr$pr_html_url})} is unmerged, we will not delete the
              remote branch {.val {pr_remref}}."
     ))
     return(invisible(FALSE))
   }
 
   ui_bullets(c(
-    "v" = "PR {.val {pr$pr_string}} has been merged, deleting remote branch
+    "v" = "{.href [PR {pr$pr_string}]({pr$pr_html_url})} has been merged, deleting remote branch
            {.val {pr_remref}}."
   ))
   # TODO: tryCatch here?


### PR DESCRIPTION
on main: 
![image](https://github.com/r-lib/usethis/assets/52606734/a6a8d033-a9b5-48f5-b61b-9a985ccec8cf)

this PR:
![image](https://github.com/r-lib/usethis/assets/52606734/fd7f51fe-2608-4609-93be-9393576720a2)

Just as `pr_resume()` can be used as a sitrep. If cancelling, it would be possible to have a direct link to `pr_resume('branch')`.

I also added more links to PRs in other pr functions (will test interactively in the coming days)