### PR TITLE
Handle URLs from GitHub Enterprise managed orgs

### DIFF
--- a/R/utils-gh.R
+++ b/R/utils-gh.R
@@ -41,9 +41,17 @@ get_apiurl <- function(url) {
   prot_host <- strsplit(host_url, "://", fixed = TRUE)[[1]]
   if (is_github_dot_com(host_url)) {
     paste0(prot_host[[1]], "://api.github.com")
+  } else if(is_github_enterprise(host_url)) {
+    paste0(prot_host[[1]], "://api.", prot_host[[2]])
   } else {
     paste0(host_url, "/api/v3")
   }
+}
+
+is_github_enterprise <- function(url) {
+  url <- get_baseurl(url)
+  url <- normalize_host(url)
+  grepl("ghe.com$", url)
 }
 
 is_github_dot_com <- function(url) {

--- a/R/utils-github.R
+++ b/R/utils-github.R
@@ -137,7 +137,7 @@ github_remote_list <- function(these = c("origin", "upstream"), x = NULL) {
 
   parsed <- parse_github_remotes(set_names(x$url, x$name))
   # TODO: generalize here for GHE hosts that don't include 'github'
-  is_github <- grepl("github", parsed$host)
+  is_github <- grepl("github|ghe", parsed$host)
   parsed <- parsed[is_github, ]
 
   parsed$remote <- parsed$name


### PR DESCRIPTION
My organisation recently set itself up on a managed GitHub Enterprise organisation. Our new URL is of the form "https://my-cool-org.ghe.com". This PR makes the changes required for usethis to recognise this kind of URL as a GitHub one and parse it to find the appropriate API URL, which is of the form "https://api.my-cool-org.ghe.com".

My immediate use case was trying `usethis::use_pkgdown_github_pages()` and I can confirm that this function now works with the proposed changes.