### PR TITLE
Fix typo in git_vaccinate doc: .Rdata → .RData

### DIFF
--- a/R/git.R
+++ b/R/git.R
@@ -536,7 +536,7 @@ default_branch_sitrep <- function() {
 
 #' Vaccinate your global gitignore file
 #'
-#' Adds `.Rproj.user`, `.Rhistory`, `.Rdata`, `.httr-oauth`, `.DS_Store`, and
+#' Adds `.Rproj.user`, `.Rhistory`, `.RData`, `.httr-oauth`, `.DS_Store`, and
 #' `.quarto` to your global (a.k.a. user-level) `.gitignore`. This is good
 #' practice as it decreases the chance that you will accidentally leak
 #' credentials to GitHub. `git_vaccinate()` also tries to detect and fix the

--- a/man/git_vaccinate.Rd
+++ b/man/git_vaccinate.Rd
@@ -7,7 +7,7 @@
 git_vaccinate()
 }
 \description{
-Adds \code{.Rproj.user}, \code{.Rhistory}, \code{.Rdata}, \code{.httr-oauth}, \code{.DS_Store}, and
+Adds \code{.Rproj.user}, \code{.Rhistory}, \code{.RData}, \code{.httr-oauth}, \code{.DS_Store}, and
 \code{.quarto} to your global (a.k.a. user-level) \code{.gitignore}. This is good
 practice as it decreases the chance that you will accidentally leak
 credentials to GitHub. \code{git_vaccinate()} also tries to detect and fix the


### PR DESCRIPTION
In the documentation page for git_vaccinate(), the list of files to ignore includes ".Rdata". But the function actually adds ".RData" (with a capital D) to .gitignore.

".RData" is the correct capitalization, so this PR fixes the small typo in the documentation.

This is my first PR on any project ever, so forgive me if I've broken everything!