### PR TITLE
vignette: use literal instead of folded block scalar

### DIFF
--- a/inst/templates/vignette.Rmd
+++ b/inst/templates/vignette.Rmd
@@ -1,7 +1,7 @@
 ---
 title: "{{{ vignette_title }}}"
 output: rmarkdown::html_vignette
-vignette: >
+vignette: |
   %\VignetteIndexEntry{{{ braced_vignette_title }}}
   %\VignetteEngine{knitr::rmarkdown}
   %\VignetteEncoding{UTF-8}
@@ -17,4 +17,3 @@ knitr::opts_chunk$set(
 ```{r setup}
 library({{Package}})
 ```
-

--- a/inst/templates/vignette.qmd
+++ b/inst/templates/vignette.qmd
@@ -1,6 +1,6 @@
 ---
 title: "{{{ vignette_title }}}"
-vignette: >
+vignette: |
   %\VignetteIndexEntry{{{ braced_vignette_title }}}
   %\VignetteEngine{quarto::html}
   %\VignetteEncoding{UTF-8}

--- a/vignettes/articles/pr-functions.Rmd
+++ b/vignettes/articles/pr-functions.Rmd
@@ -1,7 +1,7 @@
 ---
 title: "Pull request helpers"
 output: rmarkdown::html_vignette
-vignette: >
+vignette: |
   %\VignetteIndexEntry{Pull request helpers}
   %\VignetteEngine{knitr::rmarkdown}
   %\VignetteEncoding{UTF-8}


### PR DESCRIPTION
Per https://github.com/jolars/panache/issues/366, the recommendation was to switch `vignette: >` (folded block scalar) to `vignette: | (literal block scalar)` in the vignette templates.