### PR TITLE
Allow `use_github_file()` to work with non-text files

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,6 +34,7 @@ Imports:
     glue (>= 1.3.0),
     jsonlite,
     lifecycle (>= 1.0.0),
+    mime,
     purrr,
     rappdirs,
     rlang (>= 1.1.0),

--- a/R/release.R
+++ b/R/release.R
@@ -393,14 +393,15 @@ get_release_news <- function(
     news <- if (file_exists(news_path)) read_utf8(news_path) else NULL
   } else {
     news <- tryCatch(
-      read_github_file(
+      get_github_file(
         tr$repo_spec,
         path = "NEWS.md",
         ref = SHA,
         host = tr$api_url
       ),
       github_error = NULL
-    )
+    ) |>
+      read_utf8()
   }
 
   if (is.null(news)) {

--- a/R/use_github_file.R
+++ b/R/use_github_file.R
@@ -22,6 +22,8 @@
 #' @param ref The name of a branch, tag, or commit. By default, the file at
 #'   `path` will be copied from its current state in the repo's default branch.
 #'   This is extracted from `repo_spec` when user provides a URL.
+#' @param open Open the newly created file for editing, if it is a text file? Happens in RStudio, if
+#'   applicable, or via [utils::file.edit()] otherwise. Binary files will not be opened.
 #' @inheritParams use_template
 #' @inheritParams use_github
 #' @inheritParams write_over

--- a/R/use_standalone.R
+++ b/R/use_standalone.R
@@ -73,7 +73,13 @@ use_standalone <- function(repo_spec, file = NULL, ref = NULL, host = NULL) {
   src_path <- path("R", file)
   dest_path <- path("R", as_standalone_dest_file(file))
 
-  lines <- read_github_file(repo_spec, path = src_path, ref = ref, host = host)
+  lines <- get_github_file(
+    repo_spec,
+    path = src_path,
+    ref = ref,
+    host = host
+  ) |>
+    read_utf8()
   lines <- c(standalone_header(repo_spec, src_path, ref, host), lines)
   write_over(proj_path(dest_path), lines, overwrite = TRUE)
 

--- a/man/use_github_file.Rd
+++ b/man/use_github_file.Rd
@@ -40,8 +40,8 @@ This is extracted from \code{repo_spec} when user provides a URL.}
 
 \item{ignore}{Should the newly created file be added to \code{.Rbuildignore}?}
 
-\item{open}{Open the newly created file for editing? Happens in RStudio, if
-applicable, or via \code{\link[utils:file.edit]{utils::file.edit()}} otherwise.}
+\item{open}{Open the newly created file for editing, if it is a text file? Happens in RStudio, if
+applicable, or via \code{\link[utils:file.edit]{utils::file.edit()}} otherwise. Binary files will not be opened.}
 
 \item{overwrite}{Force overwrite of existing file?}
 

--- a/tests/testthat/test-use_github_file.R
+++ b/tests/testthat/test-use_github_file.R
@@ -59,3 +59,13 @@ test_that("parse_file_url() errors when it should", {
     "https://gitlab.com/OWNER/REPO/path/to/file"
   ))
 })
+
+test_that("use_github_file works with non-text files", {
+  create_local_project()
+  use_github_file(
+    "https://github.com/r-lib/usethis/blob/main/man/figures/logo.png",
+    save_as = "logo.png"
+  )
+
+  expect_proj_file("logo.png")
+})


### PR DESCRIPTION
Since text files are read with `read_utf8()` and written to the final destination with `write_over()`, I changed `read_github_file()` to `get_github_file()` and instead of returning the text lines, it returns a path to a temp file, which requires using `read_utf8()` in places it was used before.

Fixes #1782.