### PR TITLE
Stop calling `link_path()` and let `is_dir()` do its thing

### DIFF
--- a/R/directory.R
+++ b/R/directory.R
@@ -39,7 +39,7 @@ check_path_is_directory <- function(path) {
   }
 
   if (is_link(path)) {
-    path <- link_path(path)
+    path <- path_real(path)
   }
 
   if (!is_dir(path)) {

--- a/R/directory.R
+++ b/R/directory.R
@@ -38,12 +38,14 @@ check_path_is_directory <- function(path) {
     ui_abort("Directory {.path {pth(path)}} does not exist.")
   }
 
+  orig_path <- path
+
   if (is_link(path)) {
     path <- path_real(path)
   }
 
   if (!is_dir(path)) {
-    ui_abort("{.path {pth(path)}} is not a directory.")
+    ui_abort("{.path {pth(orig_path)}} is not a directory.")
   }
 }
 

--- a/R/directory.R
+++ b/R/directory.R
@@ -38,14 +38,8 @@ check_path_is_directory <- function(path) {
     ui_abort("Directory {.path {pth(path)}} does not exist.")
   }
 
-  orig_path <- path
-
-  if (is_link(path)) {
-    path <- path_real(path)
-  }
-
   if (!is_dir(path)) {
-    ui_abort("{.path {pth(orig_path)}} is not a directory.")
+    ui_abort("{.path {pth(path)}} is not a directory.")
   }
 }
 

--- a/tests/testthat/test-directory.R
+++ b/tests/testthat/test-directory.R
@@ -29,11 +29,22 @@ test_that("symlink to directory is directory", {
 
 # https://github.com/r-lib/usethis/issues/2069
 test_that("relative symlink to directory is directory", {
+  # It appears that creating links on Windows is tricky w.r.t. permissions:
+  # Error: Error: [EPERM] Failed to link 'sub_dir' to 'relative_link_to_sub_dir': operation not permitted
+
+  # See also https://github.com/r-lib/fs/pull/397 re: relative links
+
+  # The original issue arose on macOS, so I'm willing to skip this test
+  # on Windows.
+  # If it's this hard for me to create the situation on Windows, presumably the
+  # situation won't come up a lot in real life either.
+  skip_on_os("windows")
+
   base_dir <- withr::local_tempdir()
   sub_dir <- dir_create(path(base_dir, "sub_dir"))
   withr::with_dir(
     base_dir,
-    link_create("sub_dir", "relative_link_to_sub_dir", symbolic = !is_windows())
+    link_create("sub_dir", "relative_link_to_sub_dir")
   )
 
   relative_linky_path <- path(base_dir, "relative_link_to_sub_dir")

--- a/tests/testthat/test-directory.R
+++ b/tests/testthat/test-directory.R
@@ -26,3 +26,13 @@ test_that("symlink to directory is directory", {
 
   expect_no_error(check_path_is_directory(base_b))
 })
+
+# https://github.com/r-lib/usethis/issues/2069
+test_that("relative symlink to directory is directory", {
+  base_dir <- withr::local_tempdir()
+  sub_dir <- dir_create(path(base_dir, "sub_dir"))
+  withr::with_dir(base_dir, link_create("sub_dir", "relative_link_to_sub_dir"))
+
+  relative_linky_path <- path(base_dir, "relative_link_to_sub_dir")
+  expect_no_error(check_path_is_directory(relative_linky_path))
+})

--- a/tests/testthat/test-directory.R
+++ b/tests/testthat/test-directory.R
@@ -31,7 +31,10 @@ test_that("symlink to directory is directory", {
 test_that("relative symlink to directory is directory", {
   base_dir <- withr::local_tempdir()
   sub_dir <- dir_create(path(base_dir, "sub_dir"))
-  withr::with_dir(base_dir, link_create("sub_dir", "relative_link_to_sub_dir"))
+  withr::with_dir(
+    base_dir,
+    link_create("sub_dir", "relative_link_to_sub_dir", symbolic = !is_windows())
+  )
 
   relative_linky_path <- path(base_dir, "relative_link_to_sub_dir")
   expect_no_error(check_path_is_directory(relative_linky_path))


### PR DESCRIPTION
Fixes #2069 

@gaborcsardi I tagged you for fs experise. Am I failing to take advantage of anything in fs? Does fs have the equivalent of what `readlink` is doing? Does fs need a function worthy of the name `link_target()`? Hmm, I guess that's just what `path_real()` is?

This guards specifically against a (somewhat peculiar?) situation on macOS.

First, I have this in `.Renviron` to get nicer looking temp file paths. I think this is pretty common among R users or R power users:

```
TMPDIR=/tmp
```

`/tmp` is actually a symlink on macOS, but it's a *relative* symlink:

```
~/rrr/usethis % ls -l /tmp
lrwxr-xr-x@ 1 root  wheel  11 May  3 22:39 /tmp -> private/tmp
```

So it has to be interpreted relative to this directory it lives in, namely `/`.

If you use `readlink` instead, you get the full resolution:

```
~/rrr/usethis % readlink -f /tmp
/private/tmp
```

I suppose I have always assumed `fs::link_path()` was returning output akin to `readlink`, whereas it's actually doing something more like `ls -l`. I guess I have not been punished for this because relative symlinks are rare?

In any case, I think this is a correct and minimal fix to make `check_path_is_directory()` more robust. My tendency towards minimalism comes from previous painful experience proving that all path manipulation in usethis is more tricky than it seems, mostly thanks to Windows (UNC paths vs drive paths, etc.).