### PR TITLE
`use_standalone()` beyond packages

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # usethis (development version)
 
+* `use_standalone()` now again works outside packages (#2087).
+
 * `pr_resume()` (without a specific `branch`) and `pr_fetch()` (without a specific `number`) no longer error when a branch name contains curly braces (#2107, @jonthegeek).
 
 # usethis 3.2.1

--- a/R/use_standalone.R
+++ b/R/use_standalone.R
@@ -79,6 +79,15 @@ use_standalone <- function(repo_spec, file = NULL, ref = NULL, host = NULL) {
 
   dependencies <- standalone_dependencies(lines, path)
 
+  if (!is_package()) {
+    imports <- dependencies$imports
+    n <- cli::qty(length(imports$pkg))
+    ui_bullets(c(
+      "!" = "You'll need the following {n} package{?s}: {.pkg {imports$pkg}}."
+    ))
+    return(invisible())
+  }
+
   for (dependency in dependencies$deps) {
     use_standalone(repo_spec, dependency, ref = ref, host = host)
   }

--- a/tests/testthat/_snaps/use_standalone.md
+++ b/tests/testthat/_snaps/use_standalone.md
@@ -64,6 +64,14 @@
       [4] "# ----------------------------------------------------------------------"                                            
       [5] "#"                                                                                                                   
 
+# from a non-package project throws an informative message
+
+    Code
+      use_standalone("r-lib/rlang", "types-check", ref = "73182fe94")
+    Message
+      v Writing 'R/import-standalone-types-check.R'.
+      ! You'll need the following package: rlang.
+
 # can offer choices
 
     Code

--- a/tests/testthat/test-use_standalone.R
+++ b/tests/testthat/test-use_standalone.R
@@ -54,6 +54,17 @@ test_that("can import standalone file with dependencies", {
   expect_match(imports, "rlang")
 })
 
+test_that("from a non-package project throws an informative message", {
+  skip_if_offline("github.com")
+  create_local_project()
+  withr::local_options(list(usethis.quiet = FALSE))
+
+  # NOTE: Check ref after r-lib/rlang@standalone-dep has been merged
+  expect_snapshot(
+    use_standalone("r-lib/rlang", "types-check", ref = "73182fe94")
+  )
+})
+
 test_that("can use full github url", {
   skip_if_offline("github.com")
   create_local_package()


### PR DESCRIPTION
- Closes #2087

----

Thanks @jennybc for help in person during the tidy dev day 2025

Also, claude code helped with a few things:

- Fix pluralization error with `cli::qty()`
- See examples of messages in this repo
- Use `usethis.quiet = TRUE`
