### PR TITLE
Drop revdep check from patch release

### DIFF
--- a/R/release.R
+++ b/R/release.R
@@ -124,7 +124,7 @@ release_checklist <- function(version, on_cran, target_repo = NULL) {
     todo("`devtools::build_readme()`", has_readme),
     todo("`devtools::check(remote = TRUE, manual = TRUE)`"),
     todo("`devtools::check_win_devel()`"),
-    release_revdepcheck(on_cran, is_posit_pkg),
+    if (type != "patch") release_revdepcheck(on_cran, is_posit_pkg),
     todo("Update `cran-comments.md`", on_cran),
     todo("`git push`"),
     todo("Draft blog post", type != "patch"),

--- a/tests/testthat/_snaps/release.md
+++ b/tests/testthat/_snaps/release.md
@@ -55,7 +55,6 @@
       * [ ] `urlchecker::url_check()`
       * [ ] `devtools::check(remote = TRUE, manual = TRUE)`
       * [ ] `devtools::check_win_devel()`
-      * [ ] `revdepcheck::revdep_check(num_workers = 4)`
       * [ ] Update `cran-comments.md`
       * [ ] `git push`
       


### PR DESCRIPTION
IMO if you're worried you need to run revdeps it's not a patch release, and the CRAN checks are now automated enough it's not a big deal if we miss something.