### PR TITLE
Update unit test template for usethis::use_test

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # usethis (development version)
 
+* `use_test()` now creates a unit test with the ['#Arrange, #Act, #Assert'](https://xp123.com/3a-arrange-act-assert/) pattern.
 * `use_tidy_upkeep_issue()` now records the year it is being run in the
   `Config/usethis/upkeep` field in DESCRIPTION. If this value exists it is
   furthermore used to filter the checklist when making the issue.

--- a/inst/templates/test-example-2.1.R
+++ b/inst/templates/test-example-2.1.R
@@ -1,3 +1,10 @@
-test_that("multiplication works", {
-  expect_equal(2 * 2, 4)
+test_that("is.numeric returns TRUE if all elements of a vector are integers", {
+  # Arrange
+  x <- c(1L, 2L, 3L)
+
+  # Act
+  result <- is.numeric(x)
+
+  # Assert
+  expect_true(result)
 })


### PR DESCRIPTION
There is no issue created for this PR, nor have I created one, but I wanted to come forward with a small potential improvement.

The current unit test template is very minimal and it's good because it's just a placeholder.

But such a minimal template doesn't set R users to create a communicative unit test.

There's an established way of structuring unit tests with #Arrange, #Act, #Assert comments so that they are more readable and communicate intent of the test better.

This was proposed by [Bill Wake](https://xp123.com/3a-arrange-act-assert/) and is endorsed by the likes of [Martin Fowler](https://martinfowler.com/bliki/GivenWhenThen.html).

I believe by introducing this new template, R community could benefit from having guidelines how to structure their unit tests better.