### PR TITLE
suppress git_protocol message in git_sitrep

### DIFF
--- a/R/git.R
+++ b/R/git.R
@@ -357,7 +357,8 @@ git_sitrep <- function(tool = c("git", "github"),
     if (!vaccinated) {
       ui_bullets(c("i" = "See {.fun usethis::git_vaccinate} to learn more."))
     }
-    kv_line("Default Git protocol", git_protocol())
+    protocol <- suppressMessages(git_protocol())
+    kv_line("Default Git protocol", protocol)
     kv_line("Default initial branch name", init_default_branch)
   }
 

--- a/R/git.R
+++ b/R/git.R
@@ -357,8 +357,7 @@ git_sitrep <- function(tool = c("git", "github"),
     if (!vaccinated) {
       ui_bullets(c("i" = "See {.fun usethis::git_vaccinate} to learn more."))
     }
-    protocol <- suppressMessages(git_protocol())
-    kv_line("Default Git protocol", protocol)
+    kv_line("Default Git protocol", ui_silence(git_protocol()))
     kv_line("Default initial branch name", init_default_branch)
   }
 


### PR DESCRIPTION
Fixes #2034 

If the default git communication protocol isn't set, `git_protocol()` sets a default *and* messages the user about the chosen default. That message looks confusing in the output bullets for `git_sitrep()`. This PR suppresses that message.

Putting `suppressMessages()` directly in the `kv_line()` call didn't seem to work (maybe something about the environment?), so I split it into two steps. 

These chunks were useful for testing changes since I had some of these options set in my user-level .Rprofile:
```r

devtools::load_all()

options("usethis.protocol" = NULL)
git_protocol()

options("usethis.protocol" = NULL)
git_sitrep()
```
