### PR TITLE
Clarify which README file should be edited

### DIFF
--- a/inst/templates/package-README
+++ b/inst/templates/package-README
@@ -3,7 +3,7 @@
 output: github_document
 ---
 
-<!-- README.md is generated from README.Rmd. Please edit that file -->
+<!-- README.md is generated from README.Rmd. Please edit only the Rmd file. -->
 
 ```{r, include = FALSE}
 knitr::opts_chunk$set(

--- a/inst/templates/package-README-qmd
+++ b/inst/templates/package-README-qmd
@@ -4,7 +4,7 @@ format:
     default-image-extension: ""
 ---
 
-<!-- README.md is generated from README.qmd. Please edit that file -->
+<!-- README.md is generated from README.qmd. Please edit only the qmd file. -->
 
 ```{r}
 #| include: false

--- a/inst/templates/project-README
+++ b/inst/templates/project-README
@@ -3,7 +3,7 @@
 output: github_document
 ---
 
-<!-- README.md is generated from README.Rmd. Please edit that file -->
+<!-- README.md is generated from README.Rmd. Please edit only the Rmd file. -->
 
 ```{r, include = FALSE}
 knitr::opts_chunk$set(

--- a/inst/templates/project-README-qmd
+++ b/inst/templates/project-README-qmd
@@ -4,7 +4,7 @@ format:
     default-image-extension: ""
 ---
 
-<!-- README.md is generated from README.qmd. Please edit that file -->
+<!-- README.md is generated from README.qmd. Please edit only the qmd file. -->
 
 ```{r}
 #| include: false

--- a/tests/testthat/_snaps/readme.md
+++ b/tests/testthat/_snaps/readme.md
@@ -70,7 +70,7 @@
       output: github_document
       ---
       
-      <!-- README.md is generated from README.Rmd. Please edit that file -->
+      <!-- README.md is generated from README.Rmd. Please edit only the Rmd file. -->
       
       ```{r, include = FALSE}
       knitr::opts_chunk$set(
@@ -130,7 +130,7 @@
       output: github_document
       ---
       
-      <!-- README.md is generated from README.Rmd. Please edit that file -->
+      <!-- README.md is generated from README.Rmd. Please edit only the Rmd file. -->
       
       ```{r, include = FALSE}
       knitr::opts_chunk$set(
@@ -206,7 +206,7 @@
           default-image-extension: ""
       ---
       
-      <!-- README.md is generated from README.qmd. Please edit that file -->
+      <!-- README.md is generated from README.qmd. Please edit only the qmd file. -->
       
       ```{r}
       #| include: false
@@ -273,7 +273,7 @@
           default-image-extension: ""
       ---
       
-      <!-- README.md is generated from README.qmd. Please edit that file -->
+      <!-- README.md is generated from README.qmd. Please edit only the qmd file. -->
       
       ```{r}
       #| include: false


### PR DESCRIPTION
Fixes #2193. I updated 4 files in `inst/templates`:

* `package-README` and `project-README` for the Rmd templates
* `package-README-qmd` and `project-README-qmd` for the qmd templates

I think that's all the places where there was previously a comment like:

```
 <!-- README.md is generated from README.Rmd. Please edit that file --> 
```

I changed `Please edit that file` to `Please edit only the Rmd file.` or `Please edit only the qmd file.` as appropriate.

And I reran the unit tests which required updating the snapshots in `tests/testthat/_snaps/readme.md`.