### PR TITLE
`use_dependency(force = FALSE)` prevents downgrades almost all the time

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -30,3 +30,4 @@
 ^\.claude$
 ^\.positai$
 ^AGENTS\.md$
+^\.posit$

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -1,6 +1,7 @@
-use_dependency <- function(package, type, min_version = NULL) {
+use_dependency <- function(package, type, min_version = NULL, force = FALSE) {
   check_name(package)
   check_name(type)
+  check_bool(force)
 
   if (package != "R") {
     check_installed(package)
@@ -61,7 +62,7 @@ use_dependency <- function(package, type, min_version = NULL) {
 
   delta <- sign(match(existing_type, types) - match(type, types))
   if (delta < 0) {
-    # don't downgrade
+    # never demote a dependency to a weaker type, eg Imports to Suggests
     ui_bullets(c(
       "!" = "Package {.pkg {package}} is already listed in
              {.field {existing_type}} in DESCRIPTION; no change made."
@@ -69,19 +70,22 @@ use_dependency <- function(package, type, min_version = NULL) {
   } else if (
     delta == 0 && version_spec(version) != version_spec(existing_version)
   ) {
-    if (version_spec(version) > version_spec(existing_version)) {
-      direction <- "Increasing"
+    increasing <- version_spec(version) > version_spec(existing_version)
+    if (increasing || force) {
+      direction <- if (increasing) "Increasing" else "Decreasing"
+      ui_bullets(c(
+        "v" = "{direction} {.pkg {package}} version to {.val {version}} in
+               DESCRIPTION."
+      ))
+      desc$set_dep(package, type, version = version)
+      desc$write()
+      changed <- TRUE
     } else {
-      direction <- "Decreasing"
+      ui_bullets(c(
+        "!" = "Package {.pkg {package}} is already listed with version
+               {.val {existing_version}} in DESCRIPTION; no change made."
+      ))
     }
-
-    ui_bullets(c(
-      "v" = "{direction} {.pkg {package}} version to {.val {version}} in
-             DESCRIPTION."
-    ))
-    desc$set_dep(package, type, version = version)
-    desc$write()
-    changed <- TRUE
   } else if (delta > 0) {
     # moving from, e.g., Suggests to Imports
     ui_bullets(c(

--- a/R/package.R
+++ b/R/package.R
@@ -49,7 +49,12 @@ use_package <- function(package, type = "Imports", min_version = NULL) {
     refuse_package(package, verboten = c("tidyverse", "tidymodels"))
   }
 
-  changed <- use_dependency(package, type, min_version = min_version)
+  changed <- use_dependency(
+    package,
+    type,
+    min_version = min_version,
+    force = TRUE
+  )
   if (changed) {
     how_to_use(package, type)
   }

--- a/R/use_standalone.R
+++ b/R/use_standalone.R
@@ -34,9 +34,8 @@
 #'
 #' - `imports`: A package or list of packages that the standalone file
 #'    depends on. A minimal version may be specified in parentheses,
-#'    e.g. `rlang (>= 1.0.0)`. These dependencies are passed to
-#'    [use_package()] to ensure they are included in the `Imports:`
-#'    field of the `DESCRIPTION` file.
+#'    e.g. `rlang (>= 1.0.0)`. The `DESCRIPTION` file will be updated
+#'    as needed.
 #'
 #' Note that lists are specified with standard YAML syntax, using
 #' square brackets, for example: `imports: [rlang (>= 1.0.0), purrr]`.
@@ -94,7 +93,7 @@ use_standalone <- function(repo_spec, file = NULL, ref = NULL, host = NULL) {
       ver <- import$ver
     }
     ui_silence(
-      use_package(import$pkg, min_version = ver)
+      use_dependency(import$pkg, "Imports", min_version = ver)
     )
   }
 

--- a/man/use_standalone.Rd
+++ b/man/use_standalone.Rd
@@ -66,9 +66,8 @@ the standalone file depends on. These files are retrieved
 automatically by \code{use_standalone()}.
 \item \code{imports}: A package or list of packages that the standalone file
 depends on. A minimal version may be specified in parentheses,
-e.g. \verb{rlang (>= 1.0.0)}. These dependencies are passed to
-\code{\link[=use_package]{use_package()}} to ensure they are included in the \verb{Imports:}
-field of the \code{DESCRIPTION} file.
+e.g. \verb{rlang (>= 1.0.0)}. The \code{DESCRIPTION} file will be updated
+as needed.
 }
 
 Note that lists are specified with standard YAML syntax, using

--- a/tests/testthat/_snaps/helpers.md
+++ b/tests/testthat/_snaps/helpers.md
@@ -31,6 +31,14 @@
     Code
       use_dependency("crayon", "Imports", min_version = "1.0.0")
     Message
+      ! Package crayon is already listed with version ">= 2.0.0" in DESCRIPTION; no
+        change made.
+
+# use_dependency() lowers version when force = TRUE
+
+    Code
+      use_dependency("crayon", "Imports", min_version = "1.0.0", force = TRUE)
+    Message
       v Decreasing crayon version to ">= 1.0.0" in DESCRIPTION.
 
 # use_dependency() upgrades a dependency

--- a/tests/testthat/_snaps/package.md
+++ b/tests/testthat/_snaps/package.md
@@ -11,6 +11,14 @@
     Message
       ! Package withr is already listed in 'Imports' in DESCRIPTION; no change made.
 
+# use_package() honors an explicit request to lower a version
+
+    Code
+      use_package("withr", min_version = "1.0.0")
+    Message
+      v Decreasing withr version to ">= 1.0.0" in DESCRIPTION.
+      [ ] Refer to functions with `withr::fun()`.
+
 # use_package() handles R versions with aplomb
 
     Code

--- a/tests/testthat/test-helpers.R
+++ b/tests/testthat/test-helpers.R
@@ -55,6 +55,18 @@ test_that("we message for version change and are silent for same version", {
   expect_snapshot(
     use_dependency("crayon", "Imports", min_version = "1.0.0")
   )
+  expect_match(desc::desc_get("Imports"), ">= 2.0.0")
+})
+
+test_that("use_dependency() lowers version when force = TRUE", {
+  create_local_package()
+  withr::local_options(usethis.quiet = FALSE)
+
+  use_dependency("crayon", "Imports", min_version = "2.0.0")
+  expect_snapshot(
+    use_dependency("crayon", "Imports", min_version = "1.0.0", force = TRUE)
+  )
+  expect_match(desc::desc_get("Imports"), ">= 1.0.0")
 })
 
 ## https://github.com/r-lib/usethis/issues/99

--- a/tests/testthat/test-package.R
+++ b/tests/testthat/test-package.R
@@ -14,6 +14,15 @@ test_that("use_package() guides new packages but not pre-existing ones", {
   })
 })
 
+test_that("use_package() honors an explicit request to lower a version", {
+  create_local_package()
+  withr::local_options(usethis.quiet = FALSE)
+
+  use_package("withr", min_version = "2.0.0")
+  expect_snapshot(use_package("withr", min_version = "1.0.0"))
+  expect_equal(subset(proj_deps(), package == "withr")$version, ">= 1.0.0")
+})
+
 test_that("use_package() handles R versions with aplomb", {
   create_local_package()
   withr::local_options(usethis.quiet = FALSE)


### PR DESCRIPTION
Closes #2255

While reviewing #2255, I ended up working out a solution that feels better for me to maintain. The overall point is this: we should never silently downgrade an existing dependency indirectly, through a call to something like `use_standalone()` (in fact this was pointed out already in https://github.com/r-lib/usethis/pull/2083#issuecomment-2488560156, but I chose not to act on it then).

Only a direct call to `use_package()` is taken literally, i.e. will cause a downgrade if the new minimum version is lower than current. I prefer not to create any user-facing change at this point, so `use_package()` does not gain an argument.

This PR also cleans up a few functions that were calling `use_package()` internally that should probably have been using `use_dependency()`.