### PR TITLE
Adjust timinig of `#open-source-comms`

### DIFF
--- a/R/release.R
+++ b/R/release.R
@@ -81,7 +81,7 @@ release_checklist <- function(version, on_cran, target_repo = NULL) {
   milestone_num <- gh_milestone_number(target_repo, version)
 
   c(
-    if (!on_cran)
+    if (!on_cran) {
       c(
         "First release:",
         "",
@@ -100,7 +100,8 @@ release_checklist <- function(version, on_cran, target_repo = NULL) {
         ),
         todo("Review <https://github.com/DavisVaughan/extrachecks>"),
         ""
-      ),
+      )
+    },
     "Prepare for release:",
     "",
     todo("`git pull`"),
@@ -129,10 +130,6 @@ release_checklist <- function(version, on_cran, target_repo = NULL) {
     todo("Update `cran-comments.md`", on_cran),
     todo("`git push`"),
     todo("Draft blog post", type != "patch"),
-    todo(
-      "Slack link to draft blog in #open-source-comms",
-      type != "patch" && is_posit_pkg
-    ),
     release_extra_bullets(),
     "",
     "Submit to CRAN:",
@@ -149,7 +146,11 @@ release_checklist <- function(version, on_cran, target_repo = NULL) {
     todo("`usethis::use_github_release()`"),
     todo("`usethis::use_dev_version(push = TRUE)`"),
     todo("`usethis::use_news_md()`", !has_news),
-    todo("Share on social media", type != "patch")
+    todo("Share on social media", type != "patch"),
+    todo(
+      "Slack link to blog post, bluesky, and linkedin in #open-source-comms",
+      type != "patch" && is_posit_pkg
+    )
   )
 }
 

--- a/tests/testthat/_snaps/release.md
+++ b/tests/testthat/_snaps/release.md
@@ -146,7 +146,6 @@
       * [ ] Update `cran-comments.md`
       * [ ] `git push`
       * [ ] Draft blog post
-      * [ ] Slack link to draft blog in #open-source-comms
       
       Submit to CRAN:
       
@@ -163,6 +162,7 @@
       * [ ] `usethis::use_dev_version(push = TRUE)`
       * [ ] `usethis::use_news_md()`
       * [ ] Share on social media
+      * [ ] Slack link to blog post, bluesky, and linkedin in #open-source-comms
 
 # no revdep release bullets when there are no revdeps
 


### PR DESCRIPTION
Established practice is to drop a link in the channel after you have posted to social media. This update just reflects what everyone is already doing.