### PR TITLE
More informative diagnostics from `github_remotes()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # usethis (development version)
 
+* `pr_pull()`, `pr_push()` and friends now give more informative errors if usethis can't retrieve details about a remote (#1929, #2229).
 * `use_readme_qmd()` creates a starter `README.qmd` with Quarto-flavored YAML frontmatter, analogous to `use_readme_rmd()` (#1671). Thanks @VisruthSK for getting the ball rolling.
 
 * `use_pipe()` is now deprecated (@math-mcshane, #2124).

--- a/R/github_token.R
+++ b/R/github_token.R
@@ -118,6 +118,11 @@ code_hint_with_host <- function(function_name, host = NULL, arg_name = NULL) {
   glue_chr("{function_name}({arg_hint(host, arg_name)})")
 }
 
+has_pat <- function(api_url = "https://api.github.com") {
+  pat <- tryCatch(gh::gh_token(api_url = api_url), error = function(cnd) "")
+  nzchar(pat)
+}
+
 # workhorse behind gh_token_help() and called, possibly twice, in git_sitrep()
 # hence the need for `scold_for_renviron = TRUE/FALSE`
 # scope determines if "global" or "de_facto" email is checked

--- a/R/github_token.R
+++ b/R/github_token.R
@@ -118,7 +118,7 @@ code_hint_with_host <- function(function_name, host = NULL, arg_name = NULL) {
   glue_chr("{function_name}({arg_hint(host, arg_name)})")
 }
 
-has_pat <- function(api_url = "https://api.github.com") {
+has_pat <- function(api_url = default_api_url()) {
   pat <- tryCatch(gh::gh_token(api_url = api_url), error = function(cnd) "")
   nzchar(pat)
 }

--- a/R/utils-github.R
+++ b/R/utils-github.R
@@ -233,16 +233,17 @@ get_gh_repo <- function(
   remote,
   owner,
   name,
-  api_url = "https://api.github.com",
+  api_url = default_api_url(),
   github_get = TRUE,
   call = caller_env()
 ) {
-  # Don't even try to get parent info for missing remote
+  # Don't even try to get info if we don't know owner/name
+  # This happens when we try and get the parent info for remote that wasn't found
   if (is.na(owner) || is.na(name)) {
     return(list())
   }
 
-  if (identical(github_get, TRUE)) {
+  if (isTRUE(github_get)) {
     # Fail with informative message
     withCallingHandlers(
       gh_repo(owner, name, api_url),

--- a/R/utils-github.R
+++ b/R/utils-github.R
@@ -283,7 +283,7 @@ gh_repo_fail_message <- function(cnd, api_url) {
   } else if (gh_is_rate_limited(cnd)) {
     c(
       "GitHub API rate limit exceeded.",
-      "i" = if (has_path(api_url)) {
+      "i" = if (!has_pat(api_url)) {
         "An authenticated request has a much higher limit than an anonymous
              one; see {.run usethis::gh_token_help()} for advice."
       }
@@ -325,7 +325,7 @@ gh_is_rate_limited <- function(cnd) {
   } else if (inherits(cnd, "http_error_403")) {
     # GitHub also returns 403 (not 429) when you exhaust the primary hourly
     # quota, distinguished from a permissions failure by `x-ratelimit-remaining`.
-    remaining <- cnd$response$headers[["x-ratelimit-remaining"]]
+    remaining <- cnd$response_headers[["x-ratelimit-remaining"]]
     !is.null(remaining) && remaining == "0"
   } else {
     FALSE

--- a/R/utils-github.R
+++ b/R/utils-github.R
@@ -178,46 +178,26 @@ github_remote_list <- function(these = c("origin", "upstream"), x = NULL) {
 github_remotes <- function(
   these = c("origin", "upstream"),
   github_get = NA,
-  x = NULL
+  x = NULL,
+  call = caller_env()
 ) {
   grl <- github_remote_list(these = these, x = x)
-  get_gh_repo <- function(
-    repo_owner,
-    repo_name,
-    api_url = "https://api.github.com"
-  ) {
-    if (isFALSE(github_get)) {
-      f <- function(...) list()
-    } else {
-      f <- purrr::possibly(gh::gh, otherwise = list())
-    }
-    f(
-      "GET /repos/{owner}/{repo}",
-      owner = repo_owner,
-      repo = repo_name,
-      .api_url = api_url
-    )
-  }
-  repo_info <- purrr::pmap(
-    grl[c("repo_owner", "repo_name", "api_url")],
-    get_gh_repo
-  )
+
+  repo_info <- unwrap_purrr(purrr::pmap(
+    list(
+      remote = grl$remote,
+      owner = grl$repo_owner,
+      name = grl$repo_name,
+      api_url = grl$api_url
+    ),
+    get_gh_repo,
+    github_get = github_get,
+    call = call
+  ))
   # NOTE: these can be two separate matters:
   # 1. Did we call the GitHub API? Means we know `is_fork` and the parent repo.
   # 2. If so, did we call it with auth? Means we know if we can push.
   grl$github_got <- map_lgl(repo_info, \(x) length(x) > 0)
-  if (isTRUE(github_get) && !all(grl$github_got)) {
-    oops <- which(!grl$github_got)
-    oops_remotes <- grl$remote[oops]
-    oops_hosts <- unique(grl$host[oops])
-    ui_abort(c(
-      "Unable to get GitHub info for these remotes: {.val {oops_remotes}}.",
-      "Are we offline? Is GitHub down? Has the repo been deleted?",
-      "Otherwise, you probably need to configure a personal access token (PAT)
-       for {.val {oops_hosts}}.",
-      "See {.run usethis::gh_token_help()} for advice."
-    ))
-  }
 
   grl$default_branch <- map_chr(repo_info, "default_branch", .default = NA)
   grl$is_fork <- map_lgl(repo_info, "fork", .default = NA)
@@ -233,16 +213,123 @@ github_remotes <- function(
   grl$parent_repo_spec <- make_spec(grl$parent_repo_owner, grl$parent_repo_name)
 
   parent_info <- purrr::pmap(
-    set_names(
-      grl[c("parent_repo_owner", "parent_repo_name", "api_url")],
-      \(x) sub("parent_", "", x)
+    list(
+      remote = grl$remote,
+      owner = grl$parent_repo_owner,
+      name = grl$parent_repo_name,
+      api_url = grl$api_url
     ),
-    get_gh_repo
+    get_gh_repo,
+    # only ever best effort, since there may not be a parent
+    github_get = NA
   )
   grl$can_push_to_parent <-
     map_lgl(parent_info, c("permissions", "push"), .default = NA)
 
   grl
+}
+
+get_gh_repo <- function(
+  remote,
+  owner,
+  name,
+  api_url = "https://api.github.com",
+  github_get = TRUE,
+  call = caller_env()
+) {
+  # Don't even try to get parent info for missing remote
+  if (is.na(owner) || is.na(name)) {
+    return(list())
+  }
+
+  if (identical(github_get, TRUE)) {
+    # Fail with informative message
+    withCallingHandlers(
+      gh_repo(owner, name, api_url),
+      error = function(cnd) {
+        ui_abort(
+          c(
+            "Failed to get details for {.val {remote}} remote ({owner}/{name})",
+            gh_repo_fail_message(cnd, api_url)
+          ),
+          parent = cnd,
+          call = call
+        )
+      }
+    )
+  } else if (identical(github_get, NA)) {
+    # Proceed anyway
+    tryCatch(gh_repo(owner, name, api_url), error = function(cnd) list())
+  } else {
+    # Don't even try
+    list()
+  }
+}
+
+gh_repo_fail_message <- function(cnd, api_url) {
+  if (inherits(cnd, "http_error_404")) {
+    c(
+      "Failed to find repo.",
+      "i" = "Has the repo been deleted, renamed, or made private?",
+      "i" = "If it's private, you may need a personal access token with access
+             to it; see {.run usethis::gh_token_help()} for advice."
+    )
+  } else if (inherits(cnd, "http_error_401")) {
+    c(
+      "GitHub authentication failed.",
+      "i" = "Your personal access token is missing, invalid, or expired.",
+      "i" = "See {.run usethis::gh_token_help()} for advice."
+    )
+  } else if (gh_is_rate_limited(cnd)) {
+    c(
+      "GitHub API rate limit exceeded.",
+      "i" = if (has_path(api_url)) {
+        "An authenticated request has a much higher limit than an anonymous
+             one; see {.run usethis::gh_token_help()} for advice."
+      }
+    )
+  } else if (inherits(cnd, "http_error_403")) {
+    c(
+      "GitHub denied access.",
+      "i" = "Your personal access token may be missing the scopes required to read this repo.",
+      "i" = "See {.run usethis::gh_token_help()} for advice."
+    )
+  } else if (inherits(cnd, "github_error")) {
+    # Any other HTTP error (e.g., 5xx).
+    c(
+      "GitHub API request failed.",
+      "i" = "GitHub may be having trouble; check {.url https://www.githubstatus.com}."
+    )
+  } else {
+    # Non-HTTP: DNS failure, timeout, SSL, etc.
+    c(
+      "Can't reach the GitHub API at {.url {api_url}}.",
+      "i" = "Are you offline or behind a firewall that blocks GitHub?"
+    )
+  }
+}
+
+# So we can mock it
+gh_repo <- function(repo_owner, repo_name, api_url) {
+  gh::gh(
+    "GET /repos/{owner}/{repo}",
+    owner = repo_owner,
+    repo = repo_name,
+    .api_url = api_url
+  )
+}
+
+gh_is_rate_limited <- function(cnd) {
+  if (inherits(cnd, "http_error_429")) {
+    TRUE
+  } else if (inherits(cnd, "http_error_403")) {
+    # GitHub also returns 403 (not 429) when you exhaust the primary hourly
+    # quota, distinguished from a permissions failure by `x-ratelimit-remaining`.
+    remaining <- cnd$response$headers[["x-ratelimit-remaining"]]
+    !is.null(remaining) && remaining == "0"
+  } else {
+    FALSE
+  }
 }
 
 #' Classify the GitHub remote configuration
@@ -339,9 +426,9 @@ new_github_remote_config <- function() {
   )
 }
 
-github_remote_config <- function(github_get = NA) {
+github_remote_config <- function(github_get = NA, call = caller_env()) {
   cfg <- new_github_remote_config()
-  grl <- github_remotes(github_get = github_get)
+  grl <- github_remotes(github_get = github_get, call = call)
 
   if (nrow(grl) == 0) {
     return(cfg_no_github(cfg))

--- a/R/utils.R
+++ b/R/utils.R
@@ -113,3 +113,12 @@ data.frame <- function(..., stringsAsFactors = FALSE) {
 maybe_name <- function(x, ..., arg = caller_arg(x), call = caller_env()) {
   check_name(x, ..., allow_null = TRUE, arg = arg, call = call)
 }
+
+unwrap_purrr <- function(code) {
+  withCallingHandlers(
+    code,
+    purrr_error_indexed = function(err) {
+      rlang::cnd_signal(err$parent)
+    }
+  )
+}

--- a/tests/testthat/_snaps/utils-github.md
+++ b/tests/testthat/_snaps/utils-github.md
@@ -44,9 +44,19 @@
     Condition
       Error:
       x Failed to get details for "origin" remote (O/R)
-      i GitHub denied access.
-      i Your personal access token may be missing the scopes required to read this repo.
-      i See `usethis::gh_token_help()` for advice.
+      i GitHub API rate limit exceeded.
+      Caused by error in `gh_repo()`:
+      ! failed
+
+---
+
+    Code
+      get_gh_repo("origin", "O", "R")
+    Condition
+      Error:
+      x Failed to get details for "origin" remote (O/R)
+      i GitHub API rate limit exceeded.
+      i An authenticated request has a much higher limit than an anonymous one; see `usethis::gh_token_help()` for advice.
       Caused by error in `gh_repo()`:
       ! failed
 

--- a/tests/testthat/_snaps/utils-github.md
+++ b/tests/testthat/_snaps/utils-github.md
@@ -1,3 +1,79 @@
+# get_gh_repo() distinguishes between common API failures
+
+    Code
+      get_gh_repo("origin", "O", "R")
+    Condition
+      Error:
+      x Failed to get details for "origin" remote (O/R)
+      i Failed to find repo.
+      i Has the repo been deleted, renamed, or made private?
+      i If it's private, you may need a personal access token with access to it; see `usethis::gh_token_help()` for advice.
+      Caused by error in `gh_repo()`:
+      ! failed
+
+---
+
+    Code
+      get_gh_repo("origin", "O", "R")
+    Condition
+      Error:
+      x Failed to get details for "origin" remote (O/R)
+      i GitHub authentication failed.
+      i Your personal access token is missing, invalid, or expired.
+      i See `usethis::gh_token_help()` for advice.
+      Caused by error in `gh_repo()`:
+      ! failed
+
+---
+
+    Code
+      get_gh_repo("origin", "O", "R")
+    Condition
+      Error:
+      x Failed to get details for "origin" remote (O/R)
+      i GitHub denied access.
+      i Your personal access token may be missing the scopes required to read this repo.
+      i See `usethis::gh_token_help()` for advice.
+      Caused by error in `gh_repo()`:
+      ! failed
+
+---
+
+    Code
+      get_gh_repo("origin", "O", "R")
+    Condition
+      Error:
+      x Failed to get details for "origin" remote (O/R)
+      i GitHub denied access.
+      i Your personal access token may be missing the scopes required to read this repo.
+      i See `usethis::gh_token_help()` for advice.
+      Caused by error in `gh_repo()`:
+      ! failed
+
+---
+
+    Code
+      get_gh_repo("origin", "O", "R")
+    Condition
+      Error:
+      x Failed to get details for "origin" remote (O/R)
+      i GitHub API request failed.
+      i GitHub may be having trouble; check <https://www.githubstatus.com>.
+      Caused by error in `gh_repo()`:
+      ! failed
+
+---
+
+    Code
+      get_gh_repo("origin", "O", "R")
+    Condition
+      Error:
+      x Failed to get details for "origin" remote (O/R)
+      i Can't reach the GitHub API at <https://api.github.com>.
+      i Are you offline or behind a firewall that blocks GitHub?
+      Caused by error in `gh_repo()`:
+      ! could not resolve host
+
 # we understand the list of all possible configs
 
     Code

--- a/tests/testthat/test-utils-github.R
+++ b/tests/testthat/test-utils-github.R
@@ -199,13 +199,14 @@ test_that("get_gh_repo() distinguishes between common API failures", {
   expect_snapshot(get_gh_repo("origin", "O", "R"), error = TRUE)
 
   local_mocked_bindings(
-    gh_repo = fake_gh(403, list(`x-ratelimit-remaining` = "0"))
+    gh_repo = fake_gh(403, list(`x-ratelimit-remaining` = "42"))
   )
   expect_snapshot(get_gh_repo("origin", "O", "R"), error = TRUE)
 
-  local_mocked_bindings(
-    gh_repo = fake_gh(403, list(`x-ratelimit-remaining` = "42"))
-  )
+  local_mocked_bindings(gh_repo = fake_gh(429), has_pat = \(...) TRUE)
+  expect_snapshot(get_gh_repo("origin", "O", "R"), error = TRUE)
+
+  local_mocked_bindings(gh_repo = fake_gh(429), has_pat = function(...) FALSE)
   expect_snapshot(get_gh_repo("origin", "O", "R"), error = TRUE)
 
   local_mocked_bindings(gh_repo = fake_gh(500))

--- a/tests/testthat/test-utils-github.R
+++ b/tests/testthat/test-utils-github.R
@@ -167,6 +167,54 @@ test_that("github_remotes() works", {
   expect_true(is.na(grl$is_fork))
 })
 
+test_that("get_gh_repo() can short-circuit without calling the API", {
+  local_mocked_bindings(gh_repo = function(...) stop("failed"))
+
+  expect_equal(get_gh_repo("origin", "O", "R", github_get = FALSE), list())
+  expect_equal(get_gh_repo("origin", NA, "R", github_get = TRUE), list())
+  expect_equal(get_gh_repo("origin", "O", NA, github_get = TRUE), list())
+})
+
+test_that("get_gh_repo() swallows errors when github_get = NA", {
+  local_mocked_bindings(gh_repo = function(...) stop("failed"))
+  expect_equal(get_gh_repo("origin", "O", "R", github_get = NA), list())
+})
+
+test_that("get_gh_repo() distinguishes between common API failures", {
+  # see gh:::gh_error()
+  fake_gh <- function(status, headers = list()) {
+    function(...) {
+      rlang::abort(
+        "failed",
+        class = c(sprintf("http_error_%d", status), "github_error"),
+        response_headers = headers
+      )
+    }
+  }
+
+  local_mocked_bindings(gh_repo = fake_gh(404))
+  expect_snapshot(get_gh_repo("origin", "O", "R"), error = TRUE)
+
+  local_mocked_bindings(gh_repo = fake_gh(401))
+  expect_snapshot(get_gh_repo("origin", "O", "R"), error = TRUE)
+
+  local_mocked_bindings(
+    gh_repo = fake_gh(403, list(`x-ratelimit-remaining` = "0"))
+  )
+  expect_snapshot(get_gh_repo("origin", "O", "R"), error = TRUE)
+
+  local_mocked_bindings(
+    gh_repo = fake_gh(403, list(`x-ratelimit-remaining` = "42"))
+  )
+  expect_snapshot(get_gh_repo("origin", "O", "R"), error = TRUE)
+
+  local_mocked_bindings(gh_repo = fake_gh(500))
+  expect_snapshot(get_gh_repo("origin", "O", "R"), error = TRUE, )
+
+  local_mocked_bindings(gh_repo = \(...) abort("could not resolve host"))
+  expect_snapshot(get_gh_repo("origin", "O", "R"), error = TRUE)
+})
+
 test_that("github_url_from_git_remotes() is idempotent", {
   url <- "https://github.com/r-lib/usethis.git"
   out <- github_url_from_git_remotes(url)


### PR DESCRIPTION
We more carefully generate an error based on the specific error condition, always including the original error for context.

Fixes #2229. Fixes #1929.