### PR TITLE
Dots in rename

### DIFF
--- a/R/rename-files.R
+++ b/R/rename-files.R
@@ -16,6 +16,12 @@
 #' @export
 rename_files <- function(old, new) {
   check_uses_git()
+  challenge_uncommitted_changes(
+    msg = "
+    There are uncommitted changes and we're about to bulk-rename files. It is \\
+    highly recommended to get into a clean Git state before bulk-editing files",
+    untracked = TRUE
+  )
 
   old <- path_ext_remove(old)
   new <- path_ext_remove(new)

--- a/R/rename-files.R
+++ b/R/rename-files.R
@@ -12,7 +12,7 @@
 #' This is a potentially dangerous operation, so you must be using Git in
 #' order to use this function.
 #'
-#' @param old,new Old and new file names (with or without extensions).
+#' @param old,new Old and new file names (with or without `.R` extensions).
 #' @export
 rename_files <- function(old, new) {
   check_uses_git()
@@ -23,8 +23,8 @@ rename_files <- function(old, new) {
     untracked = TRUE
   )
 
-  old <- path_ext_remove(old)
-  new <- path_ext_remove(new)
+  old <- sub("\\.R$", "", old)
+  new <- sub("\\.R$", "", new)
 
   # R/ ------------------------------------------------------------------------
   r_old_path <- proj_path("R", old, ext = "R")

--- a/man/rename_files.Rd
+++ b/man/rename_files.Rd
@@ -7,7 +7,7 @@
 rename_files(old, new)
 }
 \arguments{
-\item{old, new}{Old and new file names (with or without extensions).}
+\item{old, new}{Old and new file names (with or without \code{.R} extensions).}
 }
 \description{
 \itemize{

--- a/tests/testthat/test-rename-files.R
+++ b/tests/testthat/test-rename-files.R
@@ -82,3 +82,13 @@ test_that("rename paths in test file", {
   lines <- read_utf8(proj_path("tests", "testthat", "test-bar.R"))
   expect_equal(lines, "test-bar.txt")
 })
+
+test_that("does not remove non-R dots in filename", {
+  create_local_package()
+  local_mocked_bindings(challenge_uncommitted_changes = \(...) invisible())
+  git_init()
+
+  file_create(proj_path("R/foo.bar.R"))
+  rename_files("foo.bar", "baz.qux")
+  expect_proj_file("R/baz.qux.R")
+})

--- a/tests/testthat/test-rename-files.R
+++ b/tests/testthat/test-rename-files.R
@@ -1,5 +1,19 @@
+test_that("checks uncommitted files", {
+  create_local_package()
+  expect_error(rename_files("foo", "bar"), class = "usethis_error")
+
+  git_init()
+  use_r("foo", open = FALSE)
+  expect_error(
+    rename_files("foo", "bar"),
+    "uncommitted changes",
+    class = "usethis_error"
+  )
+})
+
 test_that("renames R and test and snapshot files", {
   create_local_package()
+  local_mocked_bindings(challenge_uncommitted_changes = \(...) invisible())
   git_init()
 
   use_r("foo", open = FALSE)
@@ -18,6 +32,7 @@ test_that("renames R and test and snapshot files", {
 
 test_that("renames src/ files", {
   create_local_package()
+  local_mocked_bindings(challenge_uncommitted_changes = \(...) invisible())
   git_init()
 
   use_src()
@@ -35,6 +50,7 @@ test_that("renames src/ files", {
 
 test_that("strips context from test file", {
   create_local_package()
+  local_mocked_bindings(challenge_uncommitted_changes = \(...) invisible())
   git_init()
 
   use_testthat()
@@ -54,6 +70,7 @@ test_that("strips context from test file", {
 
 test_that("rename paths in test file", {
   create_local_package()
+  local_mocked_bindings(challenge_uncommitted_changes = \(...) invisible())
   git_init()
 
   use_testthat()

--- a/tests/testthat/test-rename-files.R
+++ b/tests/testthat/test-rename-files.R
@@ -85,7 +85,7 @@ test_that("rename paths in test file", {
 
 test_that("does not remove non-R dots in filename", {
   create_local_package()
-  local_mocked_bindings(challenge_uncommitted_changes = \(...) invisible())
+  local_mocked_bindings(challenge_uncommitted_changes = function(...) invisible())
   git_init()
 
   file_create(proj_path("R/foo.bar.R"))

--- a/tests/testthat/test-rename-files.R
+++ b/tests/testthat/test-rename-files.R
@@ -13,7 +13,7 @@ test_that("checks uncommitted files", {
 
 test_that("renames R and test and snapshot files", {
   create_local_package()
-  local_mocked_bindings(challenge_uncommitted_changes = \(...) invisible())
+  local_mocked_bindings(challenge_uncommitted_changes = function(...) invisible())
   git_init()
 
   use_r("foo", open = FALSE)
@@ -32,7 +32,7 @@ test_that("renames R and test and snapshot files", {
 
 test_that("renames src/ files", {
   create_local_package()
-  local_mocked_bindings(challenge_uncommitted_changes = \(...) invisible())
+  local_mocked_bindings(challenge_uncommitted_changes = function(...) invisible())
   git_init()
 
   use_src()
@@ -50,7 +50,7 @@ test_that("renames src/ files", {
 
 test_that("strips context from test file", {
   create_local_package()
-  local_mocked_bindings(challenge_uncommitted_changes = \(...) invisible())
+  local_mocked_bindings(challenge_uncommitted_changes = function(...) invisible())
   git_init()
 
   use_testthat()
@@ -70,7 +70,7 @@ test_that("strips context from test file", {
 
 test_that("rename paths in test file", {
   create_local_package()
-  local_mocked_bindings(challenge_uncommitted_changes = \(...) invisible())
+  local_mocked_bindings(challenge_uncommitted_changes = function(...) invisible())
   git_init()
 
   use_testthat()


### PR DESCRIPTION
Check for uncommitted changes before renaming files, and only remove `.R` file extensions in `old` and `new`.

Fixes #1969.

I *think* this is the least-surprising approach to take. It's probably best to just not use `.` in filenames, but this will stop things from breaking in confusing ways when people do.