### PR TITLE
Add a {test} for `ui_escape_glue()` helper

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # usethis (development version)
 
+* `pr_resume()` (without a specific `branch`) and `pr_fetch()` (without a specific `number`) no longer error when a branch name contains curly braces (#2107, @jonthegeek).
+
 # usethis 3.2.1
 
 * `create_quarto_project()` exits early if the Quarto CLI does not appear to be

--- a/R/pr.R
+++ b/R/pr.R
@@ -322,7 +322,7 @@ pr_fetch <- function(number = NULL, target = c("source", "primary")) {
   pr_user <- glue("@{pr$pr_user}")
   ui_bullets(c(
     "v" = "Checking out PR {.href [{pr$pr_string}]({pr$pr_html_url})} ({.field {pr_user}}):
-           {.val {ui_escape_glue(pr$pr_title)}}."
+           {.val {pr$pr_title}}."
   ))
 
   if (pr$pr_from_fork && isFALSE(pr$maintainer_can_modify)) {

--- a/R/pr.R
+++ b/R/pr.R
@@ -988,14 +988,15 @@ choose_pr <- function(tr = NULL, pr_dat = NULL) {
     function(pr_number, pr_html_url, pr_user, pr_state, pr_title) {
       href_number <- ui_pre_glue("{.href [PR #<<pr_number>>](<<pr_html_url>>)}")
       at_user <- glue("@{pr_user}")
+      pr_title_escaped <- ui_escape_glue(pr_title)
       if (some_closed) {
         template <- ui_pre_glue(
-          "<<href_number>> ({.field <<at_user>>}, {pr_state}): {.val <<ui_escape_glue(pr_title)>>}"
+          "<<href_number>> ({.field <<at_user>>}, {pr_state}): {.val <<pr_title_escaped>>}"
         )
         cli::format_inline(template)
       } else {
         template <- ui_pre_glue(
-          "<<href_number>> ({.field <<at_user>>}): {.val <<ui_escape_glue(pr_title)>>}"
+          "<<href_number>> ({.field <<at_user>>}): {.val <<pr_title_escaped>>}"
         )
         cli::format_inline(template)
       }

--- a/R/pr.R
+++ b/R/pr.R
@@ -322,7 +322,7 @@ pr_fetch <- function(number = NULL, target = c("source", "primary")) {
   pr_user <- glue("@{pr$pr_user}")
   ui_bullets(c(
     "v" = "Checking out PR {.href [{pr$pr_string}]({pr$pr_html_url})} ({.field {pr_user}}):
-           {.val {pr$pr_title}}."
+           {.val {ui_escape_glue(pr$pr_title)}}."
   ))
 
   if (pr$pr_from_fork && isFALSE(pr$maintainer_can_modify)) {
@@ -944,7 +944,7 @@ choose_branch <- function(exclude = character()) {
         )
         at_user <- glue("@{pr_user}")
         template <- ui_pre_glue(
-          "{pretty_name} {cli::symbol$arrow_right} <<href_number>> ({.field <<at_user>>}): {.val <<pr_title>>}"
+          "{pretty_name} {cli::symbol$arrow_right} <<href_number>> ({.field <<at_user>>}): {.val <<ui_escape_glue(pr_title)>>}"
         )
         cli::format_inline(template)
       }
@@ -990,12 +990,12 @@ choose_pr <- function(tr = NULL, pr_dat = NULL) {
       at_user <- glue("@{pr_user}")
       if (some_closed) {
         template <- ui_pre_glue(
-          "<<href_number>> ({.field <<at_user>>}, {pr_state}): {.val <<pr_title>>}"
+          "<<href_number>> ({.field <<at_user>>}, {pr_state}): {.val <<ui_escape_glue(pr_title)>>}"
         )
         cli::format_inline(template)
       } else {
         template <- ui_pre_glue(
-          "<<href_number>> ({.field <<at_user>>}): {.val <<pr_title>>}"
+          "<<href_number>> ({.field <<at_user>>}): {.val <<ui_escape_glue(pr_title)>>}"
         )
         cli::format_inline(template)
       }

--- a/R/utils-ui.R
+++ b/R/utils-ui.R
@@ -162,6 +162,11 @@ ui_pre_glue <- function(..., .envir = parent.frame()) {
   glue(..., .open = "<<", .close = ">>", .envir = .envir)
 }
 
+ui_escape_glue <- function(x) {
+  gsub("([{}])", "\\1\\1", x)
+}
+
+
 bulletize <- function(x, bullet = "*", n_show = 5, n_fudge = 2) {
   n <- length(x)
   n_show_actual <- compute_n_show(n, n_show, n_fudge)

--- a/tests/testthat/test-utils-ui.R
+++ b/tests/testthat/test-utils-ui.R
@@ -267,3 +267,17 @@ cli::test_that_cli(
   },
   configs = c("plain", "fancy")
 )
+
+test_that("ui_escape_glue() doubles curly braces", {
+  expect_equal(ui_escape_glue("no braces"), "no braces")
+  expect_equal(ui_escape_glue("one { brace"), "one {{ brace")
+  expect_equal(ui_escape_glue("one } brace"), "one }} brace")
+  expect_equal(
+    ui_escape_glue("A {brace_set} in text"),
+    "A {{brace_set}} in text"
+  )
+  expect_equal(
+    ui_escape_glue("{multiple} {brace} {sets}"),
+    "{{multiple}} {{brace}} {{sets}}"
+  )
+})


### PR DESCRIPTION
This was meant to be a PR into #2169, but I forgot to set that when I created this PR, so I'm closing that and moving here.

Added a simple helper to escape curly braces for glue (`ui_escape_glue()` in `utils-ui.R`), then applied it in the relevant `pr_*()` functions. I used Positron Assistant (with Claude) and Google Gemini (using my personal setup) on this to test Positron Assistant, then revised their fixes significantly. 

`pr_pause()` then `pr_resume()` shows the title of this PR properly, as does `pr_fetch()` (with no number). `pr_fetch(2171)` also shows this title properly.

Fixes #2107.