### PR TITLE
Fix `use_data()` + `use_standalone()` by not allowing decreasing R dependency

### DIFF
--- a/R/data.R
+++ b/R/data.R
@@ -45,9 +45,9 @@ use_data <- function(...,
   objs <- get_objs_from_dots(dots(...))
 
   if (version < 3) {
-    use_dependency("R", "depends", "2.10")
+    use_dependency("R", "depends", "2.10", allow_decrease = FALSE)
   } else {
-    use_dependency("R", "depends", "3.5")
+    use_dependency("R", "depends", "3.5", allow_decrease = FALSE)
   }
   if (internal) {
     use_directory("R")

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -75,7 +75,7 @@ use_dependency <- function(package, type, min_version = NULL, allow_decrease = T
     if (!is.null(direction)) {
       ui_bullets(c(
         "v" = "{direction} {.pkg {package}} version to {.val {version}} in
-             DESCRIPTION."
+               DESCRIPTION."
       ))
       desc$set_dep(package, type, version = version)
       desc$write()

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -1,6 +1,7 @@
-use_dependency <- function(package, type, min_version = NULL) {
+use_dependency <- function(package, type, min_version = NULL, allow_decrease = TRUE) {
   check_name(package)
   check_name(type)
+  check_bool(allow_decrease)
 
   if (package != "R") {
     check_installed(package)
@@ -65,17 +66,23 @@ use_dependency <- function(package, type, min_version = NULL) {
   } else if (delta == 0 && version_spec(version) != version_spec(existing_version)) {
     if (version_spec(version) > version_spec(existing_version)) {
       direction <- "Increasing"
-    } else {
+    } else if (allow_decrease) {
       direction <- "Decreasing"
+    } else {
+      direction <- NULL
     }
 
-    ui_bullets(c(
-      "v" = "{direction} {.pkg {package}} version to {.val {version}} in
+    if (!is.null(direction)) {
+      ui_bullets(c(
+        "v" = "{direction} {.pkg {package}} version to {.val {version}} in
              DESCRIPTION."
-    ))
-    desc$set_dep(package, type, version = version)
-    desc$write()
-    changed <- TRUE
+      ))
+      desc$set_dep(package, type, version = version)
+      desc$write()
+      changed <- TRUE
+    } else {
+      changed <- FALSE
+    }
 
   } else if (delta > 0) {
     # moving from, e.g., Suggests to Imports

--- a/R/test.R
+++ b/R/test.R
@@ -37,7 +37,7 @@ use_testthat_impl <- function(edition = NULL, parallel = FALSE) {
   if (is_package()) {
     edition <- check_edition(edition)
 
-    use_dependency("testthat", "Suggests", paste0(edition, ".0.0"))
+    use_dependency("testthat", "Suggests", paste0(edition, ".0.0"), allow_decrease = FALSE)
     proj_desc_field_update("Config/testthat/edition", as.character(edition), overwrite = TRUE)
 
     if (parallel) {

--- a/R/use_standalone.R
+++ b/R/use_standalone.R
@@ -94,7 +94,7 @@ use_standalone <- function(repo_spec, file = NULL, ref = NULL, host = NULL) {
       ver <- import$ver
     }
     ui_silence(
-      use_package(import$pkg, min_version = ver)
+      use_dependency(import$pkg, "Imports", min_version = ver, allow_decrease = FALSE)
     )
   }
 

--- a/tests/testthat/test-package.R
+++ b/tests/testthat/test-package.R
@@ -36,6 +36,14 @@ test_that("use_package(type = 'Suggests') guidance w/o and w/ rlang", {
   expect_snapshot(use_package("purrr", "Suggests"))
 })
 
+test_that("use_data() will not decrease R version if called internally.", {
+  create_local_package()
+  # Use a minimum R version
+  use_package("R", "Depends", "4.1")
+  use_dependency("R", "Depends", "3.6", allow_decrease = FALSE)
+  expect_equal(subset(proj_deps(), package == "R")$version, ">= 4.1")
+})
+
 # use_dev_package() -----------------------------------------------------------
 
 test_that("use_dev_package() writes a remote", {


### PR DESCRIPTION
To fix a drawback from #2043

Basically, if I have a dependency on R 4.1 and call `use_data()`, it will decrease version to 3.5. Same thing if I require rlang 1.1.4 and call `usethis::use_standalone("r-lib/rlang", "types-check")`


In short if I have DESCRIPTION

```
Depends: R (>= 4.1)
```

And I call this:

```r
usethis::use_data(data, overwrite = TRUE)
✔ Setting active project to "usethis".
✔ Decreasing R version to ">= 3.5" in DESCRIPTION.
✔ Saving "data" to "data/data.rda".
```

But this is incorrect.

The PR fixes it.

However, I fixed it in the helper function only. If an external package relied on `use_package()`, it would error.

Agreed that if I call interactively

```r
usethis::use_package("R", "depends", "3.5")
```

it should decrease by default.