### PR TITLE
feat: remind on codecov config on default-branch renaming

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,9 @@
 
 * `pr_resume()` (without a specific `branch`) and `pr_fetch()` (without a specific `number`) no longer error when a branch name contains curly braces (#2107, @jonthegeek).
 
+* `git_default_branch_rename()`, if appropriate, offers a reminder to update 
+  codecov configuration (#2078, @ijlyttle).
+
 # usethis 3.2.1
 
 * `create_quarto_project()` exits early if the Quarto CLI does not appear to be

--- a/R/git-default-branch.R
+++ b/R/git-default-branch.R
@@ -565,6 +565,7 @@ report_fishy_files <- function(old_name = "master", new_name = "main") {
   try(fishy_github_actions(new_name = new_name), silent = TRUE)
   try(fishy_badges(old_name = old_name), silent = TRUE)
   try(fishy_bookdown_config(old_name = old_name), silent = TRUE)
+  try(fishy_codecov_config(new_name = new_name), silent = TRUE)
 }
 
 # good test cases: downlit, purrr, pkgbuild, zealot, glue, bench,
@@ -670,6 +671,26 @@ fishy_bookdown_config <- function(old_name = "master") {
            {.val {old_name}}.",
     "_" = "Check and correct, if needed, in this file:
            {.path {pth(bookdown_config)}}"
+  ))
+
+  invisible(path)
+}
+
+fishy_codecov_config <- function(new_name = "main") {
+
+  path <- proj_path("codecov.yml")
+
+  if (!file_exists(path)) {
+    return(invisible(character()))
+  }
+
+  repo_spec <- target_repo_spec()
+  url <- glue("https://app.codecov.io/gh/{repo_spec}")
+
+  ui_bullets(c(
+    "-" = "Check and correct, if needed, your
+           {.href [codecov configuration]({url})}
+           to refer to the new default branch {.val {new_name}}."
   ))
 
   invisible(path)

--- a/tests/testthat/test-git-default-branch.R
+++ b/tests/testthat/test-git-default-branch.R
@@ -115,6 +115,10 @@ test_that("git_default_branch_rename() surfaces files that smell fishy", {
     file = path("whatever", "foo", "_bookdown.yaml")
   )
 
+  # The code to remind about updating codecov configuration,
+  # `fishy_codecov_config()`, is not tested because it depends
+  # on the location of a GitHub remote, which does not exist in this test.
+
   withr::local_options(usethis.quiet = FALSE)
   expect_snapshot(
     git_default_branch_rename()


### PR DESCRIPTION
Fixes #2078

Left a note, rather than a test, as the fixture does not set a GitHub remote.