### PR TITLE
Add advice to view existing branches in `pr_resume()`

### DIFF
--- a/R/pr.R
+++ b/R/pr.R
@@ -254,6 +254,7 @@ pr_resume <- function(branch = NULL) {
     code <- glue('usethis::pr_init("{branch}")')
     ui_abort(c(
       "x" = "No branch named {.val {branch}} exists.",
+      "i" = "See {.run [existing branches](gert::git_branch_list(local = TRUE))} or", 
       "_" = "Call {.run {code}} to create a new PR branch."
     ))
   }


### PR DESCRIPTION
Let's say I call `pr_resume("git")`, but branch `git2` exists. `pr_resume()` will error but there is no hint that branch `git2` exists already.

This adds a runnable link to view local branches