### PR TITLE
Bump default serialization version in use_data() to 3

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # usethis (development version)
 
+* `use_data()` now uses serialization version 3 by default. (@laurabrianna, #2044)
+
 # usethis 3.0.0
 
 ## Transition to cli package for UI

--- a/R/data.R
+++ b/R/data.R
@@ -38,7 +38,7 @@ use_data <- function(...,
                      internal = FALSE,
                      overwrite = FALSE,
                      compress = "bzip2",
-                     version = 2,
+                     version = 3,
                      ascii = FALSE) {
   check_is_package("use_data()")
 

--- a/R/data.R
+++ b/R/data.R
@@ -18,9 +18,9 @@
 #'   files. If you really want to do so, set this to `TRUE`.
 #' @param compress Choose the type of compression used by [save()].
 #'   Should be one of "gzip", "bzip2", or "xz".
-#' @param version The serialization format version to use. The default, 2, was
-#'   the default format from R 1.4.0 to 3.5.3. Version 3 became the default from
-#'   R 3.6.0 and can only be read by R versions 3.5.0 and higher.
+#' @param version The serialization format version to use. The default, 3, can
+#'   only be read by R versions 3.5.0 and higher. For R 1.4.0 to 3.5.3, use
+#'   version 2.
 #' @inheritParams base::save
 #'
 #' @seealso The [data chapter](https://r-pkgs.org/data.html) of [R

--- a/man/use_data.Rd
+++ b/man/use_data.Rd
@@ -10,7 +10,7 @@ use_data(
   internal = FALSE,
   overwrite = FALSE,
   compress = "bzip2",
-  version = 2,
+  version = 3,
   ascii = FALSE
 )
 

--- a/man/use_data.Rd
+++ b/man/use_data.Rd
@@ -35,9 +35,9 @@ files. If you really want to do so, set this to \code{TRUE}.}
 \item{compress}{Choose the type of compression used by \code{\link[=save]{save()}}.
 Should be one of "gzip", "bzip2", or "xz".}
 
-\item{version}{The serialization format version to use. The default, 2, was
-the default format from R 1.4.0 to 3.5.3. Version 3 became the default from
-R 3.6.0 and can only be read by R versions 3.5.0 and higher.}
+\item{version}{The serialization format version to use. The default, 3, can
+only be read by R versions 3.5.0 and higher. For R 1.4.0 to 3.5.3, use
+version 2.}
 
 \item{ascii}{if \code{TRUE}, an ASCII representation of the data is
     written.  The default value of \code{ascii} is \code{FALSE} which

--- a/tests/testthat/test-data.R
+++ b/tests/testthat/test-data.R
@@ -62,14 +62,14 @@ test_that("use_data() honors `overwrite` for internal data", {
   expect_identical(letters2, rev(letters))
 })
 
-test_that("use_data() writes version 2 by default", {
+test_that("use_data() writes version 3 by default", {
   create_local_package()
 
   x <- letters
-  use_data(x, internal = TRUE, version = 2, compress = FALSE)
+  use_data(x, internal = TRUE,  compress = FALSE)
   expect_identical(
     rawToChar(readBin(proj_path("R", "sysdata.rda"), n = 4, what = "raw")),
-    "RDX2"
+    "RDX3"
   )
 })
 


### PR DESCRIPTION
Fixes #1966  - The grand sum of this update is one character (plus a news bullet) Note that this change did not break anything in any test (should a test be added?)