### PR TITLE
More options for uncommitted changes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,7 +5,7 @@
 * `pr_pull()`, `pr_push()` and friends now give more informative errors if usethis can't retrieve details about a remote (#1929, #2229).
 
 * `use_readme_qmd()` creates a starter `README.qmd` with Quarto-flavored YAML frontmatter, analogous to `use_readme_rmd()` (#1671). Thanks @VisruthSK for getting the ball rolling.
-* Functions that check for uncommitted changes (like `pr_init()`) now offer a menu with four options: stash changes (and re-apply after), abort, retry, or proceed anyway. Previously, the only options were to proceed or abort (#1300).
+* Functions that check for uncommitted changes (like `pr_init()`) now offer a menu with four options: stash changes (and re-apply after), cancel, retry, or proceed anyway. Previously, the only options were to proceed or cancel (#1300).
 
 * `use_pipe()` is now deprecated (@math-mcshane, #2124).
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,7 @@
 * `pr_pull()`, `pr_push()` and friends now give more informative errors if usethis can't retrieve details about a remote (#1929, #2229).
 
 * `use_readme_qmd()` creates a starter `README.qmd` with Quarto-flavored YAML frontmatter, analogous to `use_readme_rmd()` (#1671). Thanks @VisruthSK for getting the ball rolling.
+* Functions that check for uncommitted changes (like `pr_init()`) now offer a menu with four options: stash changes (and re-apply after), abort, retry, or proceed anyway. Previously, the only options were to proceed or abort (#1300).
 
 * `use_pipe()` is now deprecated (@math-mcshane, #2124).
 

--- a/R/utils-git.R
+++ b/R/utils-git.R
@@ -211,7 +211,6 @@ challenge_uncommitted_changes <- function(untracked = FALSE, msg = NULL) {
       )
     }
 
-    cli::cli_div(theme = usethis_theme())
     cli::cli_inform(c("!" = msg))
     choice <- utils::menu(
       title = "What do you want to do?",

--- a/R/utils-git.R
+++ b/R/utils-git.R
@@ -216,7 +216,7 @@ challenge_uncommitted_changes <- function(untracked = FALSE, msg = NULL) {
     choice <- utils::menu(
       title = "What do you want to do?",
       choices = c(
-        "Abort",
+        "Cancel",
         "Try again",
         "Stash changes, re-try, then pop",
         "Proceed anyway"
@@ -224,7 +224,7 @@ challenge_uncommitted_changes <- function(untracked = FALSE, msg = NULL) {
     )
 
     if (choice == 0 || choice == 1) {
-      ui_abort("Uncommitted changes. Aborting.")
+      ui_abort("Cancelling.")
     } else if (choice == 2) {
       # Loop will re-check git_uncommitted()
     } else if (choice == 3) {

--- a/R/utils-git.R
+++ b/R/utils-git.R
@@ -199,7 +199,7 @@ challenge_uncommitted_changes <- function(untracked = FALSE, msg = NULL) {
 
   default_msg <- "
     There are uncommitted changes, which may cause problems or be lost when \\
-    we push, pull, switch, or compare branches"
+    we push, pull, switch, or compare branches."
   msg <- glue(msg %||% default_msg)
 
   while (git_uncommitted(untracked = untracked)) {

--- a/R/utils-git.R
+++ b/R/utils-git.R
@@ -216,25 +216,24 @@ challenge_uncommitted_changes <- function(untracked = FALSE, msg = NULL) {
     choice <- utils::menu(
       title = "What do you want to do?",
       choices = c(
-        "Stash changes and re-apply after",
         "Abort",
-        "Retry (after doing something with git)",
+        "Try again",
+        "Stash changes, re-try, then pop",
         "Proceed anyway"
       )
     )
 
-    if (choice == 1) {
+    if (choice == 0 || choice == 1) {
+      ui_abort("Uncommitted changes. Aborting.")
+    } else if (choice == 2) {
+      # Loop will re-check git_uncommitted()
+    } else if (choice == 3) {
       gert::git_stash_save(include_untracked = untracked, repo = git_repo())
       ui_bullets(c("v" = "Changes stashed."))
       withr::defer(git_stash_pop(), envir = parent.frame())
       return(invisible())
-    } else if (choice == 3) {
-      # Loop will re-check git_uncommitted()
     } else if (choice == 4) {
       return(invisible())
-    } else {
-      # choice == 2 or 0 (user cancelled)
-      ui_abort("Uncommitted changes. Aborting.")
     }
   }
 }

--- a/R/utils-git.R
+++ b/R/utils-git.R
@@ -201,18 +201,57 @@ challenge_uncommitted_changes <- function(untracked = FALSE, msg = NULL) {
     There are uncommitted changes, which may cause problems or be lost when \\
     we push, pull, switch, or compare branches"
   msg <- glue(msg %||% default_msg)
-  if (git_uncommitted(untracked = untracked)) {
-    if (
-      ui_yep(c(
-        "!" = msg,
-        " " = "Do you want to proceed anyway?"
-      ))
-    ) {
+
+  while (git_uncommitted(untracked = untracked)) {
+    if (!is_interactive()) {
+      ui_abort(
+        "
+        There are uncommitted changes.
+        Please commit or stash before continuing."
+      )
+    }
+
+    cli::cli_div(theme = usethis_theme())
+    cli::cli_inform(c("!" = msg))
+    choice <- utils::menu(
+      title = "What do you want to do?",
+      choices = c(
+        "Stash changes and re-apply after",
+        "Abort",
+        "Retry (after doing something with git)",
+        "Proceed anyway"
+      )
+    )
+
+    if (choice == 1) {
+      gert::git_stash_save(include_untracked = untracked, repo = git_repo())
+      ui_bullets(c("v" = "Changes stashed."))
+      withr::defer(git_stash_pop(), envir = parent.frame())
+      return(invisible())
+    } else if (choice == 3) {
+      # Loop will re-check git_uncommitted()
+    } else if (choice == 4) {
       return(invisible())
     } else {
-      ui_abort("Uncommitted changes. Please commit before continuing.")
+      # choice == 2 or 0 (user cancelled)
+      ui_abort("Uncommitted changes. Aborting.")
     }
   }
+}
+
+git_stash_pop <- function() {
+  tryCatch(
+    {
+      gert::git_stash_pop(repo = git_repo())
+      ui_bullets(c("v" = "Stashed changes re-applied."))
+    },
+    error = function(e) {
+      ui_bullets(c(
+        "!" = "Could not re-apply stashed changes automatically.",
+        "i" = "Use {.run gert::git_stash_pop()} to manually re-apply."
+      ))
+    }
+  )
 }
 
 git_conflict_report <- function() {

--- a/R/utils-git.R
+++ b/R/utils-git.R
@@ -188,7 +188,11 @@ git_uncommitted <- function(untracked = FALSE) {
   nrow(git_status(untracked)) > 0
 }
 
-challenge_uncommitted_changes <- function(untracked = FALSE, msg = NULL) {
+challenge_uncommitted_changes <- function(
+  untracked = FALSE,
+  msg = NULL,
+  error_call = caller_env()
+) {
   if (!uses_git()) {
     return(invisible())
   }
@@ -207,7 +211,8 @@ challenge_uncommitted_changes <- function(untracked = FALSE, msg = NULL) {
       ui_abort(
         "
         There are uncommitted changes.
-        Please commit or stash before continuing."
+        Please commit or stash before continuing.",
+        call = error_call
       )
     }
 
@@ -223,7 +228,7 @@ challenge_uncommitted_changes <- function(untracked = FALSE, msg = NULL) {
     )
 
     if (choice == 0 || choice == 1) {
-      ui_abort("Cancelling.")
+      ui_abort("Cancelling.", call = error_call)
     } else if (choice == 2) {
       # Loop will re-check git_uncommitted()
     } else if (choice == 3) {


### PR DESCRIPTION
Fixes #1300

Currently 100% vibe coded. It seems straightforward enough, but I'm suspicious of the use of `on.exit()` here (although it is a pragmatic way to avoid bigger API changes).