### PR TITLE
Adds `open` argument to C/C++ `use_*()` functions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,8 @@
 
 * `pr_resume()` (without a specific `branch`) and `pr_fetch()` (without a specific `number`) no longer error when a branch name contains curly braces (#2107, @jonthegeek).
 
+* Adds `open` argument to `use_c()`, `use_rcpp()`, `use_rcpp_armadillo()`, `use_rcpp_eingen()`, `use_makevars()` and `use_cpp11()` (#2207, @brunomartins-rdev).*
+
 # usethis 3.2.1
 
 * `create_quarto_project()` exits early if the Quarto CLI does not appear to be

--- a/R/cpp11.R
+++ b/R/cpp11.R
@@ -7,8 +7,10 @@
 #'   * Adds cpp11 to `DESCRIPTION`
 #'   * Creates `src/code.cpp`, an initial placeholder `.cpp` file
 #'
+#' @param open Whether to open the file for interactive editing.
+#'
 #' @export
-use_cpp11 <- function() {
+use_cpp11  <- function(open = rlang::is_interactive()) {
   check_is_package("use_cpp11()")
   check_installed("cpp11")
   check_uses_roxygen("use_cpp11()")
@@ -20,7 +22,7 @@ use_cpp11 <- function() {
   use_template(
     "code-cpp11.cpp",
     path("src", "code.cpp"),
-    open = is_interactive()
+    open = open
   )
 
   check_cpp_register_deps()

--- a/R/rcpp.R
+++ b/R/rcpp.R
@@ -8,7 +8,7 @@
 #'
 #' @inheritParams use_r
 #' @export
-use_rcpp <- function(name = NULL) {
+use_rcpp <- function(name = NULL, open = rlang::is_interactive()) {
   check_is_package("use_rcpp()")
   check_uses_roxygen("use_rcpp()")
 
@@ -19,15 +19,15 @@ use_rcpp <- function(name = NULL) {
   use_src()
   path <- path("src", compute_name(name, "cpp"))
   use_template("code.cpp", path)
-  edit_file(proj_path(path))
+  edit_file(proj_path(path), open = open)
 
   invisible()
 }
 
 #' @rdname use_rcpp
 #' @export
-use_rcpp_armadillo <- function(name = NULL) {
-  use_rcpp(name)
+use_rcpp_armadillo <- function(name = NULL, open = rlang::is_interactive()) {
+  use_rcpp(name, open = open)
 
   use_dependency("RcppArmadillo", "LinkingTo")
 
@@ -43,8 +43,8 @@ use_rcpp_armadillo <- function(name = NULL) {
 
 #' @rdname use_rcpp
 #' @export
-use_rcpp_eigen <- function(name = NULL) {
-  use_rcpp(name)
+use_rcpp_eigen <- function(name = NULL, open = rlang::is_interactive()) {
+  use_rcpp(name, open = open)
 
   use_dependency("RcppEigen", "LinkingTo")
 
@@ -55,7 +55,7 @@ use_rcpp_eigen <- function(name = NULL) {
 
 #' @rdname use_rcpp
 #' @export
-use_c <- function(name = NULL) {
+use_c <- function(name = NULL, open = rlang::is_interactive()) {
   check_is_package("use_c()")
   check_uses_roxygen("use_c()")
 
@@ -63,7 +63,7 @@ use_c <- function(name = NULL) {
 
   path <- path("src", compute_name(name, ext = "c"))
   use_template("code.c", path)
-  edit_file(proj_path(path))
+  edit_file(proj_path(path), open = open)
 
   invisible(TRUE)
 }
@@ -79,7 +79,7 @@ use_src <- function() {
   invisible()
 }
 
-use_makevars <- function(settings = NULL) {
+use_makevars <- function(settings = NULL, open = rlang::is_interactive()) {
   use_directory("src")
 
   settings_list <- settings %||% list()
@@ -107,7 +107,7 @@ use_makevars <- function(settings = NULL) {
       makevars_content,
       language = ""
     )
-    edit_file(makevars_path)
-    edit_file(makevars_win_path)
+    edit_file(makevars_path, open = open)
+    edit_file(makevars_win_path, open = open)
   }
 }

--- a/man/use_cpp11.Rd
+++ b/man/use_cpp11.Rd
@@ -4,7 +4,10 @@
 \alias{use_cpp11}
 \title{Use C++ via the cpp11 package}
 \usage{
-use_cpp11()
+use_cpp11(open = rlang::is_interactive())
+}
+\arguments{
+\item{open}{Whether to open the file for interactive editing.}
 }
 \description{
 Adds infrastructure needed to use the \href{https://cpp11.r-lib.org}{cpp11}

--- a/man/use_rcpp.Rd
+++ b/man/use_rcpp.Rd
@@ -7,17 +7,19 @@
 \alias{use_c}
 \title{Use C, C++, RcppArmadillo, or RcppEigen}
 \usage{
-use_rcpp(name = NULL)
+use_rcpp(name = NULL, open = rlang::is_interactive())
 
-use_rcpp_armadillo(name = NULL)
+use_rcpp_armadillo(name = NULL, open = rlang::is_interactive())
 
-use_rcpp_eigen(name = NULL)
+use_rcpp_eigen(name = NULL, open = rlang::is_interactive())
 
-use_c(name = NULL)
+use_c(name = NULL, open = rlang::is_interactive())
 }
 \arguments{
 \item{name}{Either a string giving a file name (without directory) or
 \code{NULL} to take the name from the currently open file in RStudio.}
+
+\item{open}{Whether to open the file for interactive editing.}
 }
 \description{
 Adds infrastructure commonly needed when using compiled code:


### PR DESCRIPTION
* Adds `open` argument to `use_c()`, `use_rcpp()`, `use_rcpp_armadillo()`, `use_rcpp_eingen()`, `use_makevars()` and `use_cpp11()` (#2207, @brunomartins-rdev).