### PR TITLE
Test existence of EDITOR before attempting to use it

### DIFF
--- a/R/edit.R
+++ b/R/edit.R
@@ -31,7 +31,7 @@ edit_file <- function(path, open = rlang::is_interactive()) {
   ui_bullets(c("_" = "Modify {.path {pth(path)}}."))
   if (rstudio_available() && rstudioapi::hasFun("navigateToFile")) {
     rstudioapi::navigateToFile(path)
-  } else {
+  } else if (nzchar(Sys.which(Sys.getenv("EDITOR")))) {
     utils::file.edit(path)
   }
   invisible(path)


### PR DESCRIPTION
Ran into this ugly output from `usethis::use_package_doc()` on a GitHub codespace (which is intentionally lightweight):

```
✔ Setting active project to "/workspaces/lori".
✔ Writing R/lori-package.R.
☐ Modify R/lori-package.R.
sh: 1: vi: not found
☐ Run `devtools::document()` to update package-level documentation.
Warning message:
error in running command
```

The problem is R prefers `EDITOR=vi` by default (even if it's not available).

A more advanced fix might instead come up with a {usethis}-internal ordered list of editors to try, iterating over them and using the first found installed. But anyway this PR is a good first improvement.