### PR TITLE
Use lifecycle instead of tibble

### DIFF
--- a/tests/testthat/_snaps/use_import_from.md
+++ b/tests/testthat/_snaps/use_import_from.md
@@ -3,8 +3,8 @@
     Code
       roxygen_ns_show()
     Output
-      [1] "#' @importFrom tibble deframe" "#' @importFrom tibble enframe"
-      [3] "#' @importFrom tibble tibble" 
+      [1] "#' @importFrom lifecycle deprecate_stop"
+      [2] "#' @importFrom lifecycle deprecate_warn"
 
 # use_import_from() generates helpful errors
 

--- a/tests/testthat/_snaps/use_import_from.md
+++ b/tests/testthat/_snaps/use_import_from.md
@@ -14,15 +14,15 @@
       Error in `use_import_from()`:
       x `package` must be a single string.
     Code
-      use_import_from(c("tibble", "rlang"))
+      use_import_from(c("desc", "rlang"))
     Condition
       Error in `use_import_from()`:
       x `package` must be a single string.
     Code
-      use_import_from("tibble", "pool_noodle")
+      use_import_from("desc", "pool_noodle")
     Condition
       Error in `map2()`:
       i In index: 1.
       Caused by error in `.f()`:
-      x Can't find `tibble::pool_noodle()`.
+      x Can't find `desc::pool_noodle()`.
 

--- a/tests/testthat/test-use_import_from.R
+++ b/tests/testthat/test-use_import_from.R
@@ -1,16 +1,16 @@
 test_that("use_import_from() imports the related package & adds line to package doc", {
   create_local_package()
   use_package_doc()
-  use_import_from("tibble", "tibble")
+  use_import_from("lifecycle", "deprecated")
 
-  expect_equal(proj_desc()$get_field("Imports"), "tibble")
-  expect_equal(roxygen_ns_show(), "#' @importFrom tibble tibble")
+  expect_equal(proj_desc()$get_field("Imports"), "lifecycle")
+  expect_equal(roxygen_ns_show(), "#' @importFrom lifecycle deprecated")
 })
 
 test_that("use_import_from() adds one line for each function", {
   create_local_package()
   use_package_doc()
-  use_import_from("tibble", c("tibble", "enframe", "deframe"))
+  use_import_from("lifecycle", c("deprecate_warn", "deprecate_stop"))
 
   expect_snapshot(roxygen_ns_show())
 })

--- a/tests/testthat/test-use_import_from.R
+++ b/tests/testthat/test-use_import_from.R
@@ -21,8 +21,8 @@ test_that("use_import_from() generates helpful errors", {
 
   expect_snapshot(error = TRUE, {
     use_import_from(1)
-    use_import_from(c("tibble", "rlang"))
+    use_import_from(c("desc", "rlang"))
 
-    use_import_from("tibble", "pool_noodle")
+    use_import_from("desc", "pool_noodle")
   })
 })


### PR DESCRIPTION
Closes #2079 

waldo previously imported tibble so switch to a package that will always be installed with usethis.

This fixes the failure on CRAN.