### PR TITLE
Agent/skill tweaks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,7 +46,7 @@ There are three possible ways to run code, listed in rough order of desirability
 ### Code style
 
 - Follow the tidyverse style guide
-- Always run `air format .` after generating code.
+- Always run `air format .` after generating code. (air is bundled with Positron so look there if you can't otherwise find it.)
 - Use the base pipe operator (`|>`), not the magrittr pipe (`%>%`).
 - Use `\() ...` for single-line anonymous functions. For all other cases, use `function() {...}`.
 
@@ -88,8 +88,9 @@ There are three possible ways to run code, listed in rough order of desirability
 
 ## Specialized skills
 
-- Do you need to deprecate a function or argument? Read the output of `usethis::learn_tidy_skill("deprecate")`.
-- Are you adding input checking to an existing function or writing a new exported function? Read the output of `usethis::learn_tidy_skill("arg-checking")`.
+- Do you need to deprecate a function or argument? Read `usethis::learn_tidy_skill("deprecate")`.
+- Are you adding input checking to an existing function or writing a new exported function? Read `usethis::learn_tidy_skill("arg-checking")`.
+- Are you creating a new package? Read `usethis::learn_tidy_skill("package-setup")`.
 
 ## Git
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 # usethis (development version)
 
 * `create_from_github()` now installs package dependencies by default, so you're set up to immediately start working on the package. Use `install_dependencies = FALSE` to suppress (#2186).
-* `learn_tidy_skill()` is an experimental new function that prints instructions for performing a specialized R package development task (like deprecating a function) the way the tidyverse team does. It's primarily designed to be called by AI coding agents, as directed by the `AGENTS.md` created by `use_tidy_agents()`.
+* `learn_tidy_skill()` is an experimental new function that prints instructions for performing a specialized R package development task (like deprecating a function) the way the tidyverse team does. It's primarily designed to be called by AI coding agents, as directed by the `AGENTS.md` created by `use_tidy_agents()`. It now errors informatively, listing the available skills, when called without a `name`.
 * `pr_init()` and other functions that check for uncommitted changes now offer a menu with four options: stash changes (and re-apply after), cancel, retry, or proceed anyway. Previously, the only options were to proceed or cancel (#1300).
 * `pr_pull()`, `pr_push()` and friends now give more informative errors if usethis can't retrieve details about a remote (#1929, #2229).
 * `pr_resume()` (without a specific `branch`) and `pr_fetch()` (without a specific `number`) no longer error when a branch name contains curly braces (#2107, @jonthegeek).

--- a/R/tidy-agents.R
+++ b/R/tidy-agents.R
@@ -66,6 +66,7 @@ use_tidy_agents <- function() {
 #' @param name Name of the skill:
 #'   * `"arg-checking"`: add input checking to a function.
 #'   * `"deprecate"`: deprecate a function or argument.
+#'   * `"package-setup"`: set up a new package.
 #' @export
 #' @examples
 #' \dontrun{

--- a/R/tidy-agents.R
+++ b/R/tidy-agents.R
@@ -74,6 +74,12 @@ use_tidy_agents <- function() {
 learn_tidy_skill <- function(name) {
   skill_paths <- dir_ls(path_package("usethis", "skills"), glob = "*.md")
   skills <- path_ext_remove(path_file(skill_paths))
+  if (is_missing(name)) {
+    cli::cli_abort(c(
+      "{.arg name} is required.",
+      "i" = "Available skills: {.val {skills}}."
+    ))
+  }
   name <- arg_match(name, values = skills)
 
   writeLines(read_utf8(path_package("usethis", "skills", paste0(name, ".md"))))

--- a/inst/AGENTS.md
+++ b/inst/AGENTS.md
@@ -1,5 +1,7 @@
 ## This package
 
+<!-- Insert package-specific content here. use_tidy_agents() will preserve this section when updating the rest of the file. -->
+
 ## Package development
 
 ### Key commands
@@ -90,7 +92,7 @@ There are three possible ways to run code, listed in rough order of desirability
 
 - Do you need to deprecate a function or argument? Read `usethis::learn_tidy_skill("deprecate")`.
 - Are you adding input checking to an existing function or writing a new exported function? Read `usethis::learn_tidy_skill("arg-checking")`.
-- Are you creating a new package? Read `usethis::learn_tidy_skill("setup")`.
+- Are you creating a new package? Read `usethis::learn_tidy_skill("package-setup")`.
 
 ## Git
 

--- a/inst/AGENTS.md
+++ b/inst/AGENTS.md
@@ -1,7 +1,5 @@
 ## This package
 
-<!-- Insert package-specific content here. use_tidy_agents() will preserve this section when updating the rest of the file. -->
-
 ## Package development
 
 ### Key commands
@@ -48,7 +46,7 @@ There are three possible ways to run code, listed in rough order of desirability
 ### Code style
 
 - Follow the tidyverse style guide
-- Always run `air format .` after generating code.
+- Always run `air format .` after generating code. (air is bundled with Positron so look there if you can't otherwise find it.)
 - Use the base pipe operator (`|>`), not the magrittr pipe (`%>%`).
 - Use `\() ...` for single-line anonymous functions. For all other cases, use `function() {...}`.
 
@@ -90,8 +88,9 @@ There are three possible ways to run code, listed in rough order of desirability
 
 ## Specialized skills
 
-- Do you need to deprecate a function or argument? Read the output of `usethis::learn_tidy_skill("deprecate")`.
-- Are you adding input checking to an existing function or writing a new exported function? Read the output of `usethis::learn_tidy_skill("arg-checking")`.
+- Do you need to deprecate a function or argument? Read `usethis::learn_tidy_skill("deprecate")`.
+- Are you adding input checking to an existing function or writing a new exported function? Read `usethis::learn_tidy_skill("arg-checking")`.
+- Are you creating a new package? Read `usethis::learn_tidy_skill("setup")`.
 
 ## Git
 

--- a/inst/skills/package-setup.md
+++ b/inst/skills/package-setup.md
@@ -11,4 +11,4 @@ In general, you will want to follow these steps.
 * Take a dependency on rlang with `usethis::use_package("rlang")`. Import all functions from rlang into the `NAMESPACE` with `@import rlang`.
 * Call `use_news_md()` to set up a news file.
 * Check the package with `devtools::check()` and ensure there are no issues
-* Make an initial git commit
+* Initialise a git repo

--- a/inst/skills/setup.md
+++ b/inst/skills/setup.md
@@ -6,9 +6,9 @@ In general, you will want to follow these steps.
 
 * Call `usethis::use_testthat()` to set up unit tests
 * Call `devtools::document()` to generate `NAMESPACE` and update docs
-* Ask the use which license they want to use, then call `usethis::use_mit_license()`, `usethis::use_proprietary_license()` etc.
+* Ask the user which license they want to use, then call `usethis::use_mit_license()`, `usethis::use_proprietary_license()` etc.
 * Create package documentation with `usethis::use_package_doc()`.
-* Take a depedency on rlang with `usethis::use_package("rlang")`. Import all functions from rlang into the `NAMESPACE` with `@import rlang`.
+* Take a dependency on rlang with `usethis::use_package("rlang")`. Import all functions from rlang into the `NAMESPACE` with `@import rlang`.
 * Call `use_news_md()` to set up a news file.
 * Check the package with `devtools::check()` and ensure there are no issues
 * Make an initial git commit

--- a/inst/skills/setup.md
+++ b/inst/skills/setup.md
@@ -1,0 +1,14 @@
+# Package setup
+
+When setting up a package for the first time, prefer using usethis functions rather than memorised solution. 
+
+In general, you will want to follow these steps.
+
+* Call `usethis::use_testthat()` to set up unit tests
+* Call `devtools::document()` to generate `NAMESPACE` and update docs
+* Ask the use which license they want to use, then call `usethis::use_mit_license()`, `usethis::use_proprietary_license()` etc.
+* Create package documentation with `usethis::use_package_doc()`.
+* Take a depedency on rlang with `usethis::use_package("rlang")`. Import all functions from rlang into the `NAMESPACE` with `@import rlang`.
+* Call `use_news_md()` to set up a news file.
+* Check the package with `devtools::check()` and ensure there are no issues
+* Make an initial git commit

--- a/man/learn_tidy_skill.Rd
+++ b/man/learn_tidy_skill.Rd
@@ -11,6 +11,7 @@ learn_tidy_skill(name)
 \itemize{
 \item \code{"arg-checking"}: add input checking to a function.
 \item \code{"deprecate"}: deprecate a function or argument.
+\item \code{"package-setup"}: set up a new package.
 }}
 }
 \description{

--- a/tests/testthat/_snaps/tidy-agents.md
+++ b/tests/testthat/_snaps/tidy-agents.md
@@ -1,8 +1,17 @@
+# learn_tidy_skill() errors informatively without a skill
+
+    Code
+      learn_tidy_skill()
+    Condition
+      Error in `learn_tidy_skill()`:
+      ! `name` is required.
+      i Available skills: "arg-checking", "deprecate", and "setup".
+
 # learn_tidy_skill() errors informatively for unknown skill
 
     Code
       learn_tidy_skill("doesnt-exist")
     Condition
       Error in `learn_tidy_skill()`:
-      ! `name` must be one of "arg-checking" or "deprecate", not "doesnt-exist".
+      ! `name` must be one of "arg-checking", "deprecate", or "setup", not "doesnt-exist".
 

--- a/tests/testthat/_snaps/tidy-agents.md
+++ b/tests/testthat/_snaps/tidy-agents.md
@@ -5,7 +5,7 @@
     Condition
       Error in `learn_tidy_skill()`:
       ! `name` is required.
-      i Available skills: "arg-checking", "deprecate", and "setup".
+      i Available skills: "arg-checking", "deprecate", and "package-setup".
 
 # learn_tidy_skill() errors informatively for unknown skill
 
@@ -13,5 +13,5 @@
       learn_tidy_skill("doesnt-exist")
     Condition
       Error in `learn_tidy_skill()`:
-      ! `name` must be one of "arg-checking", "deprecate", or "setup", not "doesnt-exist".
+      ! `name` must be one of "arg-checking", "deprecate", or "package-setup", not "doesnt-exist".
 

--- a/tests/testthat/test-tidy-agents.R
+++ b/tests/testthat/test-tidy-agents.R
@@ -41,6 +41,10 @@ test_that("learn_tidy_skill() prints the requested skill", {
   expect_output(learn_tidy_skill("deprecate"), "^# Deprecate functions")
 })
 
+test_that("learn_tidy_skill() errors informatively without a skill", {
+  expect_snapshot(learn_tidy_skill(), error = TRUE)
+})
+
 test_that("learn_tidy_skill() errors informatively for unknown skill", {
   expect_snapshot(learn_tidy_skill("doesnt-exist"), error = TRUE)
 })


### PR DESCRIPTION
* List available skills if no input to `learn_tidy_skill()`
* Add a setup skill
* Remind agents that air is bundled with Positron

Our own agents file is getting kind of long, but these are all hard won lessons 😐