### PR TITLE
Add badge when updating coverage action

### DIFF
--- a/R/github-actions.R
+++ b/R/github-actions.R
@@ -123,10 +123,14 @@ use_github_action <- function(name = NULL,
   if (!is.null(readme)) {
     ui_bullets(c("_" = "Learn more at {.url {readme}}."))
   }
-
-  badge <- badge %||% is_check_action(url)
+  badge0 <- badge
+  badge <- badge0 %||% is_check_action(url)
   if (badge) {
     use_github_actions_badge(path_file(save_as))
+  }
+  badge <- badge0 %||% is_coverage_action(url)
+  if (badge) {
+    use_codecov_badge(target_repo_spec())
   }
 
   invisible(new)
@@ -165,6 +169,10 @@ choose_gha_workflow <- function(error_call = caller_env()) {
 
 is_check_action <- function(url) {
   grepl("^check-", path_file(url))
+}
+
+is_coverage_action <- function(url) {
+  grepl("coverage", path_file(url))
 }
 
 #' Generates a GitHub Actions badge

--- a/R/github-actions.R
+++ b/R/github-actions.R
@@ -123,13 +123,11 @@ use_github_action <- function(name = NULL,
   if (!is.null(readme)) {
     ui_bullets(c("_" = "Learn more at {.url {readme}}."))
   }
-  badge0 <- badge
-  badge <- badge0 %||% is_check_action(url)
-  if (badge) {
+
+  if (badge %||% is_check_action(url)) {
     use_github_actions_badge(path_file(save_as))
   }
-  badge <- badge0 %||% is_coverage_action(url)
-  if (badge) {
+  if (badge %||% is_coverage_action(url)) {
     use_codecov_badge(target_repo_spec())
   }
 
@@ -172,7 +170,7 @@ is_check_action <- function(url) {
 }
 
 is_coverage_action <- function(url) {
-  grepl("coverage", path_file(url))
+  grepl("test-coverage", path_file(url))
 }
 
 #' Generates a GitHub Actions badge


### PR DESCRIPTION
it would be a way to update the URL like we can when updating check action.

Workflow (After deleting temporarily from usethis README.Rmd)
![image](https://github.com/r-lib/usethis/assets/52606734/bf5f3829-b692-4cf9-9213-bc98b7e8a97b)

Doesn't prompt if the badge already exist.

Should it check for `codecov.yml`?