### PR TITLE
Fix malformed Markdown link in `CODE_OF_CONDUCT.md`

### DIFF
--- a/inst/templates/CODE_OF_CONDUCT.md
+++ b/inst/templates/CODE_OF_CONDUCT.md
@@ -118,7 +118,7 @@ version 2.1, available at
 <https://www.contributor-covenant.org/version/2/1/code_of_conduct.html>.
 
 Community Impact Guidelines were inspired by
-[Mozilla's code of conduct enforcement ladder][https://github.com/mozilla/inclusion].
+[Mozilla's code of conduct enforcement ladder](https://github.com/mozilla/inclusion).
 
 For answers to common questions about this code of conduct, see the FAQ at
 <https://www.contributor-covenant.org/faq>. Translations are available at <https://www.contributor-covenant.org/translations>.


### PR DESCRIPTION
Changing `[]` to `()`.