### PR TITLE
Use `github_remote_list()` instead of `github_remotes()` when GitHub not consulted

### DIFF
--- a/R/pr.R
+++ b/R/pr.R
@@ -662,7 +662,7 @@ pr_create <- function() {
   branch <- git_branch()
   tracking_branch <- git_branch_tracking(branch)
   remote <- remref_remote(tracking_branch)
-  remote_dat <- github_remotes(remote, github_get = FALSE)
+  remote_dat <- github_remote_list(remote)
   ui_bullets(c("_" = "Create PR at link given below."))
   view_url(glue_data(remote_dat, "{host_url}/{repo_spec}/compare/{branch}"))
 }

--- a/R/utils-github.R
+++ b/R/utils-github.R
@@ -883,7 +883,7 @@ new_no_github <- function() {
 
 new_ours <- function() {
   remotes <- data.frame(name = "origin", url = "https://github.com/OWNER/REPO.git")
-  grl <- github_remotes(github_get = FALSE, x = remotes)
+  grl <- github_remote_list(x = remotes)
   grl$github_got <- grl$perm_known <- TRUE
   grl$default_branch <- "DEFAULT_BRANCH"
 
@@ -917,7 +917,7 @@ new_fork <- function() {
     name = c("origin", "upstream"),
     url = c("https://github.com/CONTRIBUTOR/REPO.git", "https://github.com/OWNER/REPO.git")
   )
-  grl <- github_remotes(github_get = FALSE, x = remotes)
+  grl <- github_remote_list(x = remotes)
   grl$github_got <- grl$perm_known <- TRUE
   grl$default_branch <- "DEFAULT_BRANCH"
 
@@ -940,7 +940,7 @@ new_fork <- function() {
 
 new_maybe_ours_or_theirs <- function() {
   remotes <- data.frame(name = "origin", url = "https://github.com/OWNER/REPO.git")
-  grl <- github_remotes(github_get = FALSE, x = remotes)
+  grl <- github_remote_list(x = remotes)
   grl$github_got <-grl$perm_known <- FALSE
   grl$default_branch <- "DEFAULT_BRANCH"
 
@@ -956,7 +956,7 @@ new_maybe_fork <- function() {
     name = c("origin", "upstream"),
     url = c("https://github.com/CONTRIBUTOR/REPO.git", "https://github.com/OWNER/REPO.git")
   )
-  grl <- github_remotes(github_get = FALSE, x = remotes)
+  grl <- github_remote_list(x = remotes)
   grl$github_got <-grl$perm_known <- FALSE
   grl$default_branch <- "DEFAULT_BRANCH"
 
@@ -973,7 +973,7 @@ new_fork_cannot_push_origin <- function() {
     name = c("origin", "upstream"),
     url = c("https://github.com/CONTRIBUTOR/REPO.git", "https://github.com/OWNER/REPO.git")
   )
-  grl <- github_remotes(github_get = FALSE, x = remotes)
+  grl <- github_remote_list(x = remotes)
   grl$github_got <-grl$perm_known <- TRUE
   grl$default_branch <- "DEFAULT_BRANCH"
 
@@ -993,7 +993,7 @@ new_fork_upstream_is_not_origin_parent<- function() {
     name = c("origin", "upstream"),
     url = c("https://github.com/CONTRIBUTOR/REPO.git", "https://github.com/OLD_OWNER/REPO.git")
   )
-  grl <- github_remotes(github_get = FALSE, x = remotes)
+  grl <- github_remote_list(x = remotes)
   grl$github_got <- grl$perm_known <- TRUE
   grl$default_branch <- "DEFAULT_BRANCH"
 
@@ -1018,7 +1018,7 @@ new_upstream_but_origin_is_not_fork <- function() {
     name = c("origin", "upstream"),
     url = c("https://github.com/CONTRIBUTOR/REPO.git", "https://github.com/OWNER/REPO.git")
   )
-  grl <- github_remotes(github_get = FALSE, x = remotes)
+  grl <- github_remote_list(x = remotes)
   grl$github_got <-grl$perm_known <- TRUE
   grl$default_branch <- "DEFAULT_BRANCH"
 

--- a/R/utils-github.R
+++ b/R/utils-github.R
@@ -899,7 +899,7 @@ new_ours <- function() {
 
 new_theirs <- function() {
   remotes <- data.frame(name = "origin", url = "https://github.com/OWNER/REPO.git")
-  grl <- github_remotes(github_get = FALSE, x = remotes)
+  grl <- github_remote_list(x = remotes)
   grl$github_got <- grl$perm_known <- TRUE
   grl$default_branch <- "DEFAULT_BRANCH"
 


### PR DESCRIPTION
To reduce some of the usage of `github_remotes()` where it's not strictly necessary.