### PR TITLE
Show package version in message when changing the `DESCRIPTION` file

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,8 @@
 
 * `pr_resume()` (without a specific `branch`) and `pr_fetch()` (without a specific `number`) no longer error when a branch name contains curly braces (#2107, @jonthegeek).
 
+* `usethis::use_package()` also prints the package version if a dependency is added or moved.
+
 # usethis 3.2.1
 
 * `create_quarto_project()` exits early if the Quarto CLI does not appear to be

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -43,7 +43,7 @@ use_dependency <- function(package, type, min_version = NULL) {
   # In all cases, we can can simply make the change.
   if (nrow(deps) == 0 || new_linking_to || new_non_linking_to) {
     ui_bullets(c(
-      "v" = "Adding {.pkg {package}} to {.field {type}} field in DESCRIPTION."
+      "v" = "Adding {.pkg {package}} ({.val {version}}) to {.field {type}} field in DESCRIPTION."
     ))
     desc$set_dep(package, type, version = version)
     desc$write()
@@ -63,7 +63,7 @@ use_dependency <- function(package, type, min_version = NULL) {
   if (delta < 0) {
     # don't downgrade
     ui_bullets(c(
-      "!" = "Package {.pkg {package}} is already listed in
+      "!" = "Package {.pkg {package}} ({.val {version}}) is already listed in
              {.field {existing_type}} in DESCRIPTION; no change made."
     ))
   } else if (
@@ -85,7 +85,7 @@ use_dependency <- function(package, type, min_version = NULL) {
   } else if (delta > 0) {
     # moving from, e.g., Suggests to Imports
     ui_bullets(c(
-      "v" = "Moving {.pkg {package}} from {.field {existing_type}} to
+      "v" = "Moving {.pkg {package}} ({.val {version}}) from {.field {existing_type}} to
              {.field {type}} field in DESCRIPTION."
     ))
     desc$del_dep(package, existing_type)

--- a/tests/testthat/_snaps/data-table.md
+++ b/tests/testthat/_snaps/data-table.md
@@ -20,7 +20,7 @@
     Message
       ! data.table should be in 'Imports' or 'Suggests', not 'Depends'!
       v Removing data.table from 'Depends'.
-      v Adding data.table to 'Imports' field in DESCRIPTION.
+      v Adding data.table ("*") to 'Imports' field in DESCRIPTION.
       v Adding "@importFrom data.table data.table", "@importFrom data.table :=",
         "@importFrom data.table .SD", "@importFrom data.table .BY", "@importFrom
         data.table .N", "@importFrom data.table .I", "@importFrom data.table .GRP",

--- a/tests/testthat/_snaps/helpers.md
+++ b/tests/testthat/_snaps/helpers.md
@@ -3,14 +3,14 @@
     Code
       use_dependency("crayon", "Imports")
     Message
-      v Adding crayon to 'Imports' field in DESCRIPTION.
+      v Adding crayon ("*") to 'Imports' field in DESCRIPTION.
 
 # we message for version change and are silent for same version
 
     Code
       use_dependency("crayon", "Imports")
     Message
-      v Adding crayon to 'Imports' field in DESCRIPTION.
+      v Adding crayon ("*") to 'Imports' field in DESCRIPTION.
 
 ---
 
@@ -38,36 +38,36 @@
     Code
       use_dependency("usethis", "Suggests")
     Message
-      v Adding usethis to 'Suggests' field in DESCRIPTION.
+      v Adding usethis ("*") to 'Suggests' field in DESCRIPTION.
 
 ---
 
     Code
       use_dependency("usethis", "Imports")
     Message
-      v Moving usethis from 'Suggests' to 'Imports' field in DESCRIPTION.
+      v Moving usethis ("*") from 'Suggests' to 'Imports' field in DESCRIPTION.
 
 # use_dependency() declines to downgrade a dependency
 
     Code
       use_dependency("usethis", "Imports")
     Message
-      v Adding usethis to 'Imports' field in DESCRIPTION.
+      v Adding usethis ("*") to 'Imports' field in DESCRIPTION.
 
 ---
 
     Code
       use_dependency("usethis", "Suggests")
     Message
-      ! Package usethis is already listed in 'Imports' in DESCRIPTION; no change
-        made.
+      ! Package usethis ("*") is already listed in 'Imports' in DESCRIPTION; no
+        change made.
 
 # can add LinkingTo dependency if other dependency already exists
 
     Code
       use_dependency("rlang", "LinkingTo")
     Message
-      v Adding rlang to 'LinkingTo' field in DESCRIPTION.
+      v Adding rlang ("*") to 'LinkingTo' field in DESCRIPTION.
 
 # use_dependency() does not fall over on 2nd LinkingTo request
 
@@ -79,6 +79,6 @@
     Code
       use_package("rlang")
     Message
-      v Moving rlang from 'Suggests' to 'Imports' field in DESCRIPTION.
+      v Moving rlang ("*") from 'Suggests' to 'Imports' field in DESCRIPTION.
       [ ] Refer to functions with `rlang::fun()`.
 

--- a/tests/testthat/_snaps/lifecycle.md
+++ b/tests/testthat/_snaps/lifecycle.md
@@ -3,7 +3,7 @@
     Code
       use_lifecycle()
     Message
-      v Adding lifecycle to 'Imports' field in DESCRIPTION.
+      v Adding lifecycle ("*") to 'Imports' field in DESCRIPTION.
       [ ] Refer to functions with `lifecycle::fun()`.
       v Adding "@importFrom lifecycle deprecated" to 'R/{TESTPKG}-package.R'.
       v Writing 'NAMESPACE'.

--- a/tests/testthat/_snaps/package.md
+++ b/tests/testthat/_snaps/package.md
@@ -3,13 +3,14 @@
     Code
       use_package("withr")
     Message
-      v Adding withr to 'Imports' field in DESCRIPTION.
+      v Adding withr ("*") to 'Imports' field in DESCRIPTION.
       [ ] Refer to functions with `withr::fun()`.
     Code
       use_package("withr")
       use_package("withr", "Suggests")
     Message
-      ! Package withr is already listed in 'Imports' in DESCRIPTION; no change made.
+      ! Package withr ("*") is already listed in 'Imports' in DESCRIPTION; no change
+        made.
 
 # use_package() handles R versions with aplomb
 
@@ -32,7 +33,7 @@
     Code
       use_package("R", type = "Depends", min_version = "3.6")
     Message
-      v Adding R to 'Depends' field in DESCRIPTION.
+      v Adding R (">= 3.6") to 'Depends' field in DESCRIPTION.
 
 ---
 
@@ -46,7 +47,7 @@
     Code
       use_package("withr", "Suggests")
     Message
-      v Adding withr to 'Suggests' field in DESCRIPTION.
+      v Adding withr ("*") to 'Suggests' field in DESCRIPTION.
       [ ] Use `requireNamespace("withr", quietly = TRUE)` to test if withr is
         installed.
       [ ] Then directly refer to functions with `withr::fun()`.
@@ -56,7 +57,7 @@
     Code
       use_package("purrr", "Suggests")
     Message
-      v Adding purrr to 'Suggests' field in DESCRIPTION.
+      v Adding purrr ("*") to 'Suggests' field in DESCRIPTION.
       [ ] In your package code, use `rlang::is_installed("purrr")` or
         `rlang::check_installed("purrr")` to test if purrr is installed.
       [ ] Then directly refer to functions with `purrr::fun()`.

--- a/tests/testthat/_snaps/tibble.md
+++ b/tests/testthat/_snaps/tibble.md
@@ -3,7 +3,7 @@
     Code
       use_tibble()
     Message
-      v Adding tibble to 'Imports' field in DESCRIPTION.
+      v Adding tibble ("*") to 'Imports' field in DESCRIPTION.
       v Adding "@importFrom tibble tibble" to 'R/{TESTPKG}-package.R'.
       [ ] Document a returned tibble like so:
         #' @return a [tibble][tibble::tibble-package]

--- a/tests/testthat/_snaps/tidyverse.md
+++ b/tests/testthat/_snaps/tidyverse.md
@@ -3,11 +3,11 @@
     Code
       use_tidy_dependencies()
     Message
-      v Adding rlang to 'Imports' field in DESCRIPTION.
-      v Adding lifecycle to 'Imports' field in DESCRIPTION.
-      v Adding cli to 'Imports' field in DESCRIPTION.
-      v Adding glue to 'Imports' field in DESCRIPTION.
-      v Adding withr to 'Imports' field in DESCRIPTION.
+      v Adding rlang ("*") to 'Imports' field in DESCRIPTION.
+      v Adding lifecycle ("*") to 'Imports' field in DESCRIPTION.
+      v Adding cli ("*") to 'Imports' field in DESCRIPTION.
+      v Adding glue ("*") to 'Imports' field in DESCRIPTION.
+      v Adding withr ("*") to 'Imports' field in DESCRIPTION.
       v Adding "@import rlang" to 'R/{TESTPKG}-package.R'.
       v Adding "@importFrom glue glue" to 'R/{TESTPKG}-package.R'.
       v Adding "@importFrom lifecycle deprecated" to 'R/{TESTPKG}-package.R'.


### PR DESCRIPTION
`usethis::use_package()` also prints the package version if a dependency is added or moved. Previously, the version was only printed if the version of a package was changed.