### PR TITLE
tweak `compute_name()` to recognize test helper and snapshot files

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # usethis (development version)
 
+* `use_test()` and `use_r()` now work when you are in `tests/testthat/helper-{foo}.R` or `tests/testthat/_snaps/{foo}.md` (@olivroy, #1988).
+
 * The `ui_*()` functions have been marked as
   [superseded](https://lifecycle.r-lib.org/articles/stages.html#superseded).
   External users of these functions are encouraged to use the

--- a/R/r.R
+++ b/R/r.R
@@ -116,13 +116,13 @@ compute_active_name <- function(path, ext, error_call = caller_env()) {
   path <- proj_path_prep(path_expand_r(path))
 
   dir <- path_dir(proj_rel_path(path))
-  if (!dir %in% c("R", "src", "tests/testthat")) {
+  if (!dir %in% c("R", "src", "tests/testthat", "tests/testthat/_snaps")) {
     cli::cli_abort("Open file must be a code or test file.", call = error_call)
   }
 
   file <- path_file(path)
   if (dir == "tests/testthat") {
-    file <- gsub("^test[-_]", "", file)
+    file <- gsub("^test[-_]|^helper[-_]", "", file)
   }
   as.character(path_ext_set(file, ext))
 }

--- a/tests/testthat/test-r.R
+++ b/tests/testthat/test-r.R
@@ -60,6 +60,14 @@ test_that("compute_active_name() standardises name", {
     "bar.R"
   )
 
+  expect_equal(
+    compute_active_name(path(dir, "tests/testthat/helper-bar.R"), "R"),
+    "bar.R"
+  )
+  expect_equal(
+    compute_active_name(path(dir, "tests/testthat/_snaps/bar.md"), "R"),
+    "bar.R"
+  )
   # https://github.com/r-lib/usethis/issues/1690
   expect_equal(
     compute_active_name(path(dir, "R/data.frame.R"), "R"),


### PR DESCRIPTION
fix #1988 

Tested manually that this worked as expected too!

I decided to create a PR because I had squeezed in and tested something similar in https://github.com/r-lib/usethis/pull/1978#discussion_r1561210187 and I thought I'd separate out in another PR.