### PR TITLE
Specifically handle offline case in `pr_init()`

### DIFF
--- a/R/pr.R
+++ b/R/pr.R
@@ -173,7 +173,7 @@ pr_init <- function(branch) {
     ui_bullets(c(
       "x" = "You are not currently online.",
       "i" = "You can still create a local branch, but we can't check that your
-             default branch is up-to-date or setup to the remote branch."
+             current branch is up-to-date or setup the remote branch."
     ))
     if (ui_nah("Do you want to continue?")) {
       ui_bullets(c("x" = "Cancelling."))

--- a/R/pr.R
+++ b/R/pr.R
@@ -172,8 +172,8 @@ pr_init <- function(branch) {
   if (!online) {
     ui_bullets(c(
       "x" = "You are not currently online.",
-      "i" = "You can still create a local branch, but you won't be able to setup
-            or push to the remote branch."
+      "i" = "You can still create a local branch, but we can't check that your
+             default branch is up-to-date or setup to the remote branch."
     ))
     if (ui_nah("Do you want to continue?")) {
       ui_bullets(c("x" = "Cancelling."))


### PR DESCRIPTION
I realised that we're checking whether or not the host is online further down, so we might as well use that a little earlier to give a more informative message.