### PR TITLE
Removes use_tidy_style() from upkeep

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # usethis (development version)
 
+* Removes deprecated `use_tidy_style()` from to-do's from upkeep (@edgararuiz)
+
 * `pr_resume()` (without a specific `branch`) and `pr_fetch()` (without a specific `number`) no longer error when a branch name contains curly braces (#2107, @jonthegeek).
 
 # usethis 3.2.1

--- a/R/upkeep.R
+++ b/R/upkeep.R
@@ -166,7 +166,6 @@ tidy_upkeep_checklist <- function(
       todo("`usethis::use_github_links()`"),
       todo("`usethis::use_pkgdown_github_pages()`"),
       todo("`usethis::use_tidy_github_labels()`"),
-      todo("`usethis::use_tidy_style()`"),
       todo("`urlchecker::url_check()`"),
       ""
     )

--- a/tests/testthat/_snaps/upkeep.md
+++ b/tests/testthat/_snaps/upkeep.md
@@ -14,7 +14,6 @@
       * [ ] `usethis::use_github_links()`
       * [ ] `usethis::use_pkgdown_github_pages()`
       * [ ] `usethis::use_tidy_github_labels()`
-      * [ ] `usethis::use_tidy_style()`
       * [ ] `urlchecker::url_check()`
       
       ### 2020


### PR DESCRIPTION
Removes `usethis::use_tidy_style()` from pre-history section of the to-do's upkeep function.

Running it today returns:

```
> usethis::use_tidy_style()
Warning message:
`use_tidy_style()` was deprecated in usethis 3.2.0.
ℹ Please use `use_air()` instead.
ℹ To continue using the styler package, call `styler::style_pkg()` or `styler::style_dir()` directly.
This warning is displayed once every 8 hours.
Call `lifecycle::last_lifecycle_warnings()` to see where this warning was generated. 
```

This change:

- Removes the line
- Updates the test snapshot
- Adds NEWS item
