### PR TITLE
Stop repeating "which repo?" question in use_release_issue()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # usethis (development version)
 
+* `use_release_issue()` and `use_upkeep()` behave better when the user has a
+  fork. The user is asked just once to choose between `origin` and `upstream` as
+  the target repo (#2023).
+
 * `use_git()` no longer asks if you want to restart RStudio when using Positron.
 
 * `use_test()` and `use_r()` now work when you are in `tests/testthat/_snaps/{foo}.md` (@olivroy, #1988).
@@ -16,7 +20,7 @@
   superior option.
   There is a cli vignette about how to make this transition:
   `vignette("usethis-ui", package = "cli")`.
-  
+
   usethis no longer uses the `ui_*()` functions internally, in favor of new
   cli-based helpers that are not exported.
 
@@ -38,7 +42,7 @@
 * Internal helper `cran_version()`, used in functions such as
   `use_release_checklist()` and `use_news_md()`, is more resilient to situations
   where no CRAN mirror has been set (#1857).
-  
+
 * Internal usage of `numeric_version()` now always provides character input,
   rather than relying on implicit `as.character()` coercion. This is in response
   to a request from CRAN to anticipate future solutions to
@@ -53,53 +57,53 @@
 
 * `use_rstudio_preferences()` lets you set RStudio preferences programmatically
   (#1518)
-  
-* `use_standalone()` is a new function that makes it easier to use standalone 
+
+* `use_standalone()` is a new function that makes it easier to use standalone
   files provided by various low-level tidyverse packages, like rlang (#1654).
-  
-* `use_upkeep_issue()` is a new function to facilitate regular maintenance of 
-  your package. Similar to `use_release_issue()`, it opens an issue in your repo 
-  with a checklist of maintenance tasks. It will include additional bullets 
-  if your package includes an `upkeep_bullets()` function that returns a 
+
+* `use_upkeep_issue()` is a new function to facilitate regular maintenance of
+  your package. Similar to `use_release_issue()`, it opens an issue in your repo
+  with a checklist of maintenance tasks. It will include additional bullets
+  if your package includes an `upkeep_bullets()` function that returns a
   character vector (#1794).
 
 ## Package development
 
-* Although nested projects are discouraged, they can be useful in development 
-  contexts. `create_package()` now sets the correct package name and returns 
+* Although nested projects are discouraged, they can be useful in development
+  contexts. `create_package()` now sets the correct package name and returns
   the correct package path for a package nested inside a project (#1647).
 
 * `use_article()` no longer adds the rmarkdown package to `Suggests`. Instead,
   if rmarkdown is not already a dependency, it's added to
   `Config/Needs/website`. This means that a package that only uses articles
   (vs. vignettes) won't gain an unnecessary dependency on rmarkdown (#1700).
-  
-* `use_data()` now sets the appropriate minimal R version in `DESCRIPTION`, 
+
+* `use_data()` now sets the appropriate minimal R version in `DESCRIPTION`,
   depending on which serialization format `version` you choose (@dpprdan, #1672).
-  
+
 * `use_github_links()` by default now appends the GitHub url to existing urls in
   in the `URL` field of DESCRIPTION, rather than replacing existing urls (#1805).
 
 * `use_latest_dependencies()` no longer affects `Suggests` since those
   dependencies are not enforced (#1749).
-  
+
 * `use_news_md()` now places "(development version)" in the header of `NEWS.md`
-   if there is a development version number in `DESCRIPTION`. It also sets the 
+   if there is a development version number in `DESCRIPTION`. It also sets the
    first bullet to "Initial CRAN submission" when it looks like a "new" package
    (#1708).
-   
+
 * `use_coverage()` no longer adds covr to `Suggests`, since the `test-coverage`
   GitHub Actions workflow takes care of installing covr (@Bisaloo, #1851).
 
 ## Package release
 
-* `use_release_issue()` will now remind you to run `use_github_links()` if 
+* `use_release_issue()` will now remind you to run `use_github_links()` if
   necessary (@Bisaloo, #1754)
 
 * `use_release_issue()` now encourages the creation of `NEWS.md` prior to
   submission, instead of after (#1755).
-  
-* `use_github_release()` now automatically pushes to GitHub (if safe) and 
+
+* `use_github_release()` now automatically pushes to GitHub (if safe) and
   automatically publishes the release, rather than requiring you to edit and
   publish the draft (#1385).
 
@@ -107,11 +111,11 @@
 
 * `use_release_issue()` will now remind you to check/close the milestone
   corresponding to the release, if it exists (#1642).
-  
+
 * `use_version()` and `use_dev_version()` gain a `push` argument to optionally
   push the result after committing. This is used to eliminate a manual step from
   the `use_release_issue()` checklist (#1385).
-  
+
 * `use_revdep()` no longer places an email template, because these days we are
   more likely to communicate with other maintainers about breaking changes via
   GitHub issues and pull requests (#1769).
@@ -120,7 +124,7 @@
 
 * `rename_files()` now also affects files in `src/` (#1585).
 
-* `use_r()` and `use_test()` now work with all active files in `R/`, `src/`, 
+* `use_r()` and `use_test()` now work with all active files in `R/`, `src/`,
   and `tests/testthat/` (#1566).
 
 * `use_r()` and `use_test()` now work with files containing `.` (#1690).
@@ -135,16 +139,16 @@
   anywhere in the repo, not just the root directory. This is useful if you're
   working with repos that contain tools for multiple languages (#1680).
 
-* `git_sitrep()` gains two arguments: `tool` and `scope`, which enables 
+* `git_sitrep()` gains two arguments: `tool` and `scope`, which enables
   you to limit the report to, for example, `tool = "git"` or `scope = "user"`.
   The default remains to provide a full report. Also, provides more
   feedback if git user's information is not set, and checks global git-email
   against user-level GitHub PAT (@ijlyttle, #1732, #1714, #1706).
-  
-* `git_vaccinated()` now treats a path configured as `core.excludesFile` like 
-  other user-supplied paths; in particular, any use of the `~/` home directory 
-  shortcut is expanded via 
-  [`fs::path_expand()`](https://fs.r-lib.org/reference/path_expand.html) 
+
+* `git_vaccinated()` now treats a path configured as `core.excludesFile` like
+  other user-supplied paths; in particular, any use of the `~/` home directory
+  shortcut is expanded via
+  [`fs::path_expand()`](https://fs.r-lib.org/reference/path_expand.html)
   (@dpprdan, #1560).
 
 * `use_github_action()` now suggests possible actions when called without
@@ -159,26 +163,26 @@
 
 * Links to the R Packages book have been updated to the second edition of
   the book (#1689).
-  
-* The SVG badges placed by `use_lifecycle()` have improved accessibility 
-  features, i.e. they advertise the lifecycle stage via the `aria-label` 
+
+* The SVG badges placed by `use_lifecycle()` have improved accessibility
+  features, i.e. they advertise the lifecycle stage via the `aria-label`
   attribute (#1554, https://github.com/r-lib/lifecycle/issues/117).
-  
-* `use_rscloud_badge()` has been deprecated in favour of 
-  `use_posit_cloud_badge()`, and both functions now accept the updated url 
+
+* `use_rscloud_badge()` has been deprecated in favour of
+  `use_posit_cloud_badge()`, and both functions now accept the updated url
   format of Posit Cloud projects (#1670).
 
-* `use_rstudio()` gains a `reformat` argument which omits `.Rproj` settings 
-  that enforce file formatting conventions, e.g. around whitespace.   
-  `create_from_github()` uses this option when it introduces an `.Rproj` to a 
-  project that lacks one, making it easier to follow the project's existing 
+* `use_rstudio()` gains a `reformat` argument which omits `.Rproj` settings
+  that enforce file formatting conventions, e.g. around whitespace.
+  `create_from_github()` uses this option when it introduces an `.Rproj` to a
+  project that lacks one, making it easier to follow the project's existing
   conventions (#1679).
 
 * `write_over()` and `use_github_file()` gain an overwrite argument (#1748).
-  
+
 ## Tidyverse-related
 
-* `use_release_issue()` now uses internal `release_extra_revdeps()` to 
+* `use_release_issue()` now uses internal `release_extra_revdeps()` to
   add extra revdep sources. Currently only use for internal Posit tooling,
   but we hope to extend to all users in the future (#1610).
 
@@ -192,68 +196,68 @@
   evaluation (#1656).
 
 * `use_travis()`, `use_pkgdown_travis()`, `browse_travis()`, and `use_appveyor()`
-  are now defunct because we no longer recommend Travis or Appveyor. We 
+  are now defunct because we no longer recommend Travis or Appveyor. We
   recommend GitHub actions instead (#1517).
 
 # usethis 2.1.6
 
 ### GitHub-related
 
-* `use_github_action()` and friends gain a `ref` argument, which defaults to 
+* `use_github_action()` and friends gain a `ref` argument, which defaults to
   the tag of the latest release in <https://github.com/r-lib/actions> (#1541).
 
-* `use_github_actions_badge()` now uses the same URLs as GitHub does via the 
-  "Create status badge" helper in the browser (#1525). This changes the 
-  significance of the `name` argument; now it really must be the name of the 
+* `use_github_actions_badge()` now uses the same URLs as GitHub does via the
+  "Create status badge" helper in the browser (#1525). This changes the
+  significance of the `name` argument; now it really must be the name of the
   workflow configuration file.
 
-* All functions error more clearly when the requested operation is not 
+* All functions error more clearly when the requested operation is not
   supported for the "theirs" remote configuration (#1588).
 
 ### Other changes
 
 * `use_roxygen_md()` gains an `overwrite` argument (#1599).
 
-* `use_rscloud_badge()` is a new function that creates a README badge 
-  indicating the repository can be launched in an 
+* `use_rscloud_badge()` is a new function that creates a README badge
+  indicating the repository can be launched in an
   [RStudio Cloud](https://rstudio.cloud) project (@gvelasq, #1584).
 
 * `use_data()` gains an `ascii` argument, which is passed along to `save()`
   (@JosiahParry, #1625).
 
-* `use_code_of_conduct()` has been updated to version 2.1 of the Contributor 
+* `use_code_of_conduct()` has been updated to version 2.1 of the Contributor
   Covenant (@batpigandme, #1591).
 
 # usethis 2.1.5
 
-* pkgdown-related functions no longer automatically strip a trailing slash from 
-  the pkgdown site URL, in order to play more nicely with CRAN's URL checks 
+* pkgdown-related functions no longer automatically strip a trailing slash from
+  the pkgdown site URL, in order to play more nicely with CRAN's URL checks
   (#1526).
 
-* `edit_pkgdown_config()` is a new function that opens the pkgdown YAML 
+* `edit_pkgdown_config()` is a new function that opens the pkgdown YAML
   configuration file for the current Project, if such a file exists.
 
-* The error thrown when reporting an unsupported GitHub configuration has been 
+* The error thrown when reporting an unsupported GitHub configuration has been
   fixed for forward compatibility with a future version of rlang, i.e. what is
   anticipated to be rlang v1.0.0.
 
-* Version 2.1.4 was never released. Version was advanced from 2.1.4 to 2.1.5 
+* Version 2.1.4 was never released. Version was advanced from 2.1.4 to 2.1.5
   strictly for CRAN (re-)submission purposes.
 
 # usethis 2.1.3
 
-* Modified a test to ensure that intermittent GitHub rate limiting does not 
-  lead to ungraceful failure on CRAN. 
+* Modified a test to ensure that intermittent GitHub rate limiting does not
+  lead to ungraceful failure on CRAN.
 
 # usethis 2.1.2
 
-* `git_default_branch_rename()` no longer errors on repos where README exists, 
+* `git_default_branch_rename()` no longer errors on repos where README exists,
   but has no badge block.
 
-* `git_default_branch_rediscover()` prunes the defunct remote ref to the old 
+* `git_default_branch_rediscover()` prunes the defunct remote ref to the old
   default branch, e.g. `origin/master`.
 
-* Version 2.1.1 was never released. Version was advanced from 2.1.1 to 2.1.2 
+* Version 2.1.1 was never released. Version was advanced from 2.1.1 to 2.1.2
   strictly for CRAN (re-)submission purposes.
 
 # usethis 2.1.0
@@ -297,20 +301,20 @@ usethis has a more sophisticated understanding of the default branch and gains s
   arbitrary file on GitHub that the user has permission to read. It supports
   targeting a specific branch, tag, or commit and can follow a symlink (#1407).
   `use_github_file()` now powers `use_github_action()` and friends.
-  
+
 * `use_github_release()` is much more diligent about using any information left
   behind by `devtools::submit_cran()` or `devtools::release()`. Specifically,
   this applies to determining which SHA is to be tagged in the release. And this
   SHA, in turn, determines the consulted versions of DESCRIPTION (for package
   version) and NEWS.md (for release notes) (#1380).
 
-* `use_release_issue()` also takes bullets from `release_questions()`, 
+* `use_release_issue()` also takes bullets from `release_questions()`,
   for compatibility with `devtools::release()`.
 
 * `git_vaccinate()`, `edit_git_ignore()`, and `git_sitrep()` are more careful to
   consult, reveal, and set the `core.excludesFile` setting in user's Git
   configuration (#1461).
-  
+
 * `use_github_action_check_full()` has been removed. It's overkill for the
   majority of R packages, which are better off with `use_github_actions()` or
   `use_github_action_check_standard()` (#1490).
@@ -319,7 +323,7 @@ usethis has a more sophisticated understanding of the default branch and gains s
   creating an empty, orphan `gh-pages` branch. This is necessary due to new
   GitHub behaviour, where it has become essentially impossible to refer to the
   empty tree (#1472).
-  
+
 * `use_github()` can create repositories with `"internal"` visibility, a feature
   that exists within GitHub Enterprise products (#1505).
 
@@ -333,7 +337,7 @@ usethis has a more sophisticated understanding of the default branch and gains s
 * `use_import_from()` is a new function that puts `@importFrom pkg fun`
   directives into a package in a consistent location (@malcolmbarrett, #1377).
 
-* `DESCRIPTION` files generated by usethis no longer include `LazyData` by 
+* `DESCRIPTION` files generated by usethis no longer include `LazyData` by
    default, as per new CRAN checks; instead, `LazyData` is now added the first
    time you use `use_data()` (@malcolmbarrett, #1404).
 
@@ -348,9 +352,9 @@ usethis has a more sophisticated understanding of the default branch and gains s
 * `use_code_of_conduct()` now requires a `contact` argument to supply contact
   details for reporting CoC violations (#1269).
 
-* `use_package()` no longer guides the user on how to use a dependency when no 
+* `use_package()` no longer guides the user on how to use a dependency when no
   change was made (@malcolmbarrett, #1384).
-  
+
 ### Aimed at the tidyverse team
 
 These functions are exported for anyone to use, but are aimed primarily at the maintainers of tidyverse, r-lib, and tidymodels packages.
@@ -358,7 +362,7 @@ These functions are exported for anyone to use, but are aimed primarily at the m
 * `use_tidy_dependencies()` is a new function that sets up standard dependencies
   used by all tidyverse packages, except those that are designed to be
   dependency free (#1423).
-  
+
 * `use_tidy_upkeep_issue()` is a new function similar to `use_release_issue()`
   that creates a checklist-style issue to prompt various updates (#1416).
 
@@ -378,11 +382,11 @@ These functions are exported for anyone to use, but are aimed primarily at the m
   a Git repo. The normal Git workflow makes it easy to see and selectively
   accept/discard any proposed changes. This behaviour is strictly opt-in
   (#1424).
-  
+
 * Functions that provide code to load packages in your `.Rprofile` now use
   `rlang::check_installed()` to make sure the package is installed locally
   (@malcolmbarrett, #1398).
- 
+
 * `edit_rstudio_prefs()` and `edit_rstudio_snippets()` should work now on
   case-sensitive OSes, due to a path fix re: the location of RStudio's config
   files (@charliejhadley, #1420).
@@ -391,24 +395,24 @@ These functions are exported for anyone to use, but are aimed primarily at the m
 
 * All functions that require a package now ask you if you'd like to install it.
 
-* Added `edit_template()` for opening and creating files in `inst/templates` 
+* Added `edit_template()` for opening and creating files in `inst/templates`
   (for use with `use_template()`) (@malcolmbarrett, #1319).
 
 * `use_article()` now creates the file in the `vignettes/articles/` (#548).
 
-* `use_lifecycle()` has been updated for changes in our lifecycle workflow 
+* `use_lifecycle()` has been updated for changes in our lifecycle workflow
   (#1323).
 
 * `use_tidy_pkgdown()` has been renamed to `use_pkgdown_github_pages()` since
   the function is useful for anyone who wants to automatically publish to GitHub
   pages, not just the tidyverse team (#1308).
 
-* `use_release_issue()` includes a bunch of minor improvements. Most 
+* `use_release_issue()` includes a bunch of minor improvements. Most
   importantly, for initial CRAN release we now include a number of common
   things that CRAN checks for that aren't in `R CMD check`.
 
-* `use_readme_rmd()`, `use_readme_md()`, `use_tidy_contributing()`, and 
-  `use_tidy_support()` use updated logic for determining the `OWNER/REPO` spec 
+* `use_readme_rmd()`, `use_readme_md()`, `use_tidy_contributing()`, and
+  `use_tidy_support()` use updated logic for determining the `OWNER/REPO` spec
   of the target repo (#1312).
 
 # usethis 2.0.0
@@ -421,7 +425,7 @@ Usethis has various functions that help with Git-related tasks, which break down
    command line Git.
 1. GitHub tasks, such as fork, release, and open an issue or pull request. These
    are things you could do in the browser or with the GitHub API.
-   
+
 We've switched from git2r to the gert package for Git operations (<https://docs.ropensci.org/gert/>). We continue to use the gh package for GitHub API work (<https://gh.r-lib.org>).
 
 The big news in this area is that these lower-level dependencies are getting better at finding Git credentials, finding the same credentials as command line Git (and, therefore, the same as RStudio), and finding the same credentials as each other. This allows usethis to shed some of the workarounds we have needed in the past, to serve as a remedial "credential valet".
@@ -433,7 +437,7 @@ Under the hood, both gert and gh are now consulting your local Git credential st
 
 Even now, gert and gh should discover the same credentials, at least for github.com. In the future, these two packages may merge into one.
 
-Git/GitHub credential management is covered in a new article:  
+Git/GitHub credential management is covered in a new article:
 [Managing Git(Hub) Credentials](https://usethis.r-lib.org/articles/articles/git-credentials.html)
 
 The main user-facing changes in usethis are:
@@ -452,7 +456,7 @@ As a result, several functions are deprecated and several other functions have s
   - `use_github()` (`auth_token`, `credentials`)
   - `use_github_links()` (`host`, `auth_token`)
   - `use_github_labels()` (`repo_spec`, `host`, `auth_token`)
-  - `use_tidy_labels()` (`repo_spec`, `host`, `auth_token`)  
+  - `use_tidy_labels()` (`repo_spec`, `host`, `auth_token`)
   - `use_github_release()` (`host`, `auth_token`)
 
 The switch to gert + credentials should eliminate most credential-finding fiascos. Gert also takes a different approach to wrapping libgit2, the underlying C library that does Git operations. The result is more consistent support for SSH and TLS, across all operating systems, without requiring special effort at install time. More users should enjoy Git remote operations that "just work", for both SSH and HTTPS remotes. There should be fewer "unsupported protocol" errors.
@@ -464,7 +468,7 @@ Usethis gains a more formal framework for characterizing a GitHub remote configu
   * Which GitHub repositories `origin` and `upstream` point to
   * Whether you can push to them
   * How they relate to each other, e.g. fork-parent relationship
-  
+
 This is an internal matter, but users will notice that usethis is more clear about which configurations are supported by various functions and which are not. The most common configurations are reviewed in a [section of Happy Git](https://happygitwithr.com/common-remote-setups.html).
 
 When working in a fork, there is sometimes a question whether to target the fork or its parent repository. For example, `use_github_links()` adds GitHub links to the URL and BugReports fields of DESCRIPTION. If someone calls `use_github_links()` when working in a fork, they probably want those links to refer to the *parent* or *source* repo, not to their fork, because the user is probably preparing a pull request. Usethis should now have better default behaviour in these situations and, in some cases, will present an interactive choice.
@@ -517,17 +521,17 @@ GitHub Actions is the preferred platform for continuous integration, because tha
 All `use_*_license()` functions now work for projects, not just packages.
 
 `use_apl2_license()` (not `use_apache_license()`) and `use_gpl3_license()` no longer modify the license text (#1198).
-   
+
 `use_mit_license()` now sets the default copyright holder to "{package} authors". This makes it more clear that the copyright holders are the contributors to the package; unless you are using a CLA there is no one copyright holder of a package (#1207).
-  
+
 New `use_gpl_license()` and  `use_agpl_license()` make it easier to pick specific versions of the GPL and AGPL licenses, and to choose whether or not you include future versions of the license. Both default to version 3 (and above).
 
 New `use_proprietary_license()` allows your package to pass R CMD check while making it clear that your code is not open source (#1163). Thanks to @atheriel for the blog post suggesting the wording: https://unconj.ca/blog/copyright-in-closed-source-r-packages-the-right-way.html
 
 `use_lgpl_license()` now uses version 3 (and above), and gains new `version` and `include_future` argument to control which version is used.
-  
+
 `use_gpl3_license()`, `use_agpl3_license()` and `use_apl2_license()` have been deprecated in favour of the new `version` argument to `use_gpl_license()`, `use_agpl_license()` and `use_apache_license()`.
-  
+
 The `name` argument to `use_mit_license()` has been changed to `copyright_holder` to make the purpose more clear. The `name` argument has been removed from all other license functions because it is not needed; no other license makes an assertion about who the copyright holder is.
 
 ## RStudio preferences
@@ -554,13 +558,13 @@ The legacy `"devtools.desc"` option is no longer consulted when populating a new
 
 `create_package()`, `create_project()`, `create_from_github()`, and `proj_activate()` work better with relative paths, inside and outside of RStudio (#1122, #954).
 
-`use_testthat()` gains an edition argument to support testthat v3.0.0 
+`use_testthat()` gains an edition argument to support testthat v3.0.0
   (#1185)
 
 `use_version()` now updates `src/version.c` if it exists and contains a line matching `PKG_version = "x.y.z";`.
 
-usethis has been re-licensed as MIT (#1252, #1253).  
-  
+usethis has been re-licensed as MIT (#1252, #1253).
+
 ## Dependency changes
 
 New Imports: gert, jsonlite (was already an indirect dependency), lifecycle, rappdirs
@@ -583,14 +587,14 @@ Patch release to align some path handling internals with an update coming in the
   destination directory to the config file if it departs from the default
   (which is `docs/`).
 
-* `use_tidy_ci()` is now deprecated in favour of `use_tidy_github_actions()` 
+* `use_tidy_ci()` is now deprecated in favour of `use_tidy_github_actions()`
   (#1098).
 
 * `use_github_action_check_standard()` is a new intermediate workflow that
   checks on more platforms than `_release`, but is less exhaustive than `_full`
   (@jimhester).
 
-* `create_tidy_package()` now uses an MIT license (@topepo, #1096). 
+* `create_tidy_package()` now uses an MIT license (@topepo, #1096).
 
 # usethis 1.6.0
 
@@ -608,55 +612,55 @@ Patch release to align some path handling internals with an update coming in the
 
 ## Package creation
 
-* `create_package()` gains a `roxygen` argument. If `TRUE` (the default), 
+* `create_package()` gains a `roxygen` argument. If `TRUE` (the default),
   it adds a `RoxygenNote` field to the `DESCRIPTION` (which means the first run
-  of `devtools::check()` will re-document the package, #963), and creates an 
-  empty `NAMESPACE` (which means you'll always need an explicit `@export` 
-  if you want to export functions, #927). It also turns markdown processing 
+  of `devtools::check()` will re-document the package, #963), and creates an
+  empty `NAMESPACE` (which means you'll always need an explicit `@export`
+  if you want to export functions, #927). It also turns markdown processing
   on by default (#911).
 
 * `use_rstudio()` now sets the `LineEndingConversion` to `Posix` so that
-  packages created using usethis always use LF line endings, regardless of 
+  packages created using usethis always use LF line endings, regardless of
   who contributes to them (#1002).
 
-* In the `usethis.description` option, you can now set `Authors@R = person()` 
-  directly, without having to wrap in additional layer of quotes. If setting 
-  this in your `.Rprofile`, you'll need to use `utils::person()` since the utils 
+* In the `usethis.description` option, you can now set `Authors@R = person()`
+  directly, without having to wrap in additional layer of quotes. If setting
+  this in your `.Rprofile`, you'll need to use `utils::person()` since the utils
   package isn't loaded until after your profile is executed.
 
 ## PR helpers
 
-* A new article [Pull request helpers](https://usethis.r-lib.org/articles/articles/pr-functions.html) 
+* A new article [Pull request helpers](https://usethis.r-lib.org/articles/articles/pr-functions.html)
   demonstrates how to use the `pr_*()` functions (@mine-cetinkaya-rundel, #802).
 
-* `pr_finish()` checks that you don't have any local changes (#805), and can 
+* `pr_finish()` checks that you don't have any local changes (#805), and can
   optionally finish any PR, not just the current (#1040).
 
-* `pr_pause()` and `pr_fetch()` now automatically pull to get latest changes 
+* `pr_pause()` and `pr_fetch()` now automatically pull to get latest changes
   (#959, #960) and refresh RStudio's git pane (#706).
 
-* `pr_push()` now works for a repository with no open pull requests 
+* `pr_push()` now works for a repository with no open pull requests
   (@maurolepore, #990).
 
-* `pr_pull()` gives more information about which files have merge conflicts 
+* `pr_pull()` gives more information about which files have merge conflicts
   and automatically opens conflicted files for editing (#1056).
 
 ## Other new features
 
-* New `rename_files()` makes it easy to rename paired `R/` and `test/` files 
+* New `rename_files()` makes it easy to rename paired `R/` and `test/` files
   (#784).
 
 * New `ui_silence()` makes it easier to selectively silence some UI output.
 
 * New `use_agpl3_license()` (@pachamaltese, #870).
 
-* New `use_data_table()` to set up a package for Import-ing `data.table` 
+* New `use_data_table()` to set up a package for Import-ing `data.table`
   (@michaelchirico, #897).
 
 * `use_latest_dependencies()` replaces `use_tidy_version()` as the new name
   better reflect its usage (#771).
 
-* New `use_lifecycle()` helper to import the lifecycle badges for functions and 
+* New `use_lifecycle()` helper to import the lifecycle badges for functions and
   arguments in your package. Learn more at <https://lifecycle.r-lib.org/>.
 
 * `use_release_issue()` will include additional bullets if your package
@@ -665,20 +669,20 @@ Patch release to align some path handling internals with an update coming in the
 
 ## Minor improvements and bug fixes
 
-* When writing files, usethis now respects line endings. Default line endings 
+* When writing files, usethis now respects line endings. Default line endings
   are taken from the `.Rproj` file (if available), otherwise the `DESCRIPTION`,
-  otherwise the first file found in `R/`, then all else failing to your 
-  platform default (#767). It should do a better job of preserving UTF-8 files 
+  otherwise the first file found in `R/`, then all else failing to your
+  platform default (#767). It should do a better job of preserving UTF-8 files
   on windows (#969).
 
-* `browse_github()` now always goes to the canonical GitHub site: 
-  `https://github.com/user/repo`. This is slightly worse than the current 
-  behaviour but makes the function more consistent across packages, and 
+* `browse_github()` now always goes to the canonical GitHub site:
+  `https://github.com/user/repo`. This is slightly worse than the current
+  behaviour but makes the function more consistent across packages, and
   considerably simplifies the implementation.
 
 * `browse_circle()` opens the project dashboard on Circle CI.
 
-* `create_download_url()` is a new helper for making "ZIP file download" 
+* `create_download_url()` is a new helper for making "ZIP file download"
   URLs suitable for use with `use_course()` and `use_zip()`, starting with the
   URLs that mere mortals can usually get their hands on in a browser
   (@fmichonneau, #406).
@@ -686,19 +690,19 @@ Patch release to align some path handling internals with an update coming in the
 * `create_package()` no longer fails partway through if you have a malformed
   `usethis.description` option (#961).
 
-* `create_package()` will now create a package in a symlink to a directory 
+* `create_package()` will now create a package in a symlink to a directory
   (#794).
 
-* `create_package()` and `use_description()` gain a `check_name` argument to 
+* `create_package()` and `use_description()` gain a `check_name` argument to
   control whether to check for package names invalid for CRAN (@noamross, #883).
 
 * `edit_file()` and `use_test()` gain an `open` parameter that allows you to
   control whether or not the function is opened for editing by the user (#817).
 
-* `edit_rstudio_snippets()` makes it more clear which snippet types are 
+* `edit_rstudio_snippets()` makes it more clear which snippet types are
   allowed and that user's snippets mask the built-in snippets (@GegznaV, #885).
 
-* `git_sitrep()` now reports project-specific user name and email, if set 
+* `git_sitrep()` now reports project-specific user name and email, if set
   (#837), and email(s) associated with your GitHub account (@dragosmg, #724).
 
 * `ui_yeah()` and `ui_nope()` allow you to override the default "yes" and
@@ -708,16 +712,16 @@ Patch release to align some path handling internals with an update coming in the
 
 * `use_circleci_badge()` is now exported (@pat-s, #920).
 
-* `use_code_of_conduct()` now generates an absolute link to code of conduct on 
+* `use_code_of_conduct()` now generates an absolute link to code of conduct on
   pkgdown website or original source to avoid R CMD check issues (#772).
-  
+
 * `use_course()` and `use_zip()` are now equipped with some retry capability,
   to cope with intermittent failure or the need for a longer connect timeout
   (#988).
 
 * `use_data()` automatically bumps R dependency to 2.10 (#962).
 
-* `use_data_raw()` template quotes the dataset name correctly 
+* `use_data_raw()` template quotes the dataset name correctly
   (#736, @mitchelloharawild).
 
 * `use_description_defaults()` now shows the default fields combined with
@@ -730,14 +734,14 @@ Patch release to align some path handling internals with an update coming in the
 
 * `use_github_release()` no longer fails if you have no news bullets (#1048).
 
-* `use_github_release()` now tags the latest local commit instead of the latest 
+* `use_github_release()` now tags the latest local commit instead of the latest
   remote commit on the default branch (@davidchall, #1029).
 
-* `use_gpl3_license()` now completes the license by providing additional 
-  information in a file named LICENSE, just like `use_mit_license()` and 
+* `use_gpl3_license()` now completes the license by providing additional
+  information in a file named LICENSE, just like `use_mit_license()` and
   friends (@Cervangirard, #683).
 
-* `use_logo()` now generates the correct href if the pkgdown `url` is set 
+* `use_logo()` now generates the correct href if the pkgdown `url` is set
   (@mitchelloharawild, #986).
 
 * `use_make()` gains missing closing parenthesis (@ryapric, #804).
@@ -745,7 +749,7 @@ Patch release to align some path handling internals with an update coming in the
 * `use_markdown_template()` no longer uses an unexported function in its
   default arguments (@fmichonneau, #761).
 
-* `use_testthat()` and `use_test()` now work in projects, not just packages 
+* `use_testthat()` and `use_test()` now work in projects, not just packages
   (#1017).
 
 * `use_test()` works on Windows when called without arguments (#901).
@@ -753,18 +757,18 @@ Patch release to align some path handling internals with an update coming in the
 * `use_tidy_issue_template()` uses current github format (@Maschette, #756).
 
 * `use_travis()`, `use_travis_badge()`, and `browse_travis()`, now default
-  to `ext = "com"` since travis-ci.com is now recommended it over travis-ci.org 
+  to `ext = "com"` since travis-ci.com is now recommended it over travis-ci.org
   (@riccardoporreca, #1038).
 
 * `use_release_issue()` reminds you to re-generate `README.md`,
   if needed (#767).
 
-* `use_r()` and `use_test()` throw a clear error if multiple names are provided 
+* `use_r()` and `use_test()` throw a clear error if multiple names are provided
   (@strboul, #862).
 
 * `use_rcpp()` and `use_c()` now ensure `src/` contains at least one `.cpp` or
   `.c` placeholder file, so that the package can be built (@coatless, #720).
-  
+
 * `usethis.destdir` is a new option that is consulted when deciding where to
   put a new folder created by `use_course()` or `create_from_github()`
   (@malcolmbarrett, #1015).
@@ -799,7 +803,7 @@ This is a patch release with various small features and bug fixes.
 
 ## Git, GitHub, and pull requests
 
-* `use_github()` removes newline `\n` characters from the description that 
+* `use_github()` removes newline `\n` characters from the description that
   can cause the initial push to fail (#493, @muschellij2).
 
 * `git_sitrep()` gives better feedback if we can't validate the GitHub PAT
@@ -809,7 +813,7 @@ This is a patch release with various small features and bug fixes.
   `upstream/master`, when it creates (and clones) a fork (#792).
 
 * `pr_pause()` can switch back to master even if there is no remote tracking
-  branch (#715, @cderv). 
+  branch (#715, @cderv).
 
 ## Build tools and continuous integration
 
@@ -818,7 +822,7 @@ This is a patch release with various small features and bug fixes.
 
 * `use_make()` and `use_jenkins()` add a Makefile and Jenkinsfile, respectively
   (#501, @ryapric).
-  
+
 * `use_circleci()` creates a `.circleci/config.yaml` config file for CircleCI
   (#703, @jdblischak).
 
@@ -848,7 +852,7 @@ usethis gains several functions to inspect and manipulate the Git situation for 
 into git2r's workings, especially around credentials (usethis uses git2r for all
 Git operations).
 
-* `git_sitrep()` lets you know what's up with your Git, git2r and GitHub 
+* `git_sitrep()` lets you know what's up with your Git, git2r and GitHub
   config (#328).
 
 * `git_vaccinate()` vaccinates your global (i.e. user-level) git ignore file.
@@ -858,7 +862,7 @@ Git operations).
 
 * `git_remotes()` and `use_git_remote()` are new helpers to inspect or modify
   Git remote URLs for the repo associated with the active project (#649).
-  
+
 * `git_protocol()` + `use_git_protocol()` and `git_credentials()` +
   `use_git_credentials()` are new helpers to summon or set Git transport
   protocol (SSH or HTTPS) or git2r credentials, respectively. These functions
@@ -871,10 +875,10 @@ Other improvements and bug fixes:
 
 * `use_github()` tries harder but also fails earlier, with more informative
   messages, making it less likely to leave the repo partially configured (#221).
-  
+
 * `use_github()` and `create_from_github()` gain a `protocol` argument
   (#494, @cderv).
-  
+
 * `create_from_github()` pulls from upstream master in a fork (#695, @ijlyttle).
 
 * `use_release_issue()` creates a GitHub issue containing a release checklist,
@@ -892,8 +896,8 @@ Other improvements and bug fixes:
 * `use_github_labels()` has been rewritten be more flexible. You can now supply
   a repo name, and `descriptions`, and you can set colours/descriptions
   independently of creating labels. You can also `rename` existing labels
-  (#290). 
-  
+  (#290).
+
 ## GitHub pull requests
 
 We've added **experimental** functions to work with GitHub pull requests. They
@@ -913,15 +917,15 @@ requests) and a contributor (who may make or explore pull requests).
 usethis gains tooling to manage part of a file. This is currently used for
 managing badges in your README and roxygen import tags:
 
-*   `use_badge()` and friends now automatically add badges if your README 
+*   `use_badge()` and friends now automatically add badges if your README
     contains a specially formatted badge block (#497):
 
     ```
     <-- badge:start -->
     <-- badge:end -->
     ```
- 
-*   `use_tibble()` and `use_rcpp()` automatically add roxygen tags to 
+
+*   `use_tibble()` and `use_rcpp()` automatically add roxygen tags to
     to `{package}-package.R` if it contains a specially formatted namespace
     block (#517):
 
@@ -930,19 +934,19 @@ managing badges in your README and roxygen import tags:
     ## usethis namespace: end
     NULL
     ```
-    
+
     Unfortunately this means that `use_rcpp()` no longer supports non-roxygen2
-    workflows, but I suspect the set of people who use usethis and Rcpp but 
+    workflows, but I suspect the set of people who use usethis and Rcpp but
     not roxygen2 is very small.
 
 ## Extending and wrapping usethis
 
-* New `proj_activate()` lets you activate a project, either opening a new 
-  RStudio session (if you use RStudio) or changing the working directory 
+* New `proj_activate()` lets you activate a project, either opening a new
+  RStudio session (if you use RStudio) or changing the working directory
   (#511).
 
-* `proj_get()` and `proj_set()` no longer have a `quiet` argument. The 
-  user-facing message about setting a project is now under the same control 
+* `proj_get()` and `proj_set()` no longer have a `quiet` argument. The
+  user-facing message about setting a project is now under the same control
   as other messages, i.e. `getOption("usethis.quiet", default = FALSE)` (#441).
 
 * A new set of `ui_*()` functions makes it possible to give your own code
@@ -956,8 +960,8 @@ managing badges in your README and roxygen import tags:
     * questions: `ui_yeah()`, `ui_nope()`.
     * inline styles: `ui_field()`, `ui_value()`, `ui_path()`, `ui_code()`.
 
-* `with_project()` and `local_project()` are new withr-style functions to 
-  temporarily set an active usethis project. They make usethis functions easier 
+* `with_project()` and `local_project()` are new withr-style functions to
+  temporarily set an active usethis project. They make usethis functions easier
   to use in an *ad hoc* fashion or from another package (#441).
 
 ## Tidyverse standards
@@ -965,8 +969,8 @@ managing badges in your README and roxygen import tags:
 These standards are (aspirationally) used by all tidyverse packages; you are
 welcome to use them if you find them helpful.
 
-* Call `use_tidy_labels()` to update GitHub labels. Colours are less 
-  saturated, docs is now documentation, we use some emoji, and performance is 
+* Call `use_tidy_labels()` to update GitHub labels. Colours are less
+  saturated, docs is now documentation, we use some emoji, and performance is
   no longer automatically added to all repos (#519). Repo specific issues
   should be given colour `#eeeeee` and have an emoji.
 
@@ -977,21 +981,21 @@ welcome to use them if you find them helpful.
   pkgdown site if available (#536).
 
 * When creating a new package, use `create_tidy_package()` to start with a
-  package following the tidyverse standards (#461). 
+  package following the tidyverse standards (#461).
 
-* `NEWS.md` for the development version should use "(development version)" 
+* `NEWS.md` for the development version should use "(development version)"
   rather than the specific version (#440).
 
 * pkgdown sites should now be built by travis and deployed automatically to
   GitHub pages. `use_pkgdown_travis()` will help you set that up.
 
-* When starting the release process, call `use_release_issue()` to create a 
+* When starting the release process, call `use_release_issue()` to create a
   release checklist issue (#338).
 
-* Prior to CRAN submission call `use_tidy_release_test_env()` to update the 
+* Prior to CRAN submission call `use_tidy_release_test_env()` to update the
   test environment section in `cran-comments()` (#496).
 
-* After acceptance, try `use_github_release()` to automatically create a 
+* After acceptance, try `use_github_release()` to automatically create a
   release. It's created as a draft so you have a chance to look over before
   publishing.
 
@@ -1007,7 +1011,7 @@ welcome to use them if you find them helpful.
 * `use_partial_warnings()` helps the user add a standard warning block to
   `.Rprofile` (#64).
 
-* `edit_r_buildignore()` opens `.Rbuildignore` for manual editing 
+* `edit_r_buildignore()` opens `.Rbuildignore` for manual editing
    (#462, @bfgray3).
 
 * `use_lgpl_license()` automates set up of the LGL license (#448, @krlmlr).
@@ -1018,7 +1022,7 @@ welcome to use them if you find them helpful.
   RcppArmadillo or RcppEigen, respectively (#421, @coatless, @duckmayr).
 
 * `use_c("foo")` sets up `src/` and creates `src/foo.c` (#117).
-  
+
 * `use_covr_ignore()` makes it easy to ignore files in test coverage (#434).
 
 * `use_pkgdown_travis()` helps you set up pkgdown for automatic build-and-deploy
@@ -1034,7 +1038,7 @@ welcome to use them if you find them helpful.
   `.Rbuildignore`. These appear on pkgdown sites, but are not included with the
   package itself (#281).
 
-* `use_citation()` creates a basic `CITATION` template and puts it in the 
+* `use_citation()` creates a basic `CITATION` template and puts it in the
   right place (#100).
 
 ## Other minor bug fixes and improvements
@@ -1050,10 +1054,10 @@ welcome to use them if you find them helpful.
 * `use_data_raw()` accepts a name for the to-be-prepared dataset and opens a
   templated R script (#646).
 
-* `browse_github()` now falls back to CRAN organisation (with a warning) if 
+* `browse_github()` now falls back to CRAN organisation (with a warning) if
   package doesn't have its own GitHub repo (#186).
 
-* `create_*()` restore the active project if they error part way through, 
+* `create_*()` restore the active project if they error part way through,
   and use `proj_activate()` (#453, #511).
 
 * `edit_r_profile()` and `edit_r_environ()` now respect environment variables
@@ -1066,14 +1070,14 @@ welcome to use them if you find them helpful.
   spread over multiple lines (#439).
 
 * `use_logo()` can override existing logo if user gives permission (#454).
-  It also produces retina appropriate logos by default, and matches the 
+  It also produces retina appropriate logos by default, and matches the
   aspect ratio to the <http://hexb.in/sticker.html> specification (#499).
 
 * `use_news_md()` will optionally commit.
 
 * `use_package()` gains a `min_version` argument to specify a minimum
-  version requirement (#498). Set to `TRUE` to use the currently installed 
-  version (#386). This is used by `use_tidy_eval()` in order to require version 
+  version requirement (#498). Set to `TRUE` to use the currently installed
+  version (#386). This is used by `use_tidy_eval()` in order to require version
   0.1.2 or greater of rlang (#484).
 
 * `use_pkgdown()` is now configurable with site options (@jayhesselberth, #467),
@@ -1081,12 +1085,12 @@ welcome to use them if you find them helpful.
 
 * `use_test()` no longer forces the filename to be lowercase (#613, @stufield).
 
-* `use_test()` will not include a `context()` in the generated file if used 
+* `use_test()` will not include a `context()` in the generated file if used
   with testthat 2.1.0 and above (the future release of testthat) (#325).
 
-* `use_tidy_description()` sets the `Encoding` field in `DESCRIPTION` 
+* `use_tidy_description()` sets the `Encoding` field in `DESCRIPTION`
   (#502, @krlmlr).
-  
+
 * `use_tidy_eval()` re-exports `:=` (#595, @jonthegeek).
 
 * `use_tidy_versions()` has source argument so that you can choose to use
@@ -1106,11 +1110,11 @@ welcome to use them if you find them helpful.
   in `NEWS.md` (#440).
 
 * `use_vignette()` now checks if the vignette name is valid (starts with letter
-  and consists of letters, numbers, hyphen, and underscore) and throws an error 
+  and consists of letters, numbers, hyphen, and underscore) and throws an error
   if not (@akgold, #555).
-  
+
 * `restart_rstudio()` now returns `FALSE` in RStudio if no project is open,
-  fixing an issue that caused errors in helpers that suggest restarting 
+  fixing an issue that caused errors in helpers that suggest restarting
   RStudio (@gadenbuie, #571).
 
 ## Dependency changes
@@ -1186,7 +1190,7 @@ No longer in Imports: backports, httr, rematch2, rmarkdown (moved to Suggests), 
 
 * `use_github_labels()` can create or update the colour of arbitrary GitHub issue labels, defaulting to a set of labels and colours used by the tidyverse packages, which are now exposed via `tidy_labels()`. That set now includes the labels "good first issue" and "help wanted" (#168, #249).
 
-* `appveyor_info()` no longer reverses the repo's URL and image link. Corrects the markdown produced by `use_appveyor_badge()` (#240, @llrs). 
+* `appveyor_info()` no longer reverses the repo's URL and image link. Corrects the markdown produced by `use_appveyor_badge()` (#240, @llrs).
 
 * `use_cran_badge()` uses an HTTPS URL for the CRAN badge image (#235, @jdblischak).
 
@@ -1244,13 +1248,13 @@ templating functions using this framework (@ijlyttle #120).
 * `create_from_github()` creates a project from an existing GitHub
   repository, forking if needed (#109).
 
-* `use_cc0_license()` applies a CC0 license, particularly appropriate for data 
+* `use_cc0_license()` applies a CC0 license, particularly appropriate for data
   packages (#94)
 
-* `use_lifecycle_badge()` creates a badge describing current stage in 
+* `use_lifecycle_badge()` creates a badge describing current stage in
   project lifecycle (#48).
 
-* `use_pkgdown()` creates the basics needed for a 
+* `use_pkgdown()` creates the basics needed for a
   [pkgdown](https://github.com/r-lib/pkgdown) website (#88).
 
 * `use_r("foo")` creates and edit `R/foo.R` file. If you have a test file open,
@@ -1260,7 +1264,7 @@ templating functions using this framework (@ijlyttle #120).
 
 ## Bug fixes and improvements
 
-* `use_dev_version()` now correctly updates the `Version` field in a package 
+* `use_dev_version()` now correctly updates the `Version` field in a package
   description file. (@tjmahr, #104)
 
 * `use_revdep()` now also git-ignores the SQLite database (#107).
@@ -1287,7 +1291,7 @@ The output from all usethis commands has been reviewed to be informative but not
 
 * `use_depsy_badge()` allows including a Depsy badge (@gvegayon, #68).
 
-* `use_dev_package()` works like `use_package()` but also adds the 
+* `use_dev_package()` works like `use_package()` but also adds the
   repo to the `Remotes` field (#32).
 
 * `use_github_labels()` will automatically set up a standard set of labels,
@@ -1301,7 +1305,7 @@ The output from all usethis commands has been reviewed to be informative but not
 * `use_tidy_description()` puts description fields in a standard order
   and alphabetises dependencies.
 
-* `use_tidy_eval()` imports and re-exports the recommend set of tidy eval 
+* `use_tidy_eval()` imports and re-exports the recommend set of tidy eval
   helpers if your package uses tidy eval (#46).
 
 * `use_usethis()` opens your `.Rprofile` and gives you the code to copy
@@ -1320,16 +1324,16 @@ A new class of functions make it easy to edit common config files:
 
 ## Updates
 
-* `use_coverage("codecov")` now sets a default threshold of 1% to try and 
+* `use_coverage("codecov")` now sets a default threshold of 1% to try and
   reduce false positives (#8).
 
 * `use_description()` now sets `ByteCompile: true` so you can benefit from
   the byte compiler (#29)
 
-* The license functions (`use_mit_license()`, `use_apl2_license()`, and 
-  `use_gpl3_license()`) save a copy of the standard license text in 
+* The license functions (`use_mit_license()`, `use_apl2_license()`, and
+  `use_gpl3_license()`) save a copy of the standard license text in
   `LICENSE.md`, which is then added to `.Rbuildignore`. This allows you
-  to follow standard licensing best practices while adhering to CRANs 
+  to follow standard licensing best practices while adhering to CRANs
   requirements (#10).
 
 * `use_package_doc()` uses more a modern roxygen2 template that requires
@@ -1348,17 +1352,17 @@ A new class of functions make it easy to edit common config files:
 
 ## Building blocks
 
-* New `use_badge()` for adding any badge to a README. Now only prints a 
+* New `use_badge()` for adding any badge to a README. Now only prints a
   todo message if the badge does not already exist.
 
-* `use_directory()` is now exported (#27). 
+* `use_directory()` is now exported (#27).
 
 ## Bug fixes and minor improvements
 
 * Functions which require code to be copied now automatically put the code on
   the clipboard if it is available (#52).
 
-* `create_package()` no longer creates a dependency on the current version of 
+* `create_package()` no longer creates a dependency on the current version of
   R.
 
 * `use_build_ignore()` now strips trailing `/`
@@ -1374,5 +1378,5 @@ A new class of functions make it easy to edit common config files:
 * `use_vignette()` now adds `*.html` and `*.R` to your `.gitgnore` so you
   don't accidentally add in compiled vignette products (#35).
 
-* `use_travis_badge()` and `use_appveyor_badge()` are now exported functions, 
-  so they can be used even if ci was separately set up (#765, @smwindecker). 
+* `use_travis_badge()` and `use_appveyor_badge()` are now exported functions,
+  so they can be used even if ci was separately set up (#765, @smwindecker).

--- a/R/github.R
+++ b/R/github.R
@@ -239,8 +239,9 @@ use_github_links <- function(auth_token = deprecated(),
   invisible()
 }
 
-has_github_links <- function() {
-  github_url <- github_url_from_git_remotes()
+has_github_links <- function(target_repo = NULL) {
+  url <- if (is.null(target_repo)) NULL else target_repo$url
+  github_url <- github_url_from_git_remotes(url)
   if (is.null(github_url)) {
     return(FALSE)
   }

--- a/R/release.R
+++ b/R/release.R
@@ -136,10 +136,6 @@ release_checklist <- function(version, on_cran, target_repo = NULL) {
 }
 
 gh_milestone_number <- function(target_repo, version, state = "open") {
-  if (!curl::has_internet()) {
-    return(NA)
-  }
-
   gh <- gh_tr(target_repo)
   milestones <- tryCatch(
     gh("/repos/{owner}/{repo}/milestones", state = state),

--- a/R/release.R
+++ b/R/release.R
@@ -56,7 +56,7 @@ use_release_issue <- function(version = NULL) {
   }
 
   on_cran <- !is.null(cran_version())
-  checklist <- release_checklist(version, on_cran)
+  checklist <- release_checklist(version, on_cran, tr)
 
   gh <- gh_tr(tr)
   issue <- gh(
@@ -69,23 +69,16 @@ use_release_issue <- function(version = NULL) {
   view_url(issue$html_url)
 }
 
-release_checklist <- function(version, on_cran) {
+release_checklist <- function(version, on_cran, target_repo = NULL) {
   type <- release_type(version)
   cran_results <- cran_results_url()
   has_news <- file_exists(proj_path("NEWS.md"))
   has_pkgdown <- uses_pkgdown()
   has_lifecycle <- proj_desc()$has_dep("lifecycle")
   has_readme <- file_exists(proj_path("README.Rmd"))
-  has_github_links <- has_github_links()
+  has_github_links <- has_github_links(target_repo)
   is_posit_pkg <- is_posit_pkg()
-
-  milestone_num <- NA # for testing (and general fallback)
-  if (uses_git() && curl::has_internet()) {
-    milestone_num <- tryCatch(
-      gh_milestone_number(target_repo_spec(), version),
-      error = function(e) NA
-    )
-  }
+  milestone_num <- gh_milestone_number(target_repo, version)
 
   c(
     if (!on_cran) c(
@@ -104,9 +97,7 @@ release_checklist <- function(version, on_cran) {
     "Prepare for release:",
     "",
     todo("`git pull`"),
-    if (!is.na(milestone_num)) {
-      todo("[Close v{version} milestone](../milestone/{milestone_num})")
-    },
+    todo("[Close v{version} milestone](../milestone/{milestone_num})", !is.na(milestone_num)),
     todo("Check [current CRAN check results]({cran_results})", on_cran),
     todo("
       Check if any deprecation processes should be advanced, as described in \\
@@ -144,11 +135,15 @@ release_checklist <- function(version, on_cran) {
   )
 }
 
-gh_milestone_number <- function(repo_spec, version, state = "open") {
-  milestones <- gh::gh(
-    "/repos/{repo_spec}/milestones",
-    repo_spec = repo_spec,
-    state = state
+gh_milestone_number <- function(target_repo, version, state = "open") {
+  if (!curl::has_internet()) {
+    return(NA)
+  }
+
+  gh <- gh_tr(target_repo)
+  milestones <- tryCatch(
+    gh("/repos/{owner}/{repo}/milestones", state = state),
+    error = function(e) list()
   )
   titles <- map_chr(milestones, "title")
   numbers <- map_int(milestones, "number")

--- a/R/upkeep.R
+++ b/R/upkeep.R
@@ -43,7 +43,7 @@ make_upkeep_issue <- function(year, tidy) {
   if (tidy) {
     checklist <- tidy_upkeep_checklist(year, repo_spec = tr$repo_spec)
   } else {
-    checklist <- upkeep_checklist()
+    checklist <- upkeep_checklist(tr)
   }
 
   title_year <- year %||% format(Sys.Date(), "%Y")
@@ -58,11 +58,13 @@ make_upkeep_issue <- function(year, tidy) {
   view_url(issue$html_url)
 }
 
-upkeep_checklist <- function() {
+upkeep_checklist <- function(target_repo = NULL) {
+  has_github_links <- has_github_links(target_repo)
+
   bullets <- c(
     todo("`usethis::use_readme_rmd()`", !file_exists(proj_path("README.Rmd"))),
     todo("`usethis::use_roxygen_md()`", !is_true(uses_roxygen_md())),
-    todo("`usethis::use_github_links()`", !has_github_links()),
+    todo("`usethis::use_github_links()`", !has_github_links),
     todo("`usethis::use_pkgdown_github_pages()`", !uses_pkgdown()),
     todo("`usethis::use_tidy_description()`"),
     todo(

--- a/R/utils-github.R
+++ b/R/utils-github.R
@@ -86,12 +86,21 @@ parse_repo_url <- function(x) {
   }
 }
 
-github_url_from_git_remotes <- function() {
-  tr <- tryCatch(target_repo(github_get = NA), error = function(e) NULL)
-  if (is.null(tr)) {
-    return()
+# Can be called in contexts where we have already asked user to choose between
+# origin and upstsream and, therefore, we know the remote URL. We parse it
+# regardless, because:
+# (1) Could be SSH not HTTPS
+# (2) Could be hosted on GHE not github.com
+github_url_from_git_remotes <- function(url = NULL) {
+  if (is.null(url)) {
+    tr <- tryCatch(target_repo(github_get = NA), error = function(e) NULL)
+    if (is.null(tr)) {
+      return()
+    }
+    url <- tr$url
   }
-  parsed <- parse_github_remotes(tr$url)
+
+  parsed <- parse_github_remotes(url)
   glue_data_chr(parsed, "https://{host}/{repo_owner}/{repo_name}")
 }
 

--- a/tests/testthat/test-github.R
+++ b/tests/testthat/test-github.R
@@ -1,3 +1,17 @@
+test_that("has_github_links() uses the target_repo, if provided", {
+  skip_if_no_git_user()
+  create_local_package()
+  local_interactive(FALSE)
+  use_git()
+
+  desc::desc_set_urls("https://github.com/OWNER/REPO")
+  desc::desc_set("BugReports", "https://github.com/OWNER/REPO/issues")
+
+  tr <- list(url = "git@github.com:OWNER/REPO.git")
+
+  expect_true(has_github_links(tr))
+})
+
 test_that("use_github_links populates empty URL field", {
   skip_if_no_git_user()
   local_interactive(FALSE)

--- a/tests/testthat/test-release.R
+++ b/tests/testthat/test-release.R
@@ -87,6 +87,37 @@ test_that("RStudio-ness detection works", {
   )
 })
 
+test_that("can find milestone numbers", {
+  skip_if_offline("github.com")
+
+  tr <- list(
+    repo_owner = "r-lib",
+    repo_name = "usethis",
+    api_url = "https://api.github.com"
+  )
+
+  expect_equal(
+    gh_milestone_number(tr, "2.1.6", state = "all"),
+    8
+  )
+  expect_equal(
+    gh_milestone_number(tr, "0.0.0", state = "all"),
+    NA_integer_
+  )
+})
+
+test_that("gh_milestone_number() returns NA when gh() errors", {
+  local_mocked_bindings(
+    gh_tr = function(tr) { function(endpoint, ...) { ui_abort("nope!") } }
+  )
+  tr <- list(
+    repo_owner = "r-lib",
+    repo_name = "usethis",
+    api_url = "https://api.github.com"
+  )
+  expect_true(is.na(gh_milestone_number(tr, "1.1.1")))
+})
+
 # news --------------------------------------------------------------------
 
 test_that("must have at least one heading", {
@@ -125,25 +156,6 @@ test_that("returns empty string if no bullets", {
     "# Heading"
   )
   expect_equal(news_latest(lines), "")
-})
-
-test_that("can find milestone numbers", {
-  skip_if_offline("github.com")
-
-  tr <- list(
-    repo_owner = "r-lib",
-    repo_name = "usethis",
-    api_url = "https://api.github.com"
-  )
-
-  expect_equal(
-    gh_milestone_number(tr, "2.1.6", state = "all"),
-    8
-  )
-  expect_equal(
-    gh_milestone_number(tr, "0.0.0", state = "all"),
-    NA_integer_
-  )
 })
 
 # draft release ----------------------------------------------------------------

--- a/tests/testthat/test-release.R
+++ b/tests/testthat/test-release.R
@@ -130,12 +130,18 @@ test_that("returns empty string if no bullets", {
 test_that("can find milestone numbers", {
   skip_if_offline("github.com")
 
+  tr <- list(
+    repo_owner = "r-lib",
+    repo_name = "usethis",
+    api_url = "https://api.github.com"
+  )
+
   expect_equal(
-    gh_milestone_number("r-lib/usethis", "2.1.6", state = "all"),
+    gh_milestone_number(tr, "2.1.6", state = "all"),
     8
   )
   expect_equal(
-    gh_milestone_number("r-lib/usethis", "0.0.0", state = "all"),
+    gh_milestone_number(tr, "0.0.0", state = "all"),
     NA_integer_
   )
 })

--- a/tests/testthat/test-utils-github.R
+++ b/tests/testthat/test-utils-github.R
@@ -150,6 +150,12 @@ test_that("github_remotes() works", {
   expect_true(is.na(grl$is_fork))
 })
 
+test_that("github_url_from_git_remotes() is idempotent", {
+  url <- "https://github.com/r-lib/usethis.git"
+  out <- github_url_from_git_remotes(url)
+  expect_equal(out, github_url_from_git_remotes(out))
+})
+
 # GitHub remote configuration --------------------------------------------------
 
 test_that("we understand the list of all possible configs", {


### PR DESCRIPTION
Addresses #2023 

We have to be careful around calling functions inside the `(release|upkeep)_checklist()` helpers that need to know which GitHub repo we're targetting. We're at risk of asking the user to choose the repo over and over again, with no context, if the user happens to have a fork of the source repo. We already _know_ the target repo at this point, so we propagate that info now.