### PR TITLE
Add a bullet for `rhub::rhub_check(platforms = 'rchk')` if a package has a `src/` directory

### DIFF
--- a/R/release.R
+++ b/R/release.R
@@ -76,6 +76,7 @@ release_checklist <- function(version, on_cran, target_repo = NULL) {
   has_pkgdown <- uses_pkgdown()
   has_lifecycle <- proj_desc()$has_dep("lifecycle")
   has_readme <- file_exists(proj_path("README.Rmd"))
+  has_c <- uses_c()
   has_github_links <- has_github_links(target_repo)
   is_posit_pkg <- is_posit_pkg()
   milestone_num <- gh_milestone_number(target_repo, version)
@@ -124,6 +125,7 @@ release_checklist <- function(version, on_cran, target_repo = NULL) {
     todo("`devtools::build_readme()`", has_readme),
     todo("`devtools::check(remote = TRUE, manual = TRUE)`"),
     todo("`devtools::check_win_devel()`"),
+    todo("`rhub::rhub_check(platforms = 'rchk')`", has_c),
     if (type != "patch") release_revdepcheck(on_cran, is_posit_pkg),
     todo("Update `cran-comments.md`", on_cran),
     todo("`git push`"),
@@ -162,6 +164,10 @@ gh_milestone_number <- function(target_repo, version, state = "open") {
   numbers <- map_int(milestones, "number")
 
   numbers[match(paste0("v", version), titles)]
+}
+
+uses_c <- function() {
+  dir_exists(proj_path("src"))
 }
 
 # Get revdeps for current package

--- a/tests/testthat/_snaps/release.md
+++ b/tests/testthat/_snaps/release.md
@@ -107,6 +107,42 @@
       * [ ] `usethis::use_news_md()`
       * [ ] Share on social media
 
+# construct correct rchk bullet
+
+    Code
+      writeLines(release_checklist("1.0.0", on_cran = TRUE))
+    Output
+      Prepare for release:
+      
+      * [ ] `git pull`
+      * [ ] Check [current CRAN check results](https://cran.rstudio.org/web/checks/check_results_{TESTPKG}.html)
+      * [ ] `usethis::use_news_md()`
+      * [ ] [Polish NEWS](https://style.tidyverse.org/news.html#news-release)
+      * [ ] `usethis::use_github_links()`
+      * [ ] `urlchecker::url_check()`
+      * [ ] `devtools::check(remote = TRUE, manual = TRUE)`
+      * [ ] `devtools::check_win_devel()`
+      * [ ] `rhub::rhub_check(platforms = 'rchk')`
+      * [ ] Update `cran-comments.md`
+      * [ ] `git push`
+      * [ ] Draft blog post
+      
+      Submit to CRAN:
+      
+      * [ ] `usethis::use_version('major')`
+      * [ ] `devtools::submit_cran()`
+      * [ ] Approve email
+      
+      Wait for CRAN...
+      
+      * [ ] Accepted :tada:
+      * [ ] Finish & publish blog post
+      * [ ] Add link to blog post in pkgdown news menu
+      * [ ] `usethis::use_github_release()`
+      * [ ] `usethis::use_dev_version(push = TRUE)`
+      * [ ] `usethis::use_news_md()`
+      * [ ] Share on social media
+
 # construct correct revdep bullet
 
     Code

--- a/tests/testthat/test-release.R
+++ b/tests/testthat/test-release.R
@@ -45,6 +45,19 @@ test_that("non-patch + lifecycle = advanced deprecation process", {
   expect_false(has_deprecation(release_checklist("1.1.1", on_cran = TRUE)))
 })
 
+test_that("construct correct rchk bullet", {
+  create_local_package()
+
+  local_mocked_bindings(
+    uses_c = function() TRUE
+  )
+
+  expect_snapshot(
+    writeLines(release_checklist("1.0.0", on_cran = TRUE)),
+    transform = scrub_testpkg
+  )
+})
+
 test_that("get extra news bullets if available", {
   env <- env(release_bullets = function() "Extra bullets")
   expect_equal(release_extra_bullets(env), "* [ ] Extra bullets")


### PR DESCRIPTION
I am having to do a patch vctrs release due to some missed rchk results
https://github.com/r-lib/vctrs/pull/2139

This feels avoidable, what if we add it to our release bullets if we see a `src/` directory in the package?