### PR TITLE
Escape curly braces in `pr_title`

### DIFF
--- a/R/pr.R
+++ b/R/pr.R
@@ -988,14 +988,15 @@ choose_pr <- function(tr = NULL, pr_dat = NULL) {
     function(pr_number, pr_html_url, pr_user, pr_state, pr_title) {
       href_number <- ui_pre_glue("{.href [PR #<<pr_number>>](<<pr_html_url>>)}")
       at_user <- glue("@{pr_user}")
+      pr_title_escaped <- ui_escape_glue(pr_title)
       if (some_closed) {
         template <- ui_pre_glue(
-          "<<href_number>> ({.field <<at_user>>}, {pr_state}): {.val <<ui_escape_glue(pr_title)>>}"
+          "<<href_number>> ({.field <<at_user>>}, {pr_state}): {.val <<pr_title_escaped>>}"
         )
         cli::format_inline(template)
       } else {
         template <- ui_pre_glue(
-          "<<href_number>> ({.field <<at_user>>}): {.val <<ui_escape_glue(pr_title)>>}"
+          "<<href_number>> ({.field <<at_user>>}): {.val <<pr_title_escaped>>}"
         )
         cli::format_inline(template)
       }

--- a/R/pr.R
+++ b/R/pr.R
@@ -322,7 +322,7 @@ pr_fetch <- function(number = NULL, target = c("source", "primary")) {
   pr_user <- glue("@{pr$pr_user}")
   ui_bullets(c(
     "v" = "Checking out PR {.href [{pr$pr_string}]({pr$pr_html_url})} ({.field {pr_user}}):
-           {.val {pr$pr_title}}."
+           {.val {ui_escape_glue(pr$pr_title)}}."
   ))
 
   if (pr$pr_from_fork && isFALSE(pr$maintainer_can_modify)) {
@@ -944,7 +944,7 @@ choose_branch <- function(exclude = character()) {
         )
         at_user <- glue("@{pr_user}")
         template <- ui_pre_glue(
-          "{pretty_name} {cli::symbol$arrow_right} <<href_number>> ({.field <<at_user>>}): {.val <<pr_title>>}"
+          "{pretty_name} {cli::symbol$arrow_right} <<href_number>> ({.field <<at_user>>}): {.val <<ui_escape_glue(pr_title)>>}"
         )
         cli::format_inline(template)
       }
@@ -990,12 +990,12 @@ choose_pr <- function(tr = NULL, pr_dat = NULL) {
       at_user <- glue("@{pr_user}")
       if (some_closed) {
         template <- ui_pre_glue(
-          "<<href_number>> ({.field <<at_user>>}, {pr_state}): {.val <<pr_title>>}"
+          "<<href_number>> ({.field <<at_user>>}, {pr_state}): {.val <<ui_escape_glue(pr_title)>>}"
         )
         cli::format_inline(template)
       } else {
         template <- ui_pre_glue(
-          "<<href_number>> ({.field <<at_user>>}): {.val <<pr_title>>}"
+          "<<href_number>> ({.field <<at_user>>}): {.val <<ui_escape_glue(pr_title)>>}"
         )
         cli::format_inline(template)
       }

--- a/R/utils-ui.R
+++ b/R/utils-ui.R
@@ -162,6 +162,11 @@ ui_pre_glue <- function(..., .envir = parent.frame()) {
   glue(..., .open = "<<", .close = ">>", .envir = .envir)
 }
 
+ui_escape_glue <- function(x) {
+  gsub("([{}])", "\\1\\1", x)
+}
+
+
 bulletize <- function(x, bullet = "*", n_show = 5, n_fudge = 2) {
   n <- length(x)
   n_show_actual <- compute_n_show(n, n_show, n_fudge)


### PR DESCRIPTION
Added a simple helper to escape curly braces for glue (`ui_escape_glue()` in `utils-ui.R`), then applied it in the relevant `pr_*()` functions. I used Positron Assistant (with Claude) and Google Gemini (using my personal setup) on this to test Positron Assistant, then revised their fixes significantly.

@jennybc Should I add a test for this in `manual-pr-functions.R`? Or I could automate this stuff with mocked github API calls if you want to go that far.

Fixes #2107