### PR TITLE
Introduce mockable `testthat_version()`

### DIFF
--- a/R/test.R
+++ b/R/test.R
@@ -28,13 +28,7 @@ use_testthat <- function(edition = NULL, parallel = FALSE) {
 }
 
 use_testthat_impl <- function(edition = NULL, parallel = FALSE) {
-  check_installed("testthat")
-  if (utils::packageVersion("testthat") < "2.1.0") {
-    ui_abort(
-      "
-      {.pkg testthat} 2.1.0 or greater needed. Please install before re-trying"
-    )
-  }
+  check_installed("testthat", version = "2.1.0")
 
   if (is_package()) {
     edition <- check_edition(edition)
@@ -70,7 +64,7 @@ use_testthat_impl <- function(edition = NULL, parallel = FALSE) {
 }
 
 check_edition <- function(edition = NULL) {
-  version <- utils::packageVersion("testthat")[[1, c(1, 2)]]
+  version <- testthat_version()[[1, c(1, 2)]]
   if (version[[2]] == "99") {
     version <- version[[1]] + 1L
   } else {
@@ -84,7 +78,7 @@ check_edition <- function(edition = NULL) {
       ui_abort("{.arg edition} must be a single number.")
     }
     if (edition > version) {
-      vers <- utils::packageVersion("testthat")
+      vers <- testthat_version()
       ui_abort(
         "
         {.var edition} ({edition}) not available in installed verion of
@@ -95,6 +89,9 @@ check_edition <- function(edition = NULL) {
   }
 }
 
+testthat_version <- function() {
+  utils::packageVersion("testthat")
+}
 
 uses_testthat <- function() {
   paths <- proj_path(c(path("inst", "tests"), path("tests", "testthat")))

--- a/R/test.R
+++ b/R/test.R
@@ -89,6 +89,7 @@ check_edition <- function(edition = NULL) {
   }
 }
 
+# wrapping so we can mock this in tests
 testthat_version <- function() {
   utils::packageVersion("testthat")
 }

--- a/tests/testthat/_snaps/test.md
+++ b/tests/testthat/_snaps/test.md
@@ -4,7 +4,7 @@
       check_edition(20)
     Condition
       Error in `check_edition()`:
-      x `edition` (20) not available in installed verion of testthat (3.2.3).
+      x `edition` (20) not available in installed verion of testthat (3.2.0).
 
 ---
 

--- a/tests/testthat/test-test.R
+++ b/tests/testthat/test-test.R
@@ -1,11 +1,8 @@
 test_that("check_edition() validates inputs", {
+  local_mocked_bindings(testthat_version = function() numeric_version("3.2.0"))
+
   expect_snapshot(check_edition(20), error = TRUE)
   expect_snapshot(check_edition("x"), error = TRUE)
   expect_equal(check_edition(1.5), 1)
-
-  if (packageVersion("testthat") >= "2.99") {
-    expect_equal(check_edition(), 3)
-  } else {
-    expect_equal(check_edition(), 2)
-  }
+  expect_equal(check_edition(), 3)
 })


### PR DESCRIPTION
So the tests don't fail if you happen to be working on the development version of testthat.