### PR TITLE
`git_sitrep()` works again without error if token is expired

### DIFF
--- a/R/github_token.R
+++ b/R/github_token.R
@@ -168,6 +168,13 @@ pat_sitrep <- function(host = "https://github.com",
       message,
       "i" = maybe_who$error
     )
+    # Workaround cli eval (to remove extra information) #2014
+    message$i.trace <- NULL
+    message$i.response_headers <- NULL
+    message$i.call <- NULL
+    message$i.response_content <- NULL
+    message$i.rlang <- NULL
+    message$i.use_cli_format <- NULL
     ui_bullets(message)
     return(invisible(FALSE))
   }


### PR DESCRIPTION
@jennybc this is a fix to a regression that is caused by the switch to cli.

Basically, this removes some elements to the message object, since it contains many things that should not be printed.

```r
usethis::git_sitrep()
```

usethis 2.2.3
![image](https://github.com/r-lib/usethis/assets/52606734/930aff1c-b811-4950-97ab-d1813c91de0b)
Current main
![image](https://github.com/r-lib/usethis/assets/52606734/be27781c-2b54-4047-9b1e-42296033c94c)
This PR
![image](https://github.com/r-lib/usethis/assets/52606734/5649b506-47e2-4b78-a1ce-97b7fe250f1b)
Doesn't show `Error in gh()`:



While working on this workaround fix, I saw another issue (not fixed).

The bullets are not properly formatted if a token is missing, but couldn't figure out how to fix this. 

I'd recommend you running `usethis::git_sitrep()` without a valid token to notice it.

Issue I am noticing (not addressed)
![image](https://github.com/r-lib/usethis/assets/52606734/e5d839ad-8dff-48a2-9b0a-5346ecad6aef)


