### PR TITLE
Encourage helpers, discourage code outside test blocks

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -36,14 +36,15 @@ air format .
 * Always run `air format .` after generating code
 * Use the base pipe operator (`|>`) not the magrittr pipe (`%>%`)
 * Don't use `_$x` or `_$[["x"]]` since this package must work on R 4.1.
-* Use `\() ...` for single-line anonymous functions. For all other cases, use `function() {...}` 
+* Use `\() ...` for single-line anonymous functions. For all other cases, use `function() {...}`
 
 ### Testing
 
-- Tests for `R/{name}.R` go in `tests/testthat/test-{name}.R`. 
+- Tests for `R/{name}.R` go in `tests/testthat/test-{name}.R`.
 - All new code should have an accompanying test.
 - If there are existing tests, place new tests next to similar existing tests.
 - Strive to keep your tests minimal with few comments.
+- Never put code in a `test-{name}.R` file outside of a `test_that()` block. Instead, use `tests/testthat/helper.R` or `tests/testthat/helper-{name}.R`.
 - Avoid `expect_true()` and `expect_false()` in favour of a specific expectation which will give a better failure message. A few expectations in newer releases that you might not know about are `expect_all_true()`, `expect_all_equal()`, and `expect_r6_class()`.
 - When testing errors and warnings, don't use `expect_error()` or `expect_warning()`. Instead, use `expect_snapshot(error = TRUE)` for errors and `expect_snapshot()` for warnings because these allow the user to review the full text of the output.
 - Avoid the `.package` argument to `local_mocked_bindings()`; this modifies the namespace of another package which is not good practice. Instead create a mockable version of the function in the current package. See `?local_mocked_bindings` for more details.
@@ -53,7 +54,7 @@ air format .
 - Every user-facing function should be exported and have roxygen2 documentation.
 - Wrap roxygen comments at 80 characters.
 - Internal functions should not have roxygen documentation.
-- Whenever you add a new (non-internal) documentation topic, also add the topic to `_pkgdown.yml`. 
+- Whenever you add a new (non-internal) documentation topic, also add the topic to `_pkgdown.yml`.
 - Always re-document the package after changing a roxygen2 comment.
 - Use `pkgdown::check_pkgdown()` to check that all topics are included in the reference index.
 
@@ -76,9 +77,9 @@ air format .
 
 ### Proofreading
 
-If the user asks you to proofread a file, act as an expert proofreader and editor with a deep understanding of clear, engaging, and well-structured writing. 
+If the user asks you to proofread a file, act as an expert proofreader and editor with a deep understanding of clear, engaging, and well-structured writing.
 
-Work paragraph by paragraph, always starting by making a TODO list that includes individual items for each top-level heading. 
+Work paragraph by paragraph, always starting by making a TODO list that includes individual items for each top-level heading.
 
 Fix spelling, grammar, and other minor problems without asking the user. Label any unclear, confusing, or ambiguous sentences with a FIXME comment.
 

--- a/inst/claude/CLAUDE.md
+++ b/inst/claude/CLAUDE.md
@@ -41,11 +41,10 @@ air format .
 ### Testing
 
 - Tests for `R/{name}.R` go in `tests/testthat/test-{name}.R`.
-- Helpers for `tests/testthat/test-{name}.R` go in `tests/testthat/helper-{name}.R`.
 - All new code should have an accompanying test.
 - If there are existing tests, place new tests next to similar existing tests.
 - Strive to keep your tests minimal with few comments.
-- Never put code in a `test-{name}.R` file outside of a `test_that()` block.
+- Never put code in a `test-{name}.R` file outside of a `test_that()` block. Instead, use `tests/testthat/helper.R` or `tests/testthat/helper-{name}.R`.
 - Avoid `expect_true()` and `expect_false()` in favour of a specific expectation which will give a better failure message. A few expectations in newer releases that you might not know about are `expect_all_true()`, `expect_all_equal()`, and `expect_r6_class()`.
 - When testing errors and warnings, don't us `expect_error()` or `expect_warning()`. Instead, use `expect_snapshot(error = TRUE)` for errors and `expect_snapshot()` for warnings because these allow the user to review the full text of the output.
 - Avoid the `.package` argument to `local_mocked_bindings()`; this modifies the namespace of another package which is not good practice. Instead create a mockable version of the function in the current package. See `?local_mocked_bindings` for more details.

--- a/inst/claude/CLAUDE.md
+++ b/inst/claude/CLAUDE.md
@@ -46,7 +46,7 @@ air format .
 - Strive to keep your tests minimal with few comments.
 - Never put code in a `test-{name}.R` file outside of a `test_that()` block. Instead, use `tests/testthat/helper.R` or `tests/testthat/helper-{name}.R`.
 - Avoid `expect_true()` and `expect_false()` in favour of a specific expectation which will give a better failure message. A few expectations in newer releases that you might not know about are `expect_all_true()`, `expect_all_equal()`, and `expect_r6_class()`.
-- When testing errors and warnings, don't us `expect_error()` or `expect_warning()`. Instead, use `expect_snapshot(error = TRUE)` for errors and `expect_snapshot()` for warnings because these allow the user to review the full text of the output.
+- When testing errors and warnings, don't use `expect_error()` or `expect_warning()`. Instead, use `expect_snapshot(error = TRUE)` for errors and `expect_snapshot()` for warnings because these allow the user to review the full text of the output.
 - Avoid the `.package` argument to `local_mocked_bindings()`; this modifies the namespace of another package which is not good practice. Instead create a mockable version of the function in the current package. See `?local_mocked_bindings` for more details.
 
 ### Documentation

--- a/inst/claude/CLAUDE.md
+++ b/inst/claude/CLAUDE.md
@@ -36,14 +36,16 @@ air format .
 * Always run `air format .` after generating code
 * Use the base pipe operator (`|>`) not the magrittr pipe (`%>%`)
 * Don't use `_$x` or `_$[["x"]]` since this package must work on R 4.1.
-* Use `\() ...` for single-line anonymous functions. For all other cases, use `function() {...}` 
+* Use `\() ...` for single-line anonymous functions. For all other cases, use `function() {...}`
 
 ### Testing
 
-- Tests for `R/{name}.R` go in `tests/testthat/test-{name}.R`. 
+- Tests for `R/{name}.R` go in `tests/testthat/test-{name}.R`.
+- Helpers for `tests/testthat/test-{name}.R` go in `tests/testthat/helper-{name}.R`.
 - All new code should have an accompanying test.
 - If there are existing tests, place new tests next to similar existing tests.
 - Strive to keep your tests minimal with few comments.
+- Never put code in a `test-{name}.R` file outside of a `test_that()` block.
 - Avoid `expect_true()` and `expect_false()` in favour of a specific expectation which will give a better failure message. A few expectations in newer releases that you might not know about are `expect_all_true()`, `expect_all_equal()`, and `expect_r6_class()`.
 - When testing errors and warnings, don't us `expect_error()` or `expect_warning()`. Instead, use `expect_snapshot(error = TRUE)` for errors and `expect_snapshot()` for warnings because these allow the user to review the full text of the output.
 - Avoid the `.package` argument to `local_mocked_bindings()`; this modifies the namespace of another package which is not good practice. Instead create a mockable version of the function in the current package. See `?local_mocked_bindings` for more details.
@@ -53,7 +55,7 @@ air format .
 - Every user-facing function should be exported and have roxygen2 documentation.
 - Wrap roxygen comments at 80 characters.
 - Internal functions should not have roxygen documentation.
-- Whenever you add a new (non-internal) documentation topic, also add the topic to `_pkgdown.yml`. 
+- Whenever you add a new (non-internal) documentation topic, also add the topic to `_pkgdown.yml`.
 - Always re-document the package after changing a roxygen2 comment.
 - Use `pkgdown::check_pkgdown()` to check that all topics are included in the reference index.
 
@@ -76,9 +78,9 @@ air format .
 
 ### Proofreading
 
-If the user asks you to proofread a file, act as an expert proofreader and editor with a deep understanding of clear, engaging, and well-structured writing. 
+If the user asks you to proofread a file, act as an expert proofreader and editor with a deep understanding of clear, engaging, and well-structured writing.
 
-Work paragraph by paragraph, always starting by making a TODO list that includes individual items for each top-level heading. 
+Work paragraph by paragraph, always starting by making a TODO list that includes individual items for each top-level heading.
 
 Fix spelling, grammar, and other minor problems without asking the user. Label any unclear, confusing, or ambiguous sentences with a FIXME comment.
 


### PR DESCRIPTION
I have noticed that when claude needs test helpers, it will put them at the top of a test file, like

`test-foo.R`

```r
helper <- function(x) {
  x + 1
}

test_that("thing", {
  expect_identical(2, helper(1))
})
```

It needs some encouragement to use `helper-foo.R` and to NEVER place code in a test file outside of a testthat block