### PR TITLE
Adds link to cli vignette on transition from ui_*()

### DIFF
--- a/R/ui-legacy.R
+++ b/R/ui-legacy.R
@@ -13,7 +13,8 @@
 #'
 #'   usethis itself now uses cli internally for its UI, but these new functions
 #'   are not exported and presumably never will be. There is a developer-focused
-#'   article on the process of transitioning usethis's own UI to use cli [here](https://cli.r-lib.org/articles/usethis-ui.html)
+#'   article on the process of transitioning usethis's own UI to use cli:
+#'   [Converting usethis's UI to use cli](https://usethis.r-lib.org/articles/ui-cli-conversion.html)
 
 #' @details
 #'

--- a/R/ui-legacy.R
+++ b/R/ui-legacy.R
@@ -13,8 +13,7 @@
 #'
 #'   usethis itself now uses cli internally for its UI, but these new functions
 #'   are not exported and presumably never will be. There is a developer-focused
-#'   article on the process of transitioning usethis's own UI to use cli (LINK
-#'   TO COME).
+#'   article on the process of transitioning usethis's own UI to use cli [here](https://cli.r-lib.org/articles/usethis-ui.html)
 
 #' @details
 #'


### PR DESCRIPTION
Replaces "(LINK TO COME)" text in ui-legacy.R roxygen.

No existing issue that I could find.