### PR TITLE
Fix some lints

### DIFF
--- a/R/data.R
+++ b/R/data.R
@@ -92,7 +92,7 @@ get_objs_from_dots <- function(.dots) {
   }
 
   is_name <- vapply(.dots, is.symbol, logical(1))
-  if (any(!is_name)) {
+  if (!all(is_name)) {
     ui_abort("Can only save existing named objects.")
   }
 

--- a/R/proj-desc.R
+++ b/R/proj-desc.R
@@ -41,7 +41,7 @@ proj_desc_field_update <- function(key, value, overwrite = TRUE, append = FALSE)
     return(invisible())
   }
 
-  if (!overwrite && length(old > 0) && any(old != "")) {
+  if (!overwrite && length(old) > 0 && any(old != "")) {
     ui_abort("
       {.field {key}} has a different value in DESCRIPTION.
       Use {.code overwrite = TRUE} to overwrite.")

--- a/R/use_standalone.R
+++ b/R/use_standalone.R
@@ -247,7 +247,7 @@ as_version_info_row <- function(field, error_call = caller_env()) {
 
   ver <- strsplit(ver, " ")[[1]]
 
-  if (!is_character(ver, n = 2) || any(is.na(ver)) || !all(nzchar(ver))) {
+  if (!is_character(ver, n = 2) || anyNA(ver) || !all(nzchar(ver))) {
     cli::cli_abort(
       c(
         "Can't parse version `{field}` in `imports:` field.",

--- a/R/utils-git.R
+++ b/R/utils-git.R
@@ -83,7 +83,7 @@ git_user_get <- function(where = c("de_facto", "local", "global")) {
 
 # translate from "usethis" terminology to "git" terminology
 where_from_scope <- function(scope = c("user", "project")) {
-  scope = match.arg(scope)
+  scope <- match.arg(scope)
 
   where_scope <- c(user = "global", project = "de_facto")
 

--- a/R/utils-github.R
+++ b/R/utils-github.R
@@ -193,7 +193,7 @@ github_remotes <- function(these = c("origin", "upstream"),
   # 1. Did we call the GitHub API? Means we know `is_fork` and the parent repo.
   # 2. If so, did we call it with auth? Means we know if we can push.
   grl$github_got <- map_lgl(repo_info, ~ length(.x) > 0)
-  if (isTRUE(github_get) && any(!grl$github_got)) {
+  if (isTRUE(github_get) && !all(grl$github_got)) {
     oops <- which(!grl$github_got)
     oops_remotes <- grl$remote[oops]
     oops_hosts <- unique(grl$host[oops])

--- a/tests/manual/manual-use-github.R
+++ b/tests/manual/manual-use-github.R
@@ -59,7 +59,7 @@ expect_match(desc::desc_get_field("BugReports"), BugReports)
 
 # remove the GitHub links
 desc::desc_del(c("BugReports", "URL"))
-expect_true(all(!desc::desc_has_fields(c("BugReports", "URL"))))
+expect_true(!any(desc::desc_has_fields(c("BugReports", "URL"))))
 
 # restore the GitHub links
 # should see a warning that `host` is deprecated and ignored

--- a/tests/testthat/test-proj.R
+++ b/tests/testthat/test-proj.R
@@ -148,12 +148,12 @@ test_that("with_project() runs code in temp proj, restores (lack of) proj", {
   )
 
   proj_set_(NULL)
-  expect_identical(proj_get_(), NULL)
+  expect_null(proj_get_())
 
   res <- with_project(path = temp_proj, proj_get_())
 
   expect_identical(res, temp_proj)
-  expect_identical(proj_get_(), NULL)
+  expect_null(proj_get_())
 })
 
 test_that("with_project() runs code in temp proj, restores original proj", {

--- a/tests/testthat/test-utils-github.R
+++ b/tests/testthat/test-utils-github.R
@@ -11,7 +11,7 @@ test_that("parse_github_remotes() works, on named list or named character", {
     bitbucket2 = "git@bitbucket.org:OWNER/REPO.git"
   )
   parsed <- parse_github_remotes(urls)
-  expect_equal(parsed$name, names(urls))
+  expect_named(urls, parsed$name)
   expect_equal(unique(parsed$repo_owner), "OWNER")
   expect_equal(
     parsed$host,

--- a/tests/testthat/test-utils-github.R
+++ b/tests/testthat/test-utils-github.R
@@ -11,7 +11,7 @@ test_that("parse_github_remotes() works, on named list or named character", {
     bitbucket2 = "git@bitbucket.org:OWNER/REPO.git"
   )
   parsed <- parse_github_remotes(urls)
-  expect_named(urls, parsed$name)
+  expect_equal(parsed$name, names(urls))
   expect_equal(unique(parsed$repo_owner), "OWNER")
   expect_equal(
     parsed$host,


### PR DESCRIPTION
Hello, I'm building a new package to find and automatically fix lints in R code: [`flint`](https://flint.etiennebacher.com/).

I'm using real-life, large packages to check its performance (both in speed and in correctness of the fixes) and `usethis` is one of them. Since I already test on this, there's almost no additional cost for me in proposing those changes.

FYI, those changes were generated with `flint::fix_package()`.

Most changes are trivial:
- replace `any(is.na())` by `anyNA()`
- replace `expect_identical(x, NULL)` by `expect_null(x)`
etc.

There's also likely a bug fix: `length(old > 0)` is replaced by `length(old) > 0`.

`flint` is quite new and linter rules are necessarily a bit opinionated (but I follow `lintr` most of the time), so some of those changes might not be to your taste, but I'd be happy to have some feedback on this.