### PR TITLE
Update contributing.md and its template

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -20,12 +20,12 @@ See our guide on [how to create a great issue](https://code-review.tidyverse.org
 
 *   Fork the package and clone onto your computer. If you haven't done this before, we recommend using `usethis::create_from_github("r-lib/usethis", fork = TRUE)`.
 
-*   Install all development dependencies with `pak::local_install_dev_deps()`, and then make sure the package passes R CMD check by running `devtools::check()`. 
-    If R CMD check doesn't pass cleanly, it's a good idea to ask for help before continuing.
+*   Install all development dependencies with `pak::local_install_dev_deps()`, and then make sure the package passes `R CMD check` by running `devtools::check()`. 
+    If `R CMD check` doesn't pass cleanly, it's a good idea to ask for help before continuing.
 
 *   Create a Git branch for your pull request (PR). We recommend using `usethis::pr_init("brief-description-of-change")`.
 
-*   Make your changes and check that the package passes R CMD check by running `devtools::check()` again.
+*   Make your changes and check that the package passes `R CMD check` by running `devtools::check()` again.
     Commit the changes to git, and then create a PR by running `usethis::pr_push()`, and follow the prompts in your browser.
     The title of your PR should briefly describe the change.
     The body of your PR should contain `Fixes #issue-number`.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,8 +1,7 @@
 # Contributing to usethis
 
-This outlines how to propose a change to usethis. 
-For more detailed info about contributing to this, and other tidyverse packages, please see the
-[**development contributing guide**](https://rstd.io/tidy-contrib). 
+This outlines how to propose a change to usethis.
+For a detailed discussion on contributing to this and other tidyverse packages, please see the [development contributing guide](https://rstd.io/tidy-contrib) and our [code review principles](https://code-review.tidyverse.org/).
 
 ## Fixing typos
 
@@ -15,16 +14,19 @@ You can find the `.R` file that generates the `.Rd` by reading the comment in th
 If you want to make a bigger change, it's a good idea to first file an issue and make sure someone from the team agrees that it’s needed. 
 If you’ve found a bug, please file an issue that illustrates the bug with a minimal 
 [reprex](https://www.tidyverse.org/help/#reprex) (this will also help you write a unit test, if needed).
+See our guide on [how to create a great issue](https://code-review.tidyverse.org/issues/) for more advice.
 
 ### Pull request process
 
 *   Fork the package and clone onto your computer. If you haven't done this before, we recommend using `usethis::create_from_github("r-lib/usethis", fork = TRUE)`.
 
-*   Install all development dependencies with `devtools::install_dev_deps()`, and then make sure the package passes R CMD check by running `devtools::check()`. 
-    If R CMD check doesn't pass cleanly, it's a good idea to ask for help before continuing. 
+*   Install all development dependencies with `pak::local_install_dev_deps()` (or, for `devtools` prior to version 2.5.0, with `devtools::install_dev_deps()`), and then make sure the package passes R CMD check by running `devtools::check()`. 
+    If R CMD check doesn't pass cleanly, it's a good idea to ask for help before continuing.
+
 *   Create a Git branch for your pull request (PR). We recommend using `usethis::pr_init("brief-description-of-change")`.
 
-*   Make your changes, commit to git, and then create a PR by running `usethis::pr_push()`, and following the prompts in your browser.
+*   Make your changes and check that the package passes R CMD check by running `devtools::check()` again.
+    Commit the changes to git, and then create a PR by running `usethis::pr_push()`, and follow the prompts in your browser.
     The title of your PR should briefly describe the change.
     The body of your PR should contain `Fixes #issue-number`.
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -20,7 +20,7 @@ See our guide on [how to create a great issue](https://code-review.tidyverse.org
 
 *   Fork the package and clone onto your computer. If you haven't done this before, we recommend using `usethis::create_from_github("r-lib/usethis", fork = TRUE)`.
 
-*   Install all development dependencies with `pak::local_install_dev_deps()` (or, for `devtools` prior to version 2.5.0, with `devtools::install_dev_deps()`), and then make sure the package passes R CMD check by running `devtools::check()`. 
+*   Install all development dependencies with `pak::local_install_dev_deps()`, and then make sure the package passes R CMD check by running `devtools::check()`. 
     If R CMD check doesn't pass cleanly, it's a good idea to ask for help before continuing.
 
 *   Create a Git branch for your pull request (PR). We recommend using `usethis::pr_init("brief-description-of-change")`.

--- a/inst/templates/tidy-contributing.md
+++ b/inst/templates/tidy-contributing.md
@@ -20,12 +20,12 @@ See our guide on [how to create a great issue](https://code-review.tidyverse.org
 
 *   Fork the package and clone onto your computer. If you haven't done this before, we recommend using `usethis::create_from_github("{{github_spec}}", fork = TRUE)`.
 
-*   Install all development dependencies with `pak::local_install_dev_deps()`, and then make sure the package passes R CMD check by running `devtools::check()`. 
-    If R CMD check doesn't pass cleanly, it's a good idea to ask for help before continuing.
+*   Install all development dependencies with `pak::local_install_dev_deps()`, and then make sure the package passes `R CMD check` by running `devtools::check()`. 
+    If `R CMD check` doesn't pass cleanly, it's a good idea to ask for help before continuing.
 
 *   Create a Git branch for your pull request (PR). We recommend using `usethis::pr_init("brief-description-of-change")`.
 
-*   Make your changes and check that the package passes R CMD check by running `devtools::check()` again.
+*   Make your changes and check that the package passes `R CMD check` by running `devtools::check()` again.
     Commit the changes to git, and then create a PR by running `usethis::pr_push()`, and follow the prompts in your browser.
     The title of your PR should briefly describe the change.
     The body of your PR should contain `Fixes #issue-number`.

--- a/inst/templates/tidy-contributing.md
+++ b/inst/templates/tidy-contributing.md
@@ -20,11 +20,13 @@ See our guide on [how to create a great issue](https://code-review.tidyverse.org
 
 *   Fork the package and clone onto your computer. If you haven't done this before, we recommend using `usethis::create_from_github("{{github_spec}}", fork = TRUE)`.
 
-*   Install all development dependencies with `devtools::install_dev_deps()`, and then make sure the package passes R CMD check by running `devtools::check()`. 
-    If R CMD check doesn't pass cleanly, it's a good idea to ask for help before continuing. 
+*   Install all development dependencies with `pak::local_install_dev_deps()` (or, for `devtools` prior to version 2.5.0, with `devtools::install_dev_deps()`), and then make sure the package passes R CMD check by running `devtools::check()`. 
+    If R CMD check doesn't pass cleanly, it's a good idea to ask for help before continuing.
+
 *   Create a Git branch for your pull request (PR). We recommend using `usethis::pr_init("brief-description-of-change")`.
 
-*   Make your changes, commit to git, and then create a PR by running `usethis::pr_push()`, and following the prompts in your browser.
+*   Make your changes and check that the package passes R CMD check by running `devtools::check()` again.
+    Commit the changes to git, and then create a PR by running `usethis::pr_push()`, and follow the prompts in your browser.
     The title of your PR should briefly describe the change.
     The body of your PR should contain `Fixes #issue-number`.
 

--- a/inst/templates/tidy-contributing.md
+++ b/inst/templates/tidy-contributing.md
@@ -20,7 +20,7 @@ See our guide on [how to create a great issue](https://code-review.tidyverse.org
 
 *   Fork the package and clone onto your computer. If you haven't done this before, we recommend using `usethis::create_from_github("{{github_spec}}", fork = TRUE)`.
 
-*   Install all development dependencies with `pak::local_install_dev_deps()` (or, for `devtools` prior to version 2.5.0, with `devtools::install_dev_deps()`), and then make sure the package passes R CMD check by running `devtools::check()`. 
+*   Install all development dependencies with `pak::local_install_dev_deps()`, and then make sure the package passes R CMD check by running `devtools::check()`. 
     If R CMD check doesn't pass cleanly, it's a good idea to ask for help before continuing.
 
 *   Create a Git branch for your pull request (PR). We recommend using `usethis::pr_init("brief-description-of-change")`.


### PR DESCRIPTION
Prefer `pak::local_install_dev_deps()` over `devtools::install_dev_deps()` to install development dependencies because the latter was deprecated in `devtools` 2.5.0. Instruct to also run R CMD check locally after changes are made. And apply the updated template to `usethis` itself (also incorporating changes that were made earlier to the template file). Fixes #2238 and is follow-up of PR #2252 .