### PR TITLE
`use_rcpp_armadillo()` - Remove unneeded CXX_STD in Makevars (#1889)

### DIFF
--- a/R/rcpp.R
+++ b/R/rcpp.R
@@ -32,7 +32,6 @@ use_rcpp_armadillo <- function(name = NULL) {
   use_dependency("RcppArmadillo", "LinkingTo")
 
   makevars_settings <- list(
-    "CXX_STD" = "CXX11",
     "PKG_CXXFLAGS" = "$(SHLIB_OPENMP_CXXFLAGS)",
     "PKG_LIBS" = "$(SHLIB_OPENMP_CXXFLAGS) $(LAPACK_LIBS) $(BLAS_LIBS) $(FLIBS)"
   )


### PR DESCRIPTION
Default CXX_STD should now be `CXX17` for R 4.3 and above and `CXX11` for R 4 so should not be necessary to specify a value any more. 

This brings things inline with RcppArmadillo's own suggested `Makevars`, https://github.com/RcppCore/RcppArmadillo/blob/master/inst/skeleton/Makevars

Fix #1889 