### PR TITLE
Add PR link to pr_finish

### DIFF
--- a/R/pr.R
+++ b/R/pr.R
@@ -967,7 +967,7 @@ pr_branch_delete <- function(pr) {
 
   if (is.null(pr_ref)) {
     ui_bullets(c(
-      "i" = "{.href [PR #{pr$pr_number}]({pr$pr_html_url})} originated from branch {.val {pr_remref}},
+      "i" = "PR {.href [{pr$pr_string}]({pr$pr_html_url})} originated from branch {.val {pr_remref}},
              which no longer exists."
     ))
     return(invisible(FALSE))
@@ -975,14 +975,14 @@ pr_branch_delete <- function(pr) {
 
   if (is.na(pr$pr_merged_at)) {
     ui_bullets(c(
-      "i" = "{.href [PR #{pr$pr_number}]({pr$pr_html_url})} is unmerged, we will not delete the
+      "i" = "PR {.href [{pr$pr_string}]({pr$pr_html_url})} is unmerged, we will not delete the
              remote branch {.val {pr_remref}}."
     ))
     return(invisible(FALSE))
   }
 
   ui_bullets(c(
-    "v" = "{.href [PR #{pr$pr_number}]({pr$pr_html_url})} has been merged, deleting remote branch
+    "v" = "PR {.href [{pr$pr_string}]({pr$pr_html_url})} has been merged, deleting remote branch
            {.val {pr_remref}}."
   ))
   # TODO: tryCatch here?

--- a/R/pr.R
+++ b/R/pr.R
@@ -967,7 +967,7 @@ pr_branch_delete <- function(pr) {
 
   if (is.null(pr_ref)) {
     ui_bullets(c(
-      "i" = "PR {.val {pr$pr_string}} originated from branch {.val {pr_remref}},
+      "i" = "PR {.href [{.val {pr$pr_string}}]({pr$pr_html_url})} originated from branch {.val {pr_remref}},
              which no longer exists."
     ))
     return(invisible(FALSE))
@@ -975,14 +975,14 @@ pr_branch_delete <- function(pr) {
 
   if (is.na(pr$pr_merged_at)) {
     ui_bullets(c(
-      "i" = "PR {.val {pr$pr_string}} is unmerged, we will not delete the
+      "i" = "PR {.href [{.val {pr$pr_string}}]({pr$pr_html_url})} is unmerged, we will not delete the
              remote branch {.val {pr_remref}}."
     ))
     return(invisible(FALSE))
   }
 
   ui_bullets(c(
-    "v" = "PR {.val {pr$pr_string}} has been merged, deleting remote branch
+    "v" = "PR {.href [{.val {pr$pr_string}}]({pr$pr_html_url})} has been merged, deleting remote branch
            {.val {pr_remref}}."
   ))
   # TODO: tryCatch here?

--- a/R/pr.R
+++ b/R/pr.R
@@ -967,7 +967,7 @@ pr_branch_delete <- function(pr) {
 
   if (is.null(pr_ref)) {
     ui_bullets(c(
-      "i" = "{.href [PR #{pr$number}]({pr$pr_html_url})} originated from branch {.val {pr_remref}},
+      "i" = "{.href [PR #{pr$pr_number}]({pr$pr_html_url})} originated from branch {.val {pr_remref}},
              which no longer exists."
     ))
     return(invisible(FALSE))
@@ -975,14 +975,14 @@ pr_branch_delete <- function(pr) {
 
   if (is.na(pr$pr_merged_at)) {
     ui_bullets(c(
-      "i" = "{.href [PR #{pr$number}]({pr$pr_html_url})} is unmerged, we will not delete the
+      "i" = "{.href [PR #{pr$pr_number}]({pr$pr_html_url})} is unmerged, we will not delete the
              remote branch {.val {pr_remref}}."
     ))
     return(invisible(FALSE))
   }
 
   ui_bullets(c(
-    "v" = "{.href [PR #{pr$number}]({pr$pr_html_url})} has been merged, deleting remote branch
+    "v" = "{.href [PR #{pr$pr_number}]({pr$pr_html_url})} has been merged, deleting remote branch
            {.val {pr_remref}}."
   ))
   # TODO: tryCatch here?

--- a/R/pr.R
+++ b/R/pr.R
@@ -967,7 +967,7 @@ pr_branch_delete <- function(pr) {
 
   if (is.null(pr_ref)) {
     ui_bullets(c(
-      "i" = "PR {.href [{.val {pr$pr_string}}]({pr$pr_html_url})} originated from branch {.val {pr_remref}},
+      "i" = "{.href [PR #{pr$number}]({pr$pr_html_url})} originated from branch {.val {pr_remref}},
              which no longer exists."
     ))
     return(invisible(FALSE))
@@ -975,14 +975,14 @@ pr_branch_delete <- function(pr) {
 
   if (is.na(pr$pr_merged_at)) {
     ui_bullets(c(
-      "i" = "PR {.href [{.val {pr$pr_string}}]({pr$pr_html_url})} is unmerged, we will not delete the
+      "i" = "{.href [PR #{pr$number}]({pr$pr_html_url})} is unmerged, we will not delete the
              remote branch {.val {pr_remref}}."
     ))
     return(invisible(FALSE))
   }
 
   ui_bullets(c(
-    "v" = "PR {.href [{.val {pr$pr_string}}]({pr$pr_html_url})} has been merged, deleting remote branch
+    "v" = "{.href [PR #{pr$number}]({pr$pr_html_url})} has been merged, deleting remote branch
            {.val {pr_remref}}."
   ))
   # TODO: tryCatch here?


### PR DESCRIPTION
Sometimes, if you reopen a project later, you may want to be able to jump back to the PR URL